### PR TITLE
ECC-1002: Windows: encoding tests fail

### DIFF
--- a/src/grib_accessor_class_unsigned.c
+++ b/src/grib_accessor_class_unsigned.c
@@ -244,7 +244,7 @@ int pack_long_unsigned_helper(grib_accessor* a, const long* val, size_t *len, in
                 }
                 if (nbits < 33) {
                     unsigned long maxval = (1UL << nbits)-1;
-                    if (v > maxval) {
+                    if (maxval > 0 && v > maxval) { /* See ECC-1002 */
                         grib_context_log(a->context, GRIB_LOG_ERROR,
                                 "Key \"%s\": Trying to encode value of %ld but the maximum allowable value is %ld (number of bits=%ld)\n",
                                 a->name, v, maxval, nbits);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,7 +57,6 @@ list( APPEND tests_no_data_reqd
     grib_2nd_order_numValues
     grib_ecc-136
     grib_ecc-967
-    grib_ecc-979
     julian
     bufr_dump_samples
     bufr_json_samples
@@ -115,6 +114,7 @@ list( APPEND tests_data_reqd
     grib_ecc-873
     grib_ecc-600
     grib_ecc-923
+    grib_ecc-979
     grib_ecc-984
     bufr_ecc-556
     gts_get


### PR DESCRIPTION
Attempt at fixing the failing Windows tests