### PR TITLE
ECC-852: Add eccodes_find_linux_utils.cmake

### DIFF
--- a/cmake/eccodes_find_linux_utils.cmake
+++ b/cmake/eccodes_find_linux_utils.cmake
@@ -1,0 +1,24 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+function( eccodes_find_linux_util )
+    find_program( FOUND_PROGRAM ${_FIRST_ARG} )
+    if( NOT FOUND_PROGRAM )
+        ecbuild_critical( "Failed to find linux util: ${_FIRST_ARG}" )
+    endif()
+endfunction( eccodes_find_linux_util )
+
+# These utils are required for the tests to run.
+# To install them on Windows, install the appropriate m2-* conda package.
+# e.g. for bash: `conda install -msys2 m2-bash`
+# Make sure to activate the conda environment so the utils are in the system path.
+set( REQUIRED_UTILS bash find grep sed gawk diff )
+
+foreach( UTIL ${REQUIRED_UTILS} )
+    eccodes_find_linux_utils( ${UTIL} )
+endforeach()


### PR DESCRIPTION
We require a handful of standard linux utils to run the tests - these
need to be explicitly installed on Windows. We add a check for the utils
so we can notify the user if any util is missing.