### PR TITLE
SUP-2971 Update section.3.def

### DIFF
--- a/definitions/bufr/section.3.def
+++ b/definitions/bufr/section.3.def
@@ -22,7 +22,8 @@ if (masterTablesVersionNumber == 19) {
 
   constant tablesLocalDir="bufr/tables/[masterTableNumber]/local/[masterTablesVersionNumber]-[localTablesVersionNumber]/[bufrHeaderCentre:l]/[bufrHeaderSubCentre]" : hidden;
 } else {
-  constant tablesLocalDir="bufr/tables/[masterTableNumber]/local/[localTablesVersionNumber]/[bufrHeaderCentre:l]/[bufrHeaderSubCentre]" : hidden;
+  # Use numeric value of bufrHeaderSubCentre so that path is predictable. See SUP-2971.
+  constant tablesLocalDir="bufr/tables/[masterTableNumber]/local/[localTablesVersionNumber]/[bufrHeaderCentre:l]/[bufrHeaderSubCentre:l]" : hidden;
 }
 constant rootTablesDir="bufr/tables" : hidden;
 


### PR DESCRIPTION
See SUP-2971, the use of the alphanumeric value for bufrHeaderSubCentre combined with section1.3.def referring to common/c-1.table resulted in Darwin (centre 2 subcentre 214) being searched for under lemm (Madrid). This is one of several possible fixes. See the other pull requests for branches SUP-2971-B1, SUP-2971-B2 and SUP-2971-C. This is independent of the other proposed changes.