### PR TITLE
SUP-2971 Update section.1.3.def

### DIFF
--- a/definitions/bufr/section.1.3.def
+++ b/definitions/bufr/section.1.3.def
@@ -5,7 +5,7 @@ section_length[3] section1Length ;
 
 unsigned[1]  masterTableNumber :dump;
 
-codetable[1] bufrHeaderSubCentre 'common/c-1.table' : dump;
+unsigned[1] bufrHeaderSubCentre : dump;
 codetable[1] bufrHeaderCentre    'common/c-1.table' : dump;
 
 unsigned[1]  updateSequenceNumber :dump;


### PR DESCRIPTION
Make bufrHeaderSubCentre unsigned instead of code table common/c-1. Table c-1 is for centres, not sub-centres. See SUP-2971. This is one of several possible solutions, see the branches SUP-2971-A, SUP-2971-B2 and SUP-2971-C. This change is independent of SUP-2971-A but conflicts and is an alternative to SUP-2971-B2. SUP-2971-C is not related to this proposed change.