### PR TITLE
Linux: add CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,14 @@ env:
     - ECCODES_SRC=${TRAVIS_BUILD_DIR}
     - ECBUILD_SRC=${ECCODES_SRC}/../ecbuild
     - BUILD_DIR=${ECCODES_SRC}/build
+    - INSTALL_DIR=/tmp/install
 
 git:
   depth: 1
+
+before_install:
+  - mkdir ${INSTALL_DIR}
+  - export PATH=$PATH:${INSTALL_DIR}
 
 install:
   # install ecbuild
@@ -52,7 +57,8 @@ script:
 
   # build ecCodes
   - mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
-  - cmake -D ENABLE_FORTRAN=0
+  - cmake -D CMAKE_INSTALL_PREFIX=${INSTALL_DIR}
+          -D ENABLE_FORTRAN=0
           -D ENABLE_PYTHON=0
           -D ENABLE_NETCDF=1
           -D ENABLE_JPG=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ git:
 
 before_install:
   - mkdir ${INSTALL_DIR}
-  - export PATH=$PATH:${INSTALL_DIR}
+  - export PATH=${PATH}:${INSTALL_DIR}/bin
 
 install:
   # install ecbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
           ${ECCODES_SRC}
   - make -j4
   - ctest -j4 --output-on-failure
-  - make install --silent
+  - make install > /dev/null
 
   # extra sanity tests
   - codes_info

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,21 @@ branches:
 
 language: c
 
-os: osx
-osx_image: xcode10.1
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      addons:
+        apt:
+          packages:
+            - libnetcdf-dev
+
+    - os: osx
+      osx_image: xcode10.1
+      addons:
+        homebrew:
+          packages:
+            - netcdf
 
 env:
   global:
@@ -26,9 +39,6 @@ git:
 install:
   # install ecbuild
   - git clone --depth 1 https://github.com/ecmwf/ecbuild.git ${ECBUILD_SRC}
-
-  # install netcdf
-  - brew install netcdf
 
 #---------------------------------#
 #       build configuration       #

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ecCodes
 =======
 
-[![Linux & macOS: master](https://img.shields.io/travis/ecmwf/eccodes/master.svg?label=Linux-&-macOS-master)](https://travis-ci.org/ecmwf/eccodes/branches)
-[![Linux & macOS: develop](https://img.shields.io/travis/ecmwf/eccodes/develop.svg?label=Linux-&-macOS-dev)](https://travis-ci.org/ecmwf/eccodes/branches)
+[![Linux & macOS: master](https://img.shields.io/travis/ecmwf/eccodes/master.svg?label=Linux-and-macOS-master)](https://travis-ci.org/ecmwf/eccodes/branches)
+[![Linux & macOS: develop](https://img.shields.io/travis/ecmwf/eccodes/develop.svg?label=Linux-and-macOS-dev)](https://travis-ci.org/ecmwf/eccodes/branches)
 [![Windows: master](https://img.shields.io/appveyor/ci/ecmwf/eccodes/master.svg?label=Windows-master)](https://ci.appveyor.com/project/ecmwf/eccodes/branch/master)
 [![Windows: develop](https://img.shields.io/appveyor/ci/ecmwf/eccodes/develop.svg?label=Windows-dev)](https://ci.appveyor.com/project/ecmwf/eccodes/branch/develop)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ecCodes
 =======
 
-[![macOS: master](https://img.shields.io/travis/ecmwf/eccodes/master.svg?label=macOS-master)](https://travis-ci.org/ecmwf/eccodes/branches)
-[![macOS: develop](https://img.shields.io/travis/ecmwf/eccodes/develop.svg?label=macOS-dev)](https://travis-ci.org/ecmwf/eccodes/branches)
+[![Linux & macOS: master](https://img.shields.io/travis/ecmwf/eccodes/master.svg?label=Linux-&-macOS-master)](https://travis-ci.org/ecmwf/eccodes/branches)
+[![Linux & macOS: develop](https://img.shields.io/travis/ecmwf/eccodes/develop.svg?label=Linux-&-macOS-dev)](https://travis-ci.org/ecmwf/eccodes/branches)
 [![Windows: master](https://img.shields.io/appveyor/ci/ecmwf/eccodes/master.svg?label=Windows-master)](https://ci.appveyor.com/project/ecmwf/eccodes/branch/master)
 [![Windows: develop](https://img.shields.io/appveyor/ci/ecmwf/eccodes/develop.svg?label=Windows-dev)](https://ci.appveyor.com/project/ecmwf/eccodes/branch/develop)
 


### PR DESCRIPTION
This is currently a basic CI setup. We only build with gcc5.

There are existing ECMWF projects (e.g. https://github.com/ecmwf/atlas/) which build with clang, gcc5, and gcc7. Would we like to do the same for ecCodes? @StephanSiemen @shahramn 