### PR TITLE
BUG assigning file variable to field_tree in index

### DIFF
--- a/src/grib_index.c
+++ b/src/grib_index.c
@@ -1203,7 +1203,7 @@ int _codes_index_add_file(grib_index* index, const char* filename, int message_t
         }
 
         field       = (grib_field*)grib_context_malloc_clear(c, sizeof(grib_field));
-        field->file = file;
+        field->file = newfile;
         index->count++;
         field->offset = h->offset;
 


### PR DESCRIPTION
When **_codes_index_add_file** is invoked from **codes_index_add_file**, a new file
structure variable (**newfile**) is created and this variable is added to the
list of index files. However, later when the field_tree struct is
generated, the **file** variable obtained from file pool (grib_file_open) is assigned instead. The ID of file variable and newfile variable may not match. Later, this can produce errors when index file is read.


To reproduce an error:

Download and uncompress tar file [examples.tar.gz](https://github.com/ecmwf/eccodes/files/4593381/examples.tar.gz):
`tar xvfz examples.tar.gz`

Compile both programs:
```
gcc -leccodes readindex.c -o readindex
gcc -leccodes writeindex.c -o writeindex
```

First execute:
`./writeindex`

Finally execute:
`./readindex`

