### PR TITLE
Add option to replace TPL absolute paths with library names

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 #      general configuration      #
 #---------------------------------#
 
-version: 2.11.0-{build}-{branch}
+version: 2.12.0-{build}-{branch}
 
 branches:
   only:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,21 @@ get_directory_property( COMPILE_DEFINITIONS ECCODES_DEFINITIONS )
 foreach( _tpl ${ECCODES_TPLS} )
     string( TOUPPER ${_tpl} TPL )
     if( ${TPL}_FOUND )
+        if( REPLACE_TPL_ABSOLUTE_PATHS )
+            # replace TPL absolute paths with their library names
+            # this helps make ecCodes relocatable
+            set( _TMP "" )
+
+            foreach( _lib ${${TPL}_LIBRARIES} )
+                get_filename_component( _lib_name ${_lib} NAME_WE )
+                string( REGEX REPLACE "^lib" "" _name ${_lib_name} )
+                list( APPEND _TMP "-l${_name}" )
+            endforeach()
+
+            set( ${TPL}_LIBRARIES ${_TMP} )
+            set( _TMP "" )
+        endif()
+
         list( APPEND ECCODES_EXTRA_DEFINITIONS   ${${TPL}_DEFINITIONS} )
         list( APPEND ECCODES_EXTRA_INCLUDE_DIRS  ${${TPL}_INCLUDE_DIRS} ${${TPL}_INCLUDE_DIR} )
         list( APPEND ECCODES_EXTRA_LIBRARIES     ${${TPL}_LIBRARIES} )


### PR DESCRIPTION
This should help with relocatability: instead of generating
eccodes-config.cmake with an absolute path to Third Party Libraries
(TPLs) (e.g. /lib/x86_64-linux-gnu/libm.so.6) we have the option to use
the library name instead (e.g. -lm).

We also use library names in eccodes-targets.cmake and eccodes.pc if the
option is set.

The motivation is so that we can distribute packages with conda-forge.
Without this change, the conda-forge build leaves its build path in the
files above. When we come to build another package downstream, e.g.
Magics, we are unable to find the ecCodes libraries because the absolute
paths to the TPLs are no longer valid. Using library names instead lets
cmake find the TPLs on the downstream build system.