### PR TITLE
Appveyor: switch to develop branch of ecbuild

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,8 +37,7 @@ clone_depth: 1
 # scripts that run after cloning repository
 install:
     # install ecbuild
-    # TODO: switch from the dtip-windows branch once the windows changes are merged
-    - cmd: git clone --depth 1 -b dtip-windows https://github.com/ecmwf/ecbuild.git %ECBUILD_SRC%
+    - cmd: git clone --depth 1 https://github.com/ecmwf/ecbuild.git %ECBUILD_SRC%
 
     # install linux utils
     - cmd: conda install -c msys2 m2-bash ^


### PR DESCRIPTION
Now the dtip-windows changes are in the develop branch of ecbuild, we can use develop for the ecCodes CI. Then I can delete the dtip-windows ecbuild branch.