### PR TITLE
ecCodesMIA 2.17.0 b6

### DIFF
--- a/ctest3.out
+++ b/ctest3.out
@@ -1,0 +1,557 @@
+Test project /home/eccuser/eccodes-2.17.0-BUILD.B6
+        Start   1: eccodes_t_definitions
+  1/266 Test   #1: eccodes_t_definitions .......................   Passed    6.72 sec
+        Start   2: eccodes_t_grib_calendar
+  2/266 Test   #2: eccodes_t_grib_calendar .....................   Passed    0.58 sec
+        Start   3: eccodes_t_unit_tests
+  3/266 Test   #3: eccodes_t_unit_tests ........................   Passed    0.30 sec
+        Start   4: eccodes_t_md5
+Process not started
+ /home/eccuser/eccodes-2.17.0-Source/tests/md5.sh
+[permission denied]
+  4/266 Test   #4: eccodes_t_md5 ...............................***Not Run   0.00 sec
+        Start   5: eccodes_t_grib_uerra
+  5/266 Test   #5: eccodes_t_grib_uerra ........................   Passed    1.29 sec
+        Start   6: eccodes_t_grib_2nd_order_numValues
+  6/266 Test   #6: eccodes_t_grib_2nd_order_numValues ..........   Passed    0.14 sec
+        Start   7: eccodes_t_grib_ecc-136
+  7/266 Test   #7: eccodes_t_grib_ecc-136 ......................   Passed    0.26 sec
+        Start   8: eccodes_t_grib_ecc-967
+  8/266 Test   #8: eccodes_t_grib_ecc-967 ......................   Passed    0.09 sec
+        Start   9: eccodes_t_grib_ecc-1065
+  9/266 Test   #9: eccodes_t_grib_ecc-1065 .....................   Passed    0.05 sec
+        Start  10: eccodes_t_julian
+ 10/266 Test  #10: eccodes_t_julian ............................   Passed    1.61 sec
+        Start  11: eccodes_t_bufr_dump_samples
+ 11/266 Test  #11: eccodes_t_bufr_dump_samples .................   Passed    0.29 sec
+        Start  12: eccodes_t_bufr_json_samples
+ 12/266 Test  #12: eccodes_t_bufr_json_samples .................   Passed    0.25 sec
+        Start  13: eccodes_t_bufr_ecc-359
+ 13/266 Test  #13: eccodes_t_bufr_ecc-359 ......................   Passed    0.05 sec
+        Start  14: eccodes_t_bufr_ecc-517
+ 14/266 Test  #14: eccodes_t_bufr_ecc-517 ......................   Passed    0.11 sec
+        Start  15: eccodes_t_bufr_rdbSubTypes
+ 15/266 Test  #15: eccodes_t_bufr_rdbSubTypes ..................   Passed    0.10 sec
+        Start  16: eccodes_t_grib_efas
+ 16/266 Test  #16: eccodes_t_grib_efas .........................   Passed    1.34 sec
+        Start  17: eccodes_t_grib_sh_imag
+ 17/266 Test  #17: eccodes_t_grib_sh_imag ......................   Passed    0.03 sec
+        Start  18: eccodes_t_diag
+ 18/266 Test  #18: eccodes_t_diag ..............................   Passed    0.10 sec
+        Start  19: eccodes_t_grib_lambert_conformal
+ 19/266 Test  #19: eccodes_t_grib_lambert_conformal ............   Passed    0.66 sec
+        Start 262: eccodes_download_gribs
+ 20/266 Test #262: eccodes_download_gribs ......................   Passed    3.98 sec
+        Start 263: eccodes_download_tigge_gribs
+ 21/266 Test #263: eccodes_download_tigge_gribs ................   Passed    9.85 sec
+        Start 264: eccodes_download_bufrs
+ 22/266 Test #264: eccodes_download_bufrs ......................   Passed   23.06 sec
+        Start 265: eccodes_download_metars
+ 23/266 Test #265: eccodes_download_metars .....................   Passed    0.13 sec
+        Start 266: eccodes_download_gts
+ 24/266 Test #266: eccodes_download_gts ........................   Passed    0.09 sec
+        Start  20: eccodes_t_grib_data_quality_checks
+ 25/266 Test  #20: eccodes_t_grib_data_quality_checks ..........   Passed    2.64 sec
+        Start  21: eccodes_t_bpv_limit
+ 26/266 Test  #21: eccodes_t_bpv_limit .........................   Passed    0.13 sec
+        Start  22: eccodes_t_grib_complex
+ 27/266 Test  #22: eccodes_t_grib_complex ......................   Passed    0.06 sec
+        Start  23: eccodes_t_grib_double_cmp
+ 28/266 Test  #23: eccodes_t_grib_double_cmp ...................   Passed    0.09 sec
+        Start  24: eccodes_t_grib_change_packing
+ 29/266 Test  #24: eccodes_t_grib_change_packing ...............   Passed    0.41 sec
+        Start  25: eccodes_t_bufr_dump_data
+ 30/266 Test  #25: eccodes_t_bufr_dump_data ....................   Passed    0.93 sec
+        Start  26: eccodes_t_bufr_dump_descriptors
+ 31/266 Test  #26: eccodes_t_bufr_dump_descriptors .............   Passed    4.10 sec
+        Start  27: eccodes_t_bufr_dump_subset
+ 32/266 Test  #27: eccodes_t_bufr_dump_subset ..................   Passed    3.02 sec
+        Start  28: eccodes_t_bufr_dump_decode_filter
+ 33/266 Test  #28: eccodes_t_bufr_dump_decode_filter ...........   Passed    5.33 sec
+        Start  29: eccodes_t_bufr_dump_encode_filter
+ 34/266 Test  #29: eccodes_t_bufr_dump_encode_filter ...........***Failed    1.64 sec
+        Start  30: eccodes_t_bufrdc_desc_ref
+ 35/266 Test  #30: eccodes_t_bufrdc_desc_ref ...................   Passed    2.45 sec
+        Start  31: eccodes_t_bufrdc_ref
+ 36/266 Test  #31: eccodes_t_bufrdc_ref ........................   Passed   26.79 sec
+        Start  32: eccodes_t_bufr_compare
+ 37/266 Test  #32: eccodes_t_bufr_compare ......................   Passed    0.35 sec
+        Start  33: eccodes_t_bufr_copy
+ 38/266 Test  #33: eccodes_t_bufr_copy .........................   Passed    0.11 sec
+        Start  34: eccodes_t_bufr_count
+ 39/266 Test  #34: eccodes_t_bufr_count ........................   Passed    0.06 sec
+        Start  35: eccodes_t_bufr_get
+ 40/266 Test  #35: eccodes_t_bufr_get ..........................   Passed    0.13 sec
+        Start  36: eccodes_t_bufr_filter
+ 41/266 Test  #36: eccodes_t_bufr_filter .......................***Failed    6.21 sec
+        Start  37: eccodes_t_bufr_filter_extract_datetime
+ 42/266 Test  #37: eccodes_t_bufr_filter_extract_datetime ......   Passed    0.63 sec
+        Start  38: eccodes_t_bufr_filter_extract_area
+ 43/266 Test  #38: eccodes_t_bufr_filter_extract_area ..........   Passed    0.21 sec
+        Start  39: eccodes_t_bufr_json_data
+ 44/266 Test  #39: eccodes_t_bufr_json_data ....................   Passed   10.04 sec
+        Start  40: eccodes_t_bufr_ls
+ 45/266 Test  #40: eccodes_t_bufr_ls ...........................   Passed    0.79 sec
+        Start  41: eccodes_t_bufr_ls_json
+ 46/266 Test  #41: eccodes_t_bufr_ls_json ......................   Passed    0.77 sec
+        Start  42: eccodes_t_bufr_change_edition
+ 47/266 Test  #42: eccodes_t_bufr_change_edition ...............   Passed    3.87 sec
+        Start  43: eccodes_t_bufr_keys_iter
+ 48/266 Test  #43: eccodes_t_bufr_keys_iter ....................   Passed    0.15 sec
+        Start  44: eccodes_t_bufr_get_element
+ 49/266 Test  #44: eccodes_t_bufr_get_element ..................   Passed    0.04 sec
+        Start  45: eccodes_t_bufr_wmo_tables
+ 50/266 Test  #45: eccodes_t_bufr_wmo_tables ...................   Passed    2.08 sec
+        Start  46: eccodes_t_bufr_extract_headers
+ 51/266 Test  #46: eccodes_t_bufr_extract_headers ..............   Passed    2.10 sec
+        Start  47: eccodes_t_bufr_ecc-673
+ 52/266 Test  #47: eccodes_t_bufr_ecc-673 ......................   Passed    0.16 sec
+        Start  48: eccodes_t_bufr_ecc-428
+ 53/266 Test  #48: eccodes_t_bufr_ecc-428 ......................   Passed    0.21 sec
+        Start  49: eccodes_t_bufr_ecc-286
+ 54/266 Test  #49: eccodes_t_bufr_ecc-286 ......................   Passed    0.14 sec
+        Start  50: eccodes_t_bufr_ecc-288
+ 55/266 Test  #50: eccodes_t_bufr_ecc-288 ......................   Passed    0.04 sec
+        Start  51: eccodes_t_bufr_ecc-313
+ 56/266 Test  #51: eccodes_t_bufr_ecc-313 ......................   Passed    0.15 sec
+        Start  52: eccodes_t_bufr_ecc-616
+ 57/266 Test  #52: eccodes_t_bufr_ecc-616 ......................   Passed    0.09 sec
+        Start  53: eccodes_t_bufr_ecc-686
+ 58/266 Test  #53: eccodes_t_bufr_ecc-686 ......................   Passed    0.07 sec
+        Start  54: eccodes_t_bufr_ecc-690
+ 59/266 Test  #54: eccodes_t_bufr_ecc-690 ......................   Passed    0.05 sec
+        Start  55: eccodes_t_bufr_ecc-379
+ 60/266 Test  #55: eccodes_t_bufr_ecc-379 ......................   Passed    0.18 sec
+        Start  56: eccodes_t_bufr_ecc-393
+ 61/266 Test  #56: eccodes_t_bufr_ecc-393 ......................***Failed    0.08 sec
+        Start  57: eccodes_t_bufr_ecc-433
+ 62/266 Test  #57: eccodes_t_bufr_ecc-433 ......................   Passed    0.05 sec
+        Start  58: eccodes_t_bufr_ecc-750
+ 63/266 Test  #58: eccodes_t_bufr_ecc-750 ......................   Passed    0.08 sec
+        Start  59: eccodes_t_bufr_ecc-765
+ 64/266 Test  #59: eccodes_t_bufr_ecc-765 ......................   Passed    0.00 sec
+        Start  60: eccodes_t_bufr_ecc-875
+ 65/266 Test  #60: eccodes_t_bufr_ecc-875 ......................   Passed    0.09 sec
+        Start  61: eccodes_t_bufr_ecc-887
+ 66/266 Test  #61: eccodes_t_bufr_ecc-887 ......................   Passed    0.03 sec
+        Start  62: eccodes_t_grib_ecc-490
+ 67/266 Test  #62: eccodes_t_grib_ecc-490 ......................   Passed    0.07 sec
+        Start  63: eccodes_t_grib_ecc-756
+ 68/266 Test  #63: eccodes_t_grib_ecc-756 ......................   Passed    0.43 sec
+        Start  64: eccodes_t_grib_ecc-873
+ 69/266 Test  #64: eccodes_t_grib_ecc-873 ......................   Passed    0.22 sec
+        Start  65: eccodes_t_grib_ecc-600
+ 70/266 Test  #65: eccodes_t_grib_ecc-600 ......................   Passed    0.10 sec
+        Start  66: eccodes_t_grib_ecc-923
+ 71/266 Test  #66: eccodes_t_grib_ecc-923 ......................   Passed    0.12 sec
+        Start  67: eccodes_t_grib_ecc-979
+ 72/266 Test  #67: eccodes_t_grib_ecc-979 ......................   Passed    0.16 sec
+        Start  68: eccodes_t_grib_ecc-984
+ 73/266 Test  #68: eccodes_t_grib_ecc-984 ......................   Passed    0.04 sec
+        Start  69: eccodes_t_grib_ecc-1000
+ 74/266 Test  #69: eccodes_t_grib_ecc-1000 .....................   Passed    0.08 sec
+        Start  70: eccodes_t_grib_ecc-1001
+ 75/266 Test  #70: eccodes_t_grib_ecc-1001 .....................   Passed    0.28 sec
+        Start  71: eccodes_t_grib_ecc-1030
+ 76/266 Test  #71: eccodes_t_grib_ecc-1030 .....................   Passed    0.04 sec
+        Start  72: eccodes_t_bufr_ecc-556
+ 77/266 Test  #72: eccodes_t_bufr_ecc-556 ......................   Passed    0.01 sec
+        Start  73: eccodes_t_gts_get
+ 78/266 Test  #73: eccodes_t_gts_get ...........................   Passed    0.18 sec
+        Start  74: eccodes_t_gts_ls
+ 79/266 Test  #74: eccodes_t_gts_ls ............................   Passed    0.05 sec
+        Start  75: eccodes_t_gts_count
+ 80/266 Test  #75: eccodes_t_gts_count .........................   Passed    0.03 sec
+        Start  76: eccodes_t_gts_compare
+ 81/266 Test  #76: eccodes_t_gts_compare .......................   Passed    0.13 sec
+        Start  77: eccodes_t_metar_ls
+ 82/266 Test  #77: eccodes_t_metar_ls ..........................   Passed    0.23 sec
+        Start  78: eccodes_t_metar_get
+ 83/266 Test  #78: eccodes_t_metar_get .........................   Passed    0.11 sec
+        Start  79: eccodes_t_metar_dump
+ 84/266 Test  #79: eccodes_t_metar_dump ........................   Passed    0.17 sec
+        Start  80: eccodes_t_metar_compare
+ 85/266 Test  #80: eccodes_t_metar_compare .....................   Passed    0.14 sec
+        Start  81: eccodes_t_bufr_set
+ 86/266 Test  #81: eccodes_t_bufr_set ..........................   Passed    0.09 sec
+        Start  82: eccodes_t_ieee
+ 87/266 Test  #82: eccodes_t_ieee ..............................   Passed    0.47 sec
+        Start  83: eccodes_t_grib_sh_ieee64
+ 88/266 Test  #83: eccodes_t_grib_sh_ieee64 ....................   Passed    0.02 sec
+        Start  84: eccodes_t_grib_optimize_scaling
+ 89/266 Test  #84: eccodes_t_grib_optimize_scaling .............   Passed    0.14 sec
+        Start  85: eccodes_t_grib_optimize_scaling_sh
+ 90/266 Test  #85: eccodes_t_grib_optimize_scaling_sh ..........   Passed    0.03 sec
+        Start  86: eccodes_t_grib_lam_bf
+ 91/266 Test  #86: eccodes_t_grib_lam_bf .......................   Passed    0.24 sec
+        Start  87: eccodes_t_grib_lam_gp
+ 92/266 Test  #87: eccodes_t_grib_lam_gp .......................   Passed    0.11 sec
+        Start  88: eccodes_t_grib1to2
+ 93/266 Test  #88: eccodes_t_grib1to2 ..........................   Passed    3.16 sec
+        Start  89: eccodes_t_grib2to1
+ 94/266 Test  #89: eccodes_t_grib2to1 ..........................   Passed    2.58 sec
+        Start  90: eccodes_t_grib1to3
+ 95/266 Test  #90: eccodes_t_grib1to3 ..........................   Passed    0.30 sec
+        Start  91: eccodes_t_grib2to3
+ 96/266 Test  #91: eccodes_t_grib2to3 ..........................   Passed    0.11 sec
+        Start  92: eccodes_t_grib3_templates
+ 97/266 Test  #92: eccodes_t_grib3_templates ...................   Passed    0.22 sec
+        Start  93: eccodes_t_badgrib
+ 98/266 Test  #93: eccodes_t_badgrib ...........................   Passed    0.05 sec
+        Start  94: eccodes_t_grib_ls
+ 99/266 Test  #94: eccodes_t_grib_ls ...........................   Passed    1.92 sec
+        Start  95: eccodes_t_grib_ls_json
+100/266 Test  #95: eccodes_t_grib_ls_json ......................   Passed    6.80 sec
+        Start  96: eccodes_t_grib_filter
+101/266 Test  #96: eccodes_t_grib_filter .......................   Passed    0.56 sec
+        Start  97: eccodes_t_grib_multi
+102/266 Test  #97: eccodes_t_grib_multi ........................   Passed    0.13 sec
+        Start  98: eccodes_t_grib_nearest_test
+103/266 Test  #98: eccodes_t_grib_nearest_test .................   Passed    0.10 sec
+        Start  99: eccodes_t_budg
+104/266 Test  #99: eccodes_t_budg ..............................   Passed    0.01 sec
+        Start 100: eccodes_t_grib_gridType
+105/266 Test #100: eccodes_t_grib_gridType .....................   Passed    0.11 sec
+        Start 101: eccodes_t_grib_octahedral
+106/266 Test #101: eccodes_t_grib_octahedral ...................   Passed    9.16 sec
+        Start 102: eccodes_t_grib_global
+107/266 Test #102: eccodes_t_grib_global .......................   Passed    0.32 sec
+        Start 103: eccodes_t_grib_concept
+108/266 Test #103: eccodes_t_grib_concept ......................   Passed    0.99 sec
+        Start 104: eccodes_t_grib_decimalPrecision
+109/266 Test #104: eccodes_t_grib_decimalPrecision .............   Passed    0.19 sec
+        Start 105: eccodes_t_grib_bitsPerValue
+110/266 Test #105: eccodes_t_grib_bitsPerValue .................   Passed    2.35 sec
+        Start 106: eccodes_t_get_fail
+111/266 Test #106: eccodes_t_get_fail ..........................   Passed    0.01 sec
+        Start 107: eccodes_t_grib_missing
+112/266 Test #107: eccodes_t_grib_missing ......................   Passed    0.09 sec
+        Start 108: eccodes_t_grib_local
+113/266 Test #108: eccodes_t_grib_local ........................   Passed    6.62 sec
+        Start 109: eccodes_t_grib_step
+114/266 Test #109: eccodes_t_grib_step .........................   Passed    0.74 sec
+        Start 110: eccodes_t_grib_set
+115/266 Test #110: eccodes_t_grib_set ..........................   Passed    0.26 sec
+        Start 111: eccodes_t_grib_iterator
+116/266 Test #111: eccodes_t_grib_iterator .....................   Passed    1.42 sec
+        Start 112: eccodes_t_grib_compare
+117/266 Test #112: eccodes_t_grib_compare ......................   Passed    0.53 sec
+        Start 113: eccodes_t_grib_copy
+118/266 Test #113: eccodes_t_grib_copy .........................   Passed    0.16 sec
+        Start 114: eccodes_t_grib_level
+119/266 Test #114: eccodes_t_grib_level ........................   Passed    1.33 sec
+        Start 115: eccodes_t_index
+120/266 Test #115: eccodes_t_index .............................   Passed    0.97 sec
+        Start 116: eccodes_t_grib_bitmap
+121/266 Test #116: eccodes_t_grib_bitmap .......................   Passed    0.96 sec
+        Start 117: eccodes_t_grib_list
+122/266 Test #117: eccodes_t_grib_list .........................   Passed    0.04 sec
+        Start 118: eccodes_t_grib_second_order
+123/266 Test #118: eccodes_t_grib_second_order .................   Passed    1.51 sec
+        Start 119: eccodes_t_grib_multi_from_message
+124/266 Test #119: eccodes_t_grib_multi_from_message ...........   Passed    0.36 sec
+        Start 120: eccodes_t_grib_change_scanning
+125/266 Test #120: eccodes_t_grib_change_scanning ..............   Passed    2.58 sec
+        Start 121: eccodes_t_grib_statistics
+126/266 Test #121: eccodes_t_grib_statistics ...................   Passed    1.30 sec
+        Start 122: eccodes_t_grib_tigge
+127/266 Test #122: eccodes_t_grib_tigge ........................   Passed   12.55 sec
+        Start 123: eccodes_t_read_any
+128/266 Test #123: eccodes_t_read_any ..........................   Passed    0.16 sec
+        Start 124: eccodes_t_grib_dump
+129/266 Test #124: eccodes_t_grib_dump .........................   Passed    0.91 sec
+        Start 125: eccodes_t_grib_dump_debug
+130/266 Test #125: eccodes_t_grib_dump_debug ...................   Passed   14.11 sec
+        Start 126: eccodes_t_grib_dump_json
+131/266 Test #126: eccodes_t_grib_dump_json ....................   Passed   16.45 sec
+        Start 127: eccodes_t_grib_local_MeteoFrance
+132/266 Test #127: eccodes_t_grib_local_MeteoFrance ............   Passed    0.05 sec
+        Start 128: eccodes_t_grib_neg_fctime
+133/266 Test #128: eccodes_t_grib_neg_fctime ...................   Passed    0.48 sec
+        Start 129: eccodes_t_codes_split_file
+134/266 Test #129: eccodes_t_codes_split_file ..................   Passed    1.10 sec
+        Start 130: eccodes_t_grib_mars_types
+135/266 Test #130: eccodes_t_grib_mars_types ...................   Passed    8.19 sec
+        Start 131: eccodes_t_bufr_dump_encode_fortran
+136/266 Test #131: eccodes_t_bufr_dump_encode_fortran ..........   Passed    3.35 sec
+        Start 132: eccodes_t_bufr_dump_decode_fortran
+137/266 Test #132: eccodes_t_bufr_dump_decode_fortran ..........   Passed    2.83 sec
+        Start 133: eccodes_t_grib_util_set_spec
+138/266 Test #133: eccodes_t_grib_util_set_spec ................   Passed    0.51 sec
+        Start 134: eccodes_t_grib_padding
+139/266 Test #134: eccodes_t_grib_padding ......................   Passed   34.67 sec
+        Start 135: eccodes_t_grib_tigge_conversions
+140/266 Test #135: eccodes_t_grib_tigge_conversions ............   Passed   26.25 sec
+        Start 136: eccodes_t_bufr_dump_encode_C
+141/266 Test #136: eccodes_t_bufr_dump_encode_C ................   Passed    3.45 sec
+        Start 137: eccodes_t_bufr_dump_decode_C
+142/266 Test #137: eccodes_t_bufr_dump_decode_C ................   Passed    2.82 sec
+        Start 138: eccodes_t_bufr_dump_encode_python
+143/266 Test #138: eccodes_t_bufr_dump_encode_python ...........***Failed   24.62 sec
+        Start 139: eccodes_t_bufr_dump_decode_python
+144/266 Test #139: eccodes_t_bufr_dump_decode_python ...........   Passed   17.22 sec
+        Start 140: eccodes_t_grib_lamb_az_eq_area
+145/266 Test #140: eccodes_t_grib_lamb_az_eq_area ..............   Passed    0.16 sec
+        Start 141: eccodes_t_tools_data_from_stdin
+146/266 Test #141: eccodes_t_tools_data_from_stdin .............   Passed    0.03 sec
+        Start 142: eccodes_t_bufr_ecc-197
+147/266 Test #142: eccodes_t_bufr_ecc-197 ......................   Passed    0.13 sec
+        Start 143: eccodes_t_grib_check_param_concepts
+148/266 Test #143: eccodes_t_grib_check_param_concepts .........   Passed    0.01 sec
+        Start 144: eccodes_c_grib_multi
+149/266 Test #144: eccodes_c_grib_multi ........................   Passed    0.09 sec
+        Start 145: eccodes_c_grib_set_data
+150/266 Test #145: eccodes_c_grib_set_data .....................   Passed    0.01 sec
+        Start 146: eccodes_c_large_grib1
+151/266 Test #146: eccodes_c_large_grib1 .......................   Passed    0.23 sec
+        Start 147: eccodes_c_grib_sections_copy
+152/266 Test #147: eccodes_c_grib_sections_copy ................   Passed    0.14 sec
+        Start 148: eccodes_c_get_product_kind_samples
+153/266 Test #148: eccodes_c_get_product_kind_samples ..........   Passed    0.12 sec
+        Start 149: eccodes_c_grib_iterator
+154/266 Test #149: eccodes_c_grib_iterator .....................   Passed    0.05 sec
+        Start 150: eccodes_c_grib_get_keys
+155/266 Test #150: eccodes_c_grib_get_keys .....................   Passed    0.01 sec
+        Start 151: eccodes_c_grib_print_data
+156/266 Test #151: eccodes_c_grib_print_data ...................   Passed    0.10 sec
+        Start 152: eccodes_c_grib_set_keys
+157/266 Test #152: eccodes_c_grib_set_keys .....................   Passed    0.03 sec
+        Start 153: eccodes_c_grib_keys_iterator
+158/266 Test #153: eccodes_c_grib_keys_iterator ................   Passed    0.22 sec
+        Start 154: eccodes_c_grib_multi_write
+159/266 Test #154: eccodes_c_grib_multi_write ..................   Passed    0.05 sec
+        Start 155: eccodes_c_grib_precision
+160/266 Test #155: eccodes_c_grib_precision ....................   Passed    0.01 sec
+        Start 156: eccodes_c_grib_clone
+161/266 Test #156: eccodes_c_grib_clone ........................   Passed    0.06 sec
+        Start 157: eccodes_c_grib_copy_message
+162/266 Test #157: eccodes_c_grib_copy_message .................   Passed    0.05 sec
+        Start 158: eccodes_c_grib_ensemble_index
+163/266 Test #158: eccodes_c_grib_ensemble_index ...............   Passed    0.25 sec
+        Start 159: eccodes_c_grib_set_pv
+164/266 Test #159: eccodes_c_grib_set_pv .......................   Passed    0.03 sec
+        Start 160: eccodes_c_grib_set_bitmap
+165/266 Test #160: eccodes_c_grib_set_bitmap ...................   Passed    0.03 sec
+        Start 161: eccodes_c_grib_list
+166/266 Test #161: eccodes_c_grib_list .........................   Passed    0.02 sec
+        Start 162: eccodes_c_grib_get_data
+167/266 Test #162: eccodes_c_grib_get_data .....................   Passed    0.31 sec
+        Start 163: eccodes_c_grib_nearest_multiple
+168/266 Test #163: eccodes_c_grib_nearest_multiple .............   Passed    0.02 sec
+        Start 164: eccodes_c_set_missing
+169/266 Test #164: eccodes_c_set_missing .......................   Passed    0.02 sec
+        Start 165: eccodes_c_bufr_attributes
+170/266 Test #165: eccodes_c_bufr_attributes ...................   Passed    0.02 sec
+        Start 166: eccodes_c_bufr_copy_data
+171/266 Test #166: eccodes_c_bufr_copy_data ....................***Failed    0.02 sec
+        Start 167: eccodes_c_bufr_clone
+172/266 Test #167: eccodes_c_bufr_clone ........................   Passed    0.03 sec
+        Start 168: eccodes_c_bufr_expanded
+173/266 Test #168: eccodes_c_bufr_expanded .....................   Passed    0.02 sec
+        Start 169: eccodes_c_bufr_get_keys
+174/266 Test #169: eccodes_c_bufr_get_keys .....................   Passed    0.02 sec
+        Start 170: eccodes_c_bufr_get_string_array
+175/266 Test #170: eccodes_c_bufr_get_string_array .............   Passed    0.02 sec
+        Start 171: eccodes_c_bufr_keys_iterator
+176/266 Test #171: eccodes_c_bufr_keys_iterator ................   Passed    0.02 sec
+        Start 172: eccodes_c_bufr_missing
+177/266 Test #172: eccodes_c_bufr_missing ......................   Passed    0.02 sec
+        Start 173: eccodes_c_bufr_read_header
+178/266 Test #173: eccodes_c_bufr_read_header ..................   Passed    0.11 sec
+        Start 174: eccodes_c_bufr_read_scatterometer
+179/266 Test #174: eccodes_c_bufr_read_scatterometer ...........   Passed    0.02 sec
+        Start 175: eccodes_c_bufr_read_synop
+180/266 Test #175: eccodes_c_bufr_read_synop ...................   Passed    0.02 sec
+        Start 176: eccodes_c_bufr_read_temp
+181/266 Test #176: eccodes_c_bufr_read_temp ....................   Passed    0.03 sec
+        Start 177: eccodes_c_bufr_set_keys
+182/266 Test #177: eccodes_c_bufr_set_keys .....................   Passed    0.03 sec
+        Start 178: eccodes_c_bufr_subset
+183/266 Test #178: eccodes_c_bufr_subset .......................   Passed    0.03 sec
+        Start 179: eccodes_c_get_product_kind
+184/266 Test #179: eccodes_c_get_product_kind ..................   Passed    0.02 sec
+        Start 180: eccodes_c_new_sample
+185/266 Test #180: eccodes_c_new_sample ........................   Passed    0.02 sec
+        Start 181: eccodes_f_grib_set_pv
+186/266 Test #181: eccodes_f_grib_set_pv .......................   Passed    0.11 sec
+        Start 182: eccodes_f_grib_set_data
+187/266 Test #182: eccodes_f_grib_set_data .....................   Passed    0.02 sec
+        Start 183: eccodes_f_grib_ecc-671
+188/266 Test #183: eccodes_f_grib_ecc-671 ......................   Passed    0.02 sec
+        Start 184: eccodes_f_grib_index
+189/266 Test #184: eccodes_f_grib_index ........................   Passed    0.90 sec
+        Start 185: eccodes_f_grib_copy_message
+190/266 Test #185: eccodes_f_grib_copy_message .................   Passed    0.12 sec
+        Start 186: eccodes_f_bufr_copy_message
+191/266 Test #186: eccodes_f_bufr_copy_message .................   Passed    0.02 sec
+        Start 187: eccodes_f_grib_get_keys
+192/266 Test #187: eccodes_f_grib_get_keys .....................   Passed    0.03 sec
+        Start 188: eccodes_f_grib_get_data
+193/266 Test #188: eccodes_f_grib_get_data .....................   Passed    0.71 sec
+        Start 189: eccodes_f_get_pl
+194/266 Test #189: eccodes_f_get_pl ............................   Passed    0.02 sec
+        Start 190: eccodes_f_get_pv
+195/266 Test #190: eccodes_f_get_pv ............................   Passed    0.01 sec
+        Start 191: eccodes_f_grib_keys_iterator
+196/266 Test #191: eccodes_f_grib_keys_iterator ................   Passed    0.05 sec
+        Start 192: eccodes_f_grib_multi_write
+197/266 Test #192: eccodes_f_grib_multi_write ..................   Passed    0.13 sec
+        Start 193: eccodes_f_grib_multi
+198/266 Test #193: eccodes_f_grib_multi ........................   Passed    0.03 sec
+        Start 194: eccodes_f_grib_nearest
+199/266 Test #194: eccodes_f_grib_nearest ......................   Passed    0.02 sec
+        Start 195: eccodes_f_grib_precision
+200/266 Test #195: eccodes_f_grib_precision ....................   Passed    0.02 sec
+        Start 196: eccodes_f_grib_print_data
+201/266 Test #196: eccodes_f_grib_print_data ...................   Passed    0.37 sec
+        Start 197: eccodes_f_grib_set_keys
+202/266 Test #197: eccodes_f_grib_set_keys .....................   Passed    0.06 sec
+        Start 198: eccodes_f_grib_set_bitmap
+203/266 Test #198: eccodes_f_grib_set_bitmap ...................   Passed    0.03 sec
+        Start 199: eccodes_f_grib_set_missing
+204/266 Test #199: eccodes_f_grib_set_missing ..................   Passed    0.02 sec
+        Start 200: eccodes_f_grib_samples
+205/266 Test #200: eccodes_f_grib_samples ......................   Passed    0.04 sec
+        Start 201: eccodes_f_grib_count_messages
+206/266 Test #201: eccodes_f_grib_count_messages ...............   Passed    0.04 sec
+        Start 202: eccodes_f_grib_count_messages_multi
+207/266 Test #202: eccodes_f_grib_count_messages_multi .........   Passed    0.04 sec
+        Start 203: eccodes_f_grib_copy_namespace
+208/266 Test #203: eccodes_f_grib_copy_namespace ...............   Passed    0.05 sec
+        Start 204: eccodes_f_read_message
+209/266 Test #204: eccodes_f_read_message ......................   Passed    0.38 sec
+        Start 205: eccodes_f_read_from_file
+210/266 Test #205: eccodes_f_read_from_file ....................   Passed    0.01 sec
+        Start 206: eccodes_f_get_set_uuid
+211/266 Test #206: eccodes_f_get_set_uuid ......................   Passed    0.05 sec
+        Start 207: eccodes_f_grib_clone
+212/266 Test #207: eccodes_f_grib_clone ........................   Passed    0.03 sec
+        Start 208: eccodes_f_bufr_attributes
+213/266 Test #208: eccodes_f_bufr_attributes ...................   Passed    0.04 sec
+        Start 209: eccodes_f_bufr_copy_data
+214/266 Test #209: eccodes_f_bufr_copy_data ....................***Failed    0.04 sec
+        Start 210: eccodes_f_bufr_clone
+215/266 Test #210: eccodes_f_bufr_clone ........................   Passed    0.03 sec
+        Start 211: eccodes_f_bufr_expanded
+216/266 Test #211: eccodes_f_bufr_expanded .....................   Passed    0.02 sec
+        Start 212: eccodes_f_bufr_get_keys
+217/266 Test #212: eccodes_f_bufr_get_keys .....................   Passed    0.02 sec
+        Start 213: eccodes_f_bufr_get_string_array
+218/266 Test #213: eccodes_f_bufr_get_string_array .............   Passed    0.03 sec
+        Start 214: eccodes_f_bufr_keys_iterator
+219/266 Test #214: eccodes_f_bufr_keys_iterator ................   Passed    0.02 sec
+        Start 215: eccodes_f_bufr_read_header
+220/266 Test #215: eccodes_f_bufr_read_header ..................   Passed    0.01 sec
+        Start 216: eccodes_f_bufr_read_scatterometer
+221/266 Test #216: eccodes_f_bufr_read_scatterometer ...........   Passed    0.05 sec
+        Start 217: eccodes_f_bufr_read_synop
+222/266 Test #217: eccodes_f_bufr_read_synop ...................   Passed    0.02 sec
+        Start 218: eccodes_f_bufr_read_temp
+223/266 Test #218: eccodes_f_bufr_read_temp ....................   Passed    0.03 sec
+        Start 219: eccodes_f_bufr_read_tropical_cyclone
+224/266 Test #219: eccodes_f_bufr_read_tropical_cyclone ........   Passed    0.04 sec
+        Start 220: eccodes_f_bufr_set_keys
+225/266 Test #220: eccodes_f_bufr_set_keys .....................   Passed    0.05 sec
+        Start 221: eccodes_f_bufr_copy_keys
+226/266 Test #221: eccodes_f_bufr_copy_keys ....................   Passed    0.02 sec
+        Start 222: eccodes_f_bufr_subset
+227/266 Test #222: eccodes_f_bufr_subset .......................   Passed    0.03 sec
+        Start 223: eccodes_f_get_product_kind
+228/266 Test #223: eccodes_f_get_product_kind ..................   Passed    0.03 sec
+        Start 224: eccodes_p_grib_set_pv_test
+229/266 Test #224: eccodes_p_grib_set_pv_test ..................   Passed    0.14 sec
+        Start 225: eccodes_p_grib_read_sample_test
+230/266 Test #225: eccodes_p_grib_read_sample_test .............   Passed    0.18 sec
+        Start 226: eccodes_p_bufr_read_sample_test
+231/266 Test #226: eccodes_p_bufr_read_sample_test .............   Passed    0.19 sec
+        Start 227: eccodes_p_bufr_ecc-869_test
+232/266 Test #227: eccodes_p_bufr_ecc-869_test .................   Passed    0.19 sec
+        Start 228: eccodes_p_grib_clone_test
+233/266 Test #228: eccodes_p_grib_clone_test ...................   Passed    0.21 sec
+        Start 229: eccodes_p_grib_count_messages_test
+234/266 Test #229: eccodes_p_grib_count_messages_test ..........   Passed    0.15 sec
+        Start 230: eccodes_p_grib_get_message_offset_test
+235/266 Test #230: eccodes_p_grib_get_message_offset_test ......   Passed    0.17 sec
+        Start 231: eccodes_p_grib_get_keys_test
+236/266 Test #231: eccodes_p_grib_get_keys_test ................   Passed    0.19 sec
+        Start 232: eccodes_p_grib_index_test
+237/266 Test #232: eccodes_p_grib_index_test ...................   Passed    1.00 sec
+        Start 233: eccodes_p_grib_iterator_test
+238/266 Test #233: eccodes_p_grib_iterator_test ................   Passed    5.61 sec
+        Start 234: eccodes_p_grib_keys_iterator_test
+239/266 Test #234: eccodes_p_grib_keys_iterator_test ...........   Passed    0.17 sec
+        Start 235: eccodes_p_grib_multi_write_test
+240/266 Test #235: eccodes_p_grib_multi_write_test .............   Passed    0.09 sec
+        Start 236: eccodes_p_grib_nearest_test
+241/266 Test #236: eccodes_p_grib_nearest_test .................   Passed    0.09 sec
+        Start 237: eccodes_p_grib_print_data_test
+242/266 Test #237: eccodes_p_grib_print_data_test ..............   Passed    0.10 sec
+        Start 238: eccodes_p_grib_samples_test
+243/266 Test #238: eccodes_p_grib_samples_test .................   Passed    0.10 sec
+        Start 239: eccodes_p_grib_set_missing_test
+244/266 Test #239: eccodes_p_grib_set_missing_test .............   Passed    0.11 sec
+        Start 240: eccodes_p_binary_message_test
+245/266 Test #240: eccodes_p_binary_message_test ...............   Passed    0.27 sec
+        Start 241: eccodes_p_grib_set_bitmap_test
+246/266 Test #241: eccodes_p_grib_set_bitmap_test ..............   Passed    0.10 sec
+        Start 242: eccodes_p_bufr_attributes_test
+247/266 Test #242: eccodes_p_bufr_attributes_test ..............   Passed    0.10 sec
+        Start 243: eccodes_p_bufr_clone_test
+248/266 Test #243: eccodes_p_bufr_clone_test ...................   Passed    0.11 sec
+        Start 244: eccodes_p_bufr_copy_data_test
+249/266 Test #244: eccodes_p_bufr_copy_data_test ...............***Failed    0.11 sec
+        Start 245: eccodes_p_bufr_expanded_test
+250/266 Test #245: eccodes_p_bufr_expanded_test ................   Passed    0.09 sec
+        Start 246: eccodes_p_bufr_get_keys_test
+251/266 Test #246: eccodes_p_bufr_get_keys_test ................   Passed    0.10 sec
+        Start 247: eccodes_p_bufr_keys_iterator_test
+252/266 Test #247: eccodes_p_bufr_keys_iterator_test ...........   Passed    0.10 sec
+        Start 248: eccodes_p_bufr_read_header_test
+253/266 Test #248: eccodes_p_bufr_read_header_test .............   Passed    0.32 sec
+        Start 249: eccodes_p_bufr_read_scatterometer_test
+254/266 Test #249: eccodes_p_bufr_read_scatterometer_test ......   Passed    0.10 sec
+        Start 250: eccodes_p_bufr_read_tropical_cyclone_test
+255/266 Test #250: eccodes_p_bufr_read_tropical_cyclone_test ...   Passed    0.29 sec
+        Start 251: eccodes_p_bufr_read_synop_test
+256/266 Test #251: eccodes_p_bufr_read_synop_test ..............   Passed    0.09 sec
+        Start 252: eccodes_p_bufr_read_temp_test
+257/266 Test #252: eccodes_p_bufr_read_temp_test ...............   Passed    0.09 sec
+        Start 253: eccodes_p_bufr_set_keys_test
+258/266 Test #253: eccodes_p_bufr_set_keys_test ................   Passed    0.11 sec
+        Start 254: eccodes_p_bufr_subset_test
+259/266 Test #254: eccodes_p_bufr_subset_test ..................   Passed    0.10 sec
+        Start 255: eccodes_p_get_product_kind_test
+260/266 Test #255: eccodes_p_get_product_kind_test .............   Passed    0.10 sec
+        Start 256: eccodes_p_gts_get_keys_test
+261/266 Test #256: eccodes_p_gts_get_keys_test .................   Passed    0.16 sec
+        Start 257: eccodes_p_metar_get_keys_test
+262/266 Test #257: eccodes_p_metar_get_keys_test ...............   Passed    0.19 sec
+        Start 258: eccodes_p_bufr_ecc-448_test
+263/266 Test #258: eccodes_p_bufr_ecc-448_test .................   Passed    0.10 sec
+        Start 259: eccodes_p_high_level_api_test
+264/266 Test #259: eccodes_p_high_level_api_test ...............   Passed    0.33 sec
+        Start 260: eccodes_p_grib_set_keys_test
+265/266 Test #260: eccodes_p_grib_set_keys_test ................   Passed    0.09 sec
+        Start 261: eccodes_p_bufr_encode_flight_test
+266/266 Test #261: eccodes_p_bufr_encode_flight_test ...........   Passed    0.25 sec
+
+97% tests passed, 8 tests failed out of 266
+
+Label Time Summary:
+download_data    =  37.11 sec*proc (5 tests)
+eccodes          = 367.44 sec*proc (266 tests)
+executable       =   0.02 sec*proc (1 test)
+script           = 330.30 sec*proc (260 tests)
+
+Total Test time (real) = 368.04 sec
+
+The following tests FAILED:
+	  4 - eccodes_t_md5 (BAD_COMMAND)
+	 29 - eccodes_t_bufr_dump_encode_filter (Failed)
+	 36 - eccodes_t_bufr_filter (Failed)
+	 56 - eccodes_t_bufr_ecc-393 (Failed)
+	138 - eccodes_t_bufr_dump_encode_python (Failed)
+	166 - eccodes_c_bufr_copy_data (Failed)
+	209 - eccodes_f_bufr_copy_data (Failed)
+	244 - eccodes_p_bufr_copy_data_test (Failed)
+Errors while running CTest

--- a/src/ChangesB6.txt
+++ b/src/ChangesB6.txt
@@ -1,0 +1,157 @@
+Compilation
+---------------
+unlink eccodes-2.17.0-Source; unlink eccodes-2.17.0-BUILD; unlink eccodes-2.17.0-INSTALL ; 
+ln -fs eccodes-2.17.0-Source.B6 eccodes-2.17.0-Source ; ln -fs eccodes-2.17.0-BUILD.B6 eccodes-2.17.0-BUILD ; ln -fs eccodes-2.17.0-INSTALL.B6 eccodes-2.17.0-INSTALL ; 
+
+#DEBUG OFF
+rm -rf cmake.out ;cmake3 -DENABLE_NETCDF=OFF -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_PREFIX=/home/eccuser/eccodes-2.17.0-INSTALL.B6 -DENABLE_EXTRA_TESTS=1 /home/eccuser/eccodes-2.17.0-Source >> cmake.out 2>&1 ; egrep -i "error|fail" cmake.out
+
+#DEBUG ON
+rm -rf cmake.out ;cmake3 -DCMAKE_C_FLAGS="-g -O0" -DENABLE_NETCDF=OFF -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_PREFIX=/home/eccuser/eccodes-2.17.0-INSTALL.B6  -DCMAKE_BUILD_TYPE=Debug -DENABLE_EXTRA_TESTS=1 -DDEVELOPER_MODE=1 /home/eccuser/eccodes-2.17.0-Source.B6 >> cmake.out 2>&1 ; egrep -i "error|fail" cmake.out
+
+rm -rf make.out; make >> make.out 2>&1; egrep -i "error|fail" make.out;
+
+rm -rf ctest3.out; ctest3 >> ctest3.out 2>&1 ; egrep -i "error|fail" ctest3.out; 
+
+rm -rf make_install.out; make install >> make_install.out 2>&1 ; egrep -i "error|fail" make_install.out;
+
+Base version
+-------------
+The base version for this version is B5.
+
+Differences/Rules
+-----------------
+The Rule 1,2,3 are applied on the dynamic array structs of:  
+* grib_darray.c  
+* grib_iarray.c  
+* grib_oarray.c  
+* grib_sarray.c  
+* grib_vdarray.c  
+* grib_viarray.c  
+* grib_vsarray.c 
+
+* Rule 1. Add to a dynamic array struct a static array , which will be filled for first;  
+* Rule 2. Once the static array is full, proceed to resize the array, allocating the dynamic memory in the dynamic area of the dynamic array struct;  
+* Rule 3. Tuning all the dynamic arrays getters/setters methods accordingly.  
+
+Corrections
+-----------
+* Removed unused functions in all the mentioned arrays;
+
+Examples
+----------
+* Rule 1.
+
+"grib_darray" struct in version B5 was
+
+struct grib_darray  
+{  
+    double* v;  
+    size_t size;  
+    size_t n;  
+    size_t incsize;    
+};  
+  
+In B6 the same struct is  
+  
+struct grib_darray  
+{  
+    double sv[DYN_DEFAULT_DARRAY_SIZE_INIT];  
+    size_t size;  
+    size_t n;  
+    size_t incsize;  
+    double* v;  
+};  
+  
+Where "sv" is a static array which is allocated at runtime when the malloc for "grib_darray" allocation is called. This space will first be filled and only if completely full, the dynamic area "v" will be allocated, with a consequent malloc/free burden at runtime.   
+When a new dynamic array is build through the method "new", only one malloc will be called to build it and not two mallocs as in B5. Here an example which clarify the mechanism.
+Location: grib_accessor_class_bufr_data_array.c/process_elements  
+elementsDescriptorsIndex = grib_iarray_new(c, DYN_DEFAULT_IARRAY_SIZE_INIT, DYN_DEFAULT_IARRAY_SIZE_INCR);  
+The method grib_iarray_new directly instantiates in only one malloc the space for the struct, like this:  
+grib_iarray* result = NULL;  
+	result = (grib_iarray*)grib_context_malloc(c, sizeof(grib_iarray));  
+The dynamic area "v" will be allocated only if the startsize is bigger than the defined value DYN_DEFAULT_IARRAY_SIZE_INIT. This mechanism, already eliminates a malloc call.
+
+* Rule 2.
+
+The changed dynamic arrays are quite similar in their structures. As a matter of fact, also the functions which access them have similar signatures. So the allocation of more space is done for all of them in the "resize" method" and it is precisely the method which was changed for all of them. Here it is reported the the resize method for "grib_iarray":
+newsize = origin->incsize + origin->size;
+	if (origin->v != NULL){
+		newv      = (long*)grib_context_realloc(c, origin->v, (newsize-DYN_DEFAULT_IARRAY_SIZE_INIT) * sizeof(long));
+		origin->v=newv;
+	} else {
+		newv      = (long*)grib_context_malloc(c,  (newsize-DYN_DEFAULT_IARRAY_SIZE_INIT ) * sizeof(long) );
+		origin->v=newv;
+	}
+	origin->size                = newsize; 
+
+* Rule 3.
+
+While in the original version the dynamic array "v", of any of the dynamic structures under exam, was accessed widely through the C access operators "[]", in B6 this was changed. In fact, after the reenginering of the data structures, it is not obvious anymore that an element at index "idx" can be found in v[idx]. In fact the general rule is that if idx is smaller that the default size of the static array, than the element is to be searched in at "sv[idx]". Otherwise, the element will be searched in v[idx-SV_DEFAULT_SIZE]. These calculations are done by setters/getters method like:  
+long grib_iarray_get(grib_iarray* source, size_t index);  
+grib_iarray* grib_iarray_push(grib_iarray* source, long val);
+Another method whch is important to mention is:  
+double* grib_darray_get_arrays_by_reference(grib_darray* source);
+The method will in fact analyse which is the actual array and will return the correct reference to it. This method is directly used from the accessors in order to unpack the messages, with the help of the parser.  
+  
+Differences
+------------
+The complete list of differences, due to Rule 1, 2 and 3 and other corrections are here.
+
+Difference between original code contained in eccodes-2.17.0 and B6:
+For Rule 1 and 2, plus removal of unused functions:
+grib_api.h
+grib_api_internal.h
+grib_api_prototypes.h
+grib_darray.c
+grib_iarray.c
+grib_oarray.c
+grib_sarray.c
+grib_vdarray.c
+grib_viarray.c
+grib_vsarray.c
+
+For Rule 3
+action_class_set_darray.c
+action_class_set_iarray.c
+action_class_set_sarray.c
+bufr_util.c
+grib_accessor_class_bufr_data_array.c
+grib_accessor_class_bufr_data_element.c
+grib_accessor_class_bufr_string_values.c
+grib_accessor_class_concept.c
+grib_accessor_class_hash_array.c
+grib_accessor_class_long_vector.c
+grib_bufr_descriptors_array.c
+grib_accessor_class_transient_darray.c
+grib_trie_with_rank.c
+
+Difference between B5 code and B6:
+
+./action_class_set_darray.c
+./action_class_set_iarray.c
+./action_class_set_sarray.c
+./grib_accessor_class_bufr_data_array.c
+./grib_accessor_class_bufr_data_element.c
+./grib_accessor_class_bufr_string_values.c
+./grib_accessor_class_concept.c
+./grib_accessor_class_hash_array.c
+./grib_accessor_class_long_vector.c
+./grib_accessor_class_transient_darray.c
+./grib_api.h
+./grib_api_internal.h
+./grib_api_prototypes.h
+./grib_darray.c
+./grib_iarray.c
+./grib_oarray.c
+./grib_sarray.c
+./grib_trie_with_rank.c
+./grib_vdarray.c
+./grib_viarray.c
+./grib_vsarray.c
+
+Observations
+------------
+* "grib_action* grib_action_create_set_iarray(grib_context* context, const char* name, grib_iarray* iarray)"
+in action_class_set_iarray.c is never used
+

--- a/src/action_class_set_darray.c
+++ b/src/action_class_set_darray.c
@@ -107,7 +107,8 @@ static int execute(grib_action* a, grib_handle* h)
 {
     grib_action_set_darray* self = (grib_action_set_darray*)a;
 
-    return grib_set_double_array(h, self->name, self->darray->v, self->darray->n);
+    return grib_set_double_array(h, self->name, grib_darray_get_arrays_by_reference(self->darray), self->darray->n);
+    //return grib_set_double_array(h, self->name, self->darray->v, self->darray->n);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/action_class_set_iarray.c
+++ b/src/action_class_set_iarray.c
@@ -106,8 +106,9 @@ grib_action* grib_action_create_set_iarray(grib_context* context,
 static int execute(grib_action* a, grib_handle* h)
 {
     grib_action_set_iarray* self = (grib_action_set_iarray*)a;
-
-    return grib_set_long_array(h, self->name, self->iarray->v, self->iarray->n);
+    size_t size = grib_iarray_used_size(self->iarray);
+    //return grib_set_long_array(h, self->name, self->iarray->v, self->iarray->n);
+    return grib_set_long_array(h, self->name, grib_iarray_get_arrays_by_reference(self->iarray), size);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/action_class_set_sarray.c
+++ b/src/action_class_set_sarray.c
@@ -107,7 +107,8 @@ static int execute(grib_action* a, grib_handle* h)
 {
     grib_action_set_sarray* self = (grib_action_set_sarray*)a;
 
-    return grib_set_string_array(h, self->name, (const char**)self->sarray->v, self->sarray->n);
+    //return grib_set_string_array(h, self->name, (const char**)self->sarray->v, self->sarray->n);
+    return grib_set_string_array(h, self->name, (const char**)grib_sarray_get_arrays_by_reference(self->sarray), self->sarray->n);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/action_class_transient_darray.c
+++ b/src/action_class_transient_darray.c
@@ -121,7 +121,8 @@ static int execute(grib_action* act, grib_handle* h)
     if (a->flags & GRIB_ACCESSOR_FLAG_CONSTRAINT)
         grib_dependency_observe_arguments(a, act->default_value);
 
-    return grib_pack_double(a, self->darray->v, &len);
+    /*return grib_pack_double(a, self->darray->dynA, &len);*/
+    return grib_pack_double(a,  grib_darray_get_arrays_by_reference(self->darray), &len);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/bufr_util.c
+++ b/src/bufr_util.c
@@ -70,7 +70,9 @@ char** codes_bufr_copy_data_return_copied_keys(grib_handle* hin, grib_handle* ho
     kiter = codes_bufr_data_section_keys_iterator_new(hin);
     if (!kiter)
         return NULL;
-    k = grib_sarray_new(hin->context, 50, 10);
+    //magic numbers 50 and 10 are not documented anywhere...
+    //k = grib_sarray_new(hin->context, 50, 10);
+    k = grib_sarray_new(hin->context, 50, 60);
 
     while (codes_bufr_keys_iterator_next(kiter)) {
         name = codes_bufr_keys_iterator_get_name(kiter);

--- a/src/grib_accessor_class_bufr_data_element.c
+++ b/src/grib_accessor_class_bufr_data_element.c
@@ -10,6 +10,7 @@
 
 /*****************************************
  *  Enrico Fucile
+ *  Modified for Performance Study by: CS GMBH
  ****************************************/
 
 #include "grib_api_internal.h"
@@ -295,20 +296,30 @@ static int unpack_string_array(grib_accessor* a, char** val, size_t* len)
     grib_context* c = a->context;
 
     if (self->compressedData) {
-        DebugAssert(self->index < self->numericValues->n);
-        idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
-        DebugAssert(idx < self->stringValues->n);
-        count = grib_sarray_used_size(self->stringValues->v[idx]);
+        //DebugAssert(self->index < self->numericValues->n);
+        DebugAssert(self->index < grib_vdarray_used_size (self->numericValues));
+        //idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        //idx = (  (int) grib_darray_get (self->numericValues->v[self->index], 0) / 1000 - 1) / self->numberOfSubsets;
+        idx = (  (int) grib_darray_get (grib_vdarray_get (self->numericValues, self->index), 0) / 1000 - 1) / self->numberOfSubsets;
+        //DebugAssert(idx < self->stringValues->n);
+        DebugAssert(idx < grib_vsarray_used_size(self->stringValues));
+        //count = grib_sarray_used_size(self->stringValues->v[idx]);
+        count = grib_sarray_used_size(grib_vsarray_get(self->stringValues,idx));
         for (i = 0; i < count; i++) {
-            val[i] = grib_context_strdup(c, self->stringValues->v[idx]->v[i]);
+            //val[i] = grib_context_strdup(c, self->stringValues->v[idx]->v[i]);
+            val[i] = grib_context_strdup(c, grib_sarray_get(grib_vsarray_get(self->stringValues,idx),i));
         }
         *len = count;
     }
     else {
-        DebugAssert(self->subsetNumber < self->numericValues->n);
-        DebugAssert(self->index < self->numericValues->v[self->subsetNumber]->n);
-        idx    = (int)self->numericValues->v[self->subsetNumber]->v[self->index] / 1000 - 1;
-        val[0] = grib_context_strdup(c, self->stringValues->v[idx]->v[0]);
+        DebugAssert(self->subsetNumber < grib_vdarray_used_size (self->numericValues));
+        DebugAssert(self->index < grib_darray_used_size(grib_vdarray_get (self->numericValues, self->subsetNumber)) );
+        //idx    = (int)self->numericValues->v[self->subsetNumber]->v[self->index] / 1000 - 1;
+        //idx    = (int) grib_darray_get ( self->numericValues->v[self->subsetNumber], self->index) / 1000 - 1;
+        idx    = (int) grib_darray_get ( grib_vdarray_get (self->numericValues, self->subsetNumber), self->index) / 1000 - 1;
+        //val[0] = grib_context_strdup(c, self->stringValues->v[idx]->v[0]);
+        //val[0] = grib_context_strdup(c, grib_sarray_get(self->stringValues->v[idx],0));
+        val[0] = grib_context_strdup(c, grib_sarray_get(grib_vsarray_get(self->stringValues,idx),0));
         *len   = 1;
     }
 
@@ -324,17 +335,21 @@ static int pack_string_array(grib_accessor* a, const char** v, size_t* len)
     grib_context* c = a->context;
 
     if (self->compressedData) {
-        idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        //idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        idx = ((int) grib_darray_get (grib_vdarray_get (self->numericValues, self->index), 0 ) / 1000 - 1) / self->numberOfSubsets;
         if (*len != 1 && *len != self->numberOfSubsets) {
             grib_context_log(c, GRIB_LOG_ERROR, "Number of values mismatch for '%s': %ld strings provided but expected %ld (=number of subsets)",
-                             self->descriptors->v[self->elementsDescriptorsIndex->v[0]->v[idx]]->shortName, *len, self->numberOfSubsets);
+                            // self->descriptors->v[self->elementsDescriptorsIndex->v[0]->v[idx]]->shortName, *len, self->numberOfSubsets);
+            		          self->descriptors->v[  grib_iarray_get ( grib_viarray_get (self->elementsDescriptorsIndex, 0), idx) ]->shortName, *len, self->numberOfSubsets);
             return GRIB_ARRAY_TOO_SMALL;
         }
-        grib_sarray_delete(c, self->stringValues->v[idx]);
-        self->stringValues->v[idx] = grib_sarray_new(c, *len, 1);
+        grib_sarray_delete(c, grib_vsarray_get(self->stringValues,idx));
+        //self->stringValues->v[idx] = grib_sarray_new(c, *len, 1);
+        //self->stringValues->v[idx] = grib_sarray_new(c, *len, *len );
+        grib_vsarray_put ( self->stringValues, idx, grib_sarray_new(c, *len, *len ));
         for (i = 0; i < *len; i++) {
             s = grib_context_strdup(c, v[i]);
-            grib_sarray_push(c, self->stringValues->v[idx], s);
+            grib_sarray_push(c, grib_vsarray_get(self->stringValues,idx), s);
         }
     }
     else {
@@ -368,19 +383,25 @@ static int unpack_string(grib_accessor* a, char* val, size_t* len)
     }
 
     if (self->compressedData) {
-        DebugAssert(self->index < self->numericValues->n);
-        idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        DebugAssert(self->index < grib_vdarray_used_size (self->numericValues));
+        //idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        idx = ((int) grib_darray_get (grib_vdarray_get (self->numericValues, self->index), 0) / 1000 - 1) / self->numberOfSubsets;
         if (idx < 0)
             return GRIB_INTERNAL_ERROR;
-        str = grib_context_strdup(c, self->stringValues->v[idx]->v[0]);
+        //str = grib_context_strdup(c, self->stringValues->v[idx]->v[0]);
+        //str = grib_context_strdup(c, grib_sarray_get(self->stringValues->v[idx],0));
+        str = grib_context_strdup(c, grib_sarray_get( grib_vsarray_get(self->stringValues,idx),0));
     }
     else {
-        DebugAssert(self->subsetNumber < self->numericValues->n);
-        idx = (int)self->numericValues->v[self->subsetNumber]->v[self->index] / 1000 - 1;
+        DebugAssert(self->subsetNumber < grib_vdarray_used_size (self->numericValues));
+        //idx = (int)self->numericValues->v[self->subsetNumber]->v[self->index] / 1000 - 1;
+        idx = (int) grib_darray_get (grib_vdarray_get (self->numericValues, self->subsetNumber), self->index) / 1000 - 1;
         if (idx < 0)
             return GRIB_INTERNAL_ERROR;
-        DebugAssert(idx < self->stringValues->n);
-        str = grib_context_strdup(c, self->stringValues->v[idx]->v[0]);
+        //DebugAssert(idx < self->stringValues->n);
+        DebugAssert(idx < grib_vsarray_used_size(self->stringValues));
+        //str = grib_context_strdup(c, self->stringValues->v[idx]->v[0]);
+        str = grib_context_strdup(c, grib_sarray_get(grib_vsarray_get(self->stringValues,idx),0));
     }
 
     if (str == 0 || strlen(str) == 0) {
@@ -420,15 +441,20 @@ static int pack_string(grib_accessor* a, const char* val, size_t* len)
     grib_context* c = a->context;
 
     if (self->compressedData) {
-        idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+       // idx = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        idx = ((int) grib_darray_get ( grib_vdarray_get (self->numericValues, self->index), 0) / 1000 - 1) / self->numberOfSubsets;
     }
     else {
-        idx = (int)self->numericValues->v[self->subsetNumber]->v[self->index] / 1000 - 1;
+        //idx = (int)self->numericValues->v[self->subsetNumber]->v[self->index] / 1000 - 1;
+        idx = (int) grib_darray_get ( grib_vdarray_get (self->numericValues, self->subsetNumber), self->index) / 1000 - 1;
     }
-    grib_sarray_delete(c, self->stringValues->v[idx]);
-    self->stringValues->v[idx] = grib_sarray_new(c, 1, 1);
+    //grib_sarray_delete(c, self->stringValues->v[idx]);
+    grib_sarray_delete(c, grib_vsarray_get(self->stringValues,idx));
+    //self->stringValues->v[idx] = grib_sarray_new(c, 1, 1);
+    grib_vsarray_put(self->stringValues, idx, grib_sarray_new(c, 1, 1));
     s                          = grib_context_strdup(c, val);
-    grib_sarray_push(c, self->stringValues->v[idx], s);
+    //grib_sarray_push(c, self->stringValues->v[idx], s);
+    grib_sarray_push(c, grib_vsarray_get(self->stringValues, idx), s);
 
     return ret;
 }
@@ -446,16 +472,27 @@ static int unpack_long(grib_accessor* a, long* val, size_t* len)
 
     if (self->compressedData) {
         for (i = 0; i < count; i++) {
-            DebugAssert(self->index < self->numericValues->n);
-            DebugAssert(i < self->numericValues->v[self->index]->n);
-            val[i] = self->numericValues->v[self->index]->v[i] == GRIB_MISSING_DOUBLE ? GRIB_MISSING_LONG : (long)self->numericValues->v[self->index]->v[i];
+            //DebugAssert(self->index < self->numericValues->n);
+            DebugAssert(self->index < grib_vdarray_used_size (self->numericValues) );
+            //DebugAssert(i < self->numericValues->v[self->index]->n);
+            DebugAssert(i <  grib_darray_used_size (grib_vdarray_get (self->numericValues, self->index)) );
+            //val[i] = self->numericValues->v[self->index]->v[i] == GRIB_MISSING_DOUBLE ? GRIB_MISSING_LONG : (long)self->numericValues->v[self->index]->v[i];
+            val[i] = (grib_darray_get (grib_vdarray_get (self->numericValues, self->index), i) == GRIB_MISSING_DOUBLE ) ?
+            		GRIB_MISSING_LONG :
+					(long) grib_darray_get ( grib_vdarray_get (self->numericValues, self->index), i);
         }
         *len = count;
     }
     else {
-        DebugAssert(self->subsetNumber < self->numericValues->n);
-        DebugAssert(self->index < self->numericValues->v[self->subsetNumber]->n);
-        val[0] = self->numericValues->v[self->subsetNumber]->v[self->index] == GRIB_MISSING_DOUBLE ? GRIB_MISSING_LONG : (long)self->numericValues->v[self->subsetNumber]->v[self->index];
+        //DebugAssert(self->subsetNumber < self->numericValues->n);
+        DebugAssert(self->subsetNumber <  grib_vdarray_used_size (self->numericValues) );
+        //DebugAssert(self->index < self->numericValues->v[self->subsetNumber]->n);
+        DebugAssert(self->index < grib_darray_used_size (grib_vdarray_get (self->numericValues, self->subsetNumber)) );
+
+        //val[0] = self->numericValues->v[self->subsetNumber]->v[self->index] == GRIB_MISSING_DOUBLE ? GRIB_MISSING_LONG : (long)self->numericValues->v[self->subsetNumber]->v[self->index];
+        val[0] = ( grib_darray_get (grib_vdarray_get (self->numericValues, self->subsetNumber), self->index ) == GRIB_MISSING_DOUBLE  ) ?
+        		GRIB_MISSING_LONG :
+				(long) grib_darray_get ( grib_vdarray_get (self->numericValues, self->subsetNumber),  self->index );
         *len   = 1;
     }
 
@@ -475,16 +512,24 @@ static int unpack_double(grib_accessor* a, double* val, size_t* len)
 
     if (self->compressedData) {
         for (i = 0; i < count; i++) {
-            DebugAssert(self->index < self->numericValues->n);
-            DebugAssert(i < self->numericValues->v[self->index]->n);
-            val[i] = self->numericValues->v[self->index]->v[i];
+            //DebugAssert(self->index < self->numericValues->n);
+            //DebugAssert(i < self->numericValues->v[self->index]->n);
+            DebugAssert(self->index < grib_vdarray_used_size (self->numericValues));
+            DebugAssert(i < grib_darray_used_size (grib_vdarray_get (self->numericValues, self->index)) );
+
+            //val[i] = self->numericValues->v[self->index]->v[i];
+            val[i] = grib_darray_get ( grib_vdarray_get (self->numericValues, self->index) , i );
         }
         *len = count;
     }
     else {
-        DebugAssert(self->subsetNumber < self->numericValues->n);
-        DebugAssert(self->index < self->numericValues->v[self->subsetNumber]->n);
-        val[0] = self->numericValues->v[self->subsetNumber]->v[self->index];
+        //DebugAssert(self->subsetNumber < self->numericValues->n);
+        //DebugAssert(self->index < self->numericValues->v[self->subsetNumber]->n);
+        DebugAssert(self->subsetNumber < grib_vdarray_used_size (self->numericValues));
+        DebugAssert(self->index < grib_darray_used_size (grib_vdarray_get (self->numericValues, self->subsetNumber)));
+
+        //val[0] = self->numericValues->v[self->subsetNumber]->v[self->index];
+        val[0] = grib_darray_get ( grib_vdarray_get (self->numericValues, self->subsetNumber), self->index );
         *len   = 1;
     }
 
@@ -502,20 +547,23 @@ static int pack_double(grib_accessor* a, const double* val, size_t* len)
         count = *len;
         if (count != 1 && count != self->numberOfSubsets) {
             grib_context_log(c, GRIB_LOG_ERROR, "Number of values mismatch for '%s': %ld doubles provided but expected %ld (=number of subsets)",
-                             self->descriptors->v[self->elementsDescriptorsIndex->v[0]->v[self->index]]->shortName, count, self->numberOfSubsets);
+                             //self->descriptors->v[self->elementsDescriptorsIndex->v[0]->v[self->index]]->shortName, count, self->numberOfSubsets);
+            			self->descriptors->v[ grib_iarray_get ( grib_viarray_get (self->elementsDescriptorsIndex, 0), self->index) ]->shortName, count, self->numberOfSubsets);
             return GRIB_ARRAY_TOO_SMALL;
         }
-        grib_darray_delete(a->context, self->numericValues->v[self->index]);
-        self->numericValues->v[self->index] = grib_darray_new(a->context, count, 1);
+        grib_darray_delete(a->context, grib_vdarray_get (self->numericValues, self->index) );
+        //self->numericValues->v[self->index] = grib_darray_new(a->context, count, 1);
+        grib_vdarray_put (self->numericValues, self->index, grib_darray_new(a->context, count, 1));
 
         for (i = 0; i < count; i++)
-            grib_darray_push(a->context, self->numericValues->v[self->index], val[i]);
+            grib_darray_push(a->context, grib_vdarray_get (self->numericValues, self->index), val[i]);
 
         *len = count;
     }
     else {
-        self->numericValues->v[self->subsetNumber]->v[self->index] = val[0];
-        *len                                                       = 1;
+        //self->numericValues->v[self->subsetNumber]->v[self->index] = val[0];
+    	grib_darray_put(grib_vdarray_get (self->numericValues, self->subsetNumber), self->index, val[0]);
+        *len = 1;
     }
 
     return ret;
@@ -532,20 +580,24 @@ static int pack_long(grib_accessor* a, const long* val, size_t* len)
         count = *len;
         if (count != 1 && count != self->numberOfSubsets) {
             grib_context_log(c, GRIB_LOG_ERROR, "Number of values mismatch for '%s': %ld integers provided but expected %ld (=number of subsets)",
-                             self->descriptors->v[self->elementsDescriptorsIndex->v[0]->v[self->index]]->shortName, count, self->numberOfSubsets);
+                             //self->descriptors->v[self->elementsDescriptorsIndex->v[0]->v[self->index]]->shortName, count, self->numberOfSubsets);
+            			self->descriptors->v[ grib_iarray_get ( grib_viarray_get (self->elementsDescriptorsIndex, 0), self->index) ]->shortName, count, self->numberOfSubsets);
             return GRIB_ARRAY_TOO_SMALL;
         }
-        grib_darray_delete(a->context, self->numericValues->v[self->index]);
-        self->numericValues->v[self->index] = grib_darray_new(a->context, count, 1);
+        grib_darray_delete(a->context, grib_vdarray_get (self->numericValues, self->index));
+        //self->numericValues->v[self->index] = grib_darray_new(a->context, count, 1);
+        //self->numericValues->v[self->index] = grib_darray_new(a->context, count, count);
+        grib_vdarray_put (self->numericValues, self->index, grib_darray_new(a->context, count, count));
 
         for (i = 0; i < count; i++) {
-            grib_darray_push(a->context, self->numericValues->v[self->index], val[i] == GRIB_MISSING_LONG ? GRIB_MISSING_DOUBLE : val[i]);
+            grib_darray_push(a->context, grib_vdarray_get (self->numericValues, self->index), ( (val[i] == GRIB_MISSING_LONG) ? GRIB_MISSING_DOUBLE : val[i] ) );
         }
         *len = count;
     }
     else {
-        self->numericValues->v[self->subsetNumber]->v[self->index] = val[0] == GRIB_MISSING_LONG ? GRIB_MISSING_DOUBLE : val[0];
-        *len                                                       = 1;
+       // self->numericValues->v[self->subsetNumber]->v[self->index] = val[0] == GRIB_MISSING_LONG ? GRIB_MISSING_DOUBLE : val[0];
+    	grib_darray_put (grib_vdarray_get (self->numericValues, self->subsetNumber), self->index,  ( (val[0] == GRIB_MISSING_LONG ) ? GRIB_MISSING_DOUBLE : val[0] )  );
+        *len = 1;
     }
 
     return ret;
@@ -563,13 +615,15 @@ static int value_count(grib_accessor* a, long* count)
     type = get_native_type(a);
 
     if (type == GRIB_TYPE_STRING) {
-        DebugAssert(self->index < self->numericValues->n);
-        idx  = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
-        size = grib_sarray_used_size(self->stringValues->v[idx]);
+        DebugAssert(self->index < grib_vdarray_used_size (self->numericValues));
+        //idx  = ((int)self->numericValues->v[self->index]->v[0] / 1000 - 1) / self->numberOfSubsets;
+        idx  = ( (int)(grib_darray_get (grib_vdarray_get (self->numericValues, self->index), 0 )) / 1000 - 1) / self->numberOfSubsets;
+        //size = grib_sarray_used_size(self->stringValues->v[idx]);
+        size = grib_sarray_used_size( grib_vsarray_get(self->stringValues, idx) );
     }
     else {
-        DebugAssert(self->index < self->numericValues->n);
-        size = grib_darray_used_size(self->numericValues->v[self->index]);
+        DebugAssert(self->index < grib_vdarray_used_size (self->numericValues));
+        size = grib_darray_used_size(grib_vdarray_get (self->numericValues, self->index));
     }
 
     *count = size == 1 ? 1 : self->numberOfSubsets;
@@ -590,7 +644,8 @@ static int unpack_double_element(grib_accessor* a, size_t idx, double* val)
     }
 
     if (self->compressedData) {
-        *val = self->numericValues->v[self->index]->v[idx];
+        //*val = self->numericValues->v[self->index]->v[idx];
+        *val = grib_darray_get ( grib_vdarray_get (self->numericValues, self->index), idx);
     }
     else {
         ret = GRIB_NOT_IMPLEMENTED;

--- a/src/grib_accessor_class_bufr_extract_area_subsets.c
+++ b/src/grib_accessor_class_bufr_extract_area_subsets.c
@@ -324,6 +324,7 @@ static int select_area(grib_accessor* a)
     grib_context_free(c, lat);
     grib_context_free(c, lon);
     grib_iarray_delete(subsets);
+    /*grib_iarray_delete(subsets_ar);*//* CSGMB: deallocate array after the set ?*/
     subsets = 0;
 
     return ret;

--- a/src/grib_accessor_class_bufr_extract_datetime_subsets.c
+++ b/src/grib_accessor_class_bufr_extract_datetime_subsets.c
@@ -458,6 +458,7 @@ static int select_datetime(grib_accessor* a)
     grib_context_free(c, minute);
     grib_context_free(c, second);
     grib_iarray_delete(subsets);
+    grib_iarray_delete(subsets_ar);/* CSGMB: deallocate array after the set ?*/
     subsets = 0;
 
     return ret;

--- a/src/grib_accessor_class_bufr_string_values.c
+++ b/src/grib_accessor_class_bufr_string_values.c
@@ -188,14 +188,16 @@ static int unpack_string_array(grib_accessor* a, char** buffer, size_t* len)
 
     tl = 0;
     for (j = 0; j < n; j++) {
-        l = grib_sarray_used_size(stringValues->v[j]);
+        //l = grib_sarray_used_size(stringValues->v[j]);
+        l = grib_sarray_used_size(grib_vsarray_get (stringValues, j) );
         tl += l;
 
         if (tl > *len)
             return GRIB_ARRAY_TOO_SMALL;
 
         for (i = 0; i < l; i++) {
-            *(b++) = grib_context_strdup(c, stringValues->v[j]->v[i]);
+            //*(b++) = grib_context_strdup(c, stringValues->v[j]->v[i]);
+        	*(b++) = grib_context_strdup(c, grib_sarray_get (  grib_vsarray_get (stringValues, j), i)  );
         }
     }
     *len = tl;

--- a/src/grib_accessor_class_concept.c
+++ b/src/grib_accessor_class_concept.c
@@ -11,6 +11,7 @@
 
 /*******************************************************
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  ******************************************************/
 
 #include "grib_api_internal.h"
@@ -226,7 +227,7 @@ static int concept_condition_iarray_true(grib_handle* h, grib_concept_condition*
 
     ret = 1;
     for (i = 0; i < size; i++) {
-        if (val[i] != c->iarray->v[i]) {
+        if (val[i] != grib_iarray_get(c->iarray, i) ) {
             ret = 0;
             break;
         }
@@ -299,8 +300,10 @@ static int concept_conditions_expression_apply(grib_handle* h, grib_concept_cond
             values[count].double_value = dres;
             break;
         case GRIB_TYPE_STRING:
-            size                       = sizeof(sa->v[count]);
-            values[count].string_value = grib_expression_evaluate_string(h, e->expression, sa->v[count], &size, &err);
+            //size                       = sizeof(sa->v[count]);
+            size			 = sizeof(grib_sarray_get(sa,count));
+            //values[count].string_value = grib_expression_evaluate_string(h, e->expression, sa->v[count], &size, &err);
+            values[count].string_value = grib_expression_evaluate_string(h, e->expression, grib_sarray_get(sa,count), &size, &err);
             break;
         default:
             return GRIB_NOT_IMPLEMENTED;
@@ -313,7 +316,8 @@ static int concept_conditions_expression_apply(grib_handle* h, grib_concept_cond
 static int concept_conditions_iarray_apply(grib_handle* h, grib_concept_condition* c)
 {
     size_t size = grib_iarray_used_size(c->iarray);
-    return grib_set_long_array(h, c->name, c->iarray->v, size);
+    return grib_set_long_array(h, c->name, grib_iarray_get_arrays_by_reference(c->iarray), size );
+    /*return grib_set_long_array(h, c->name, c->iarray->dynA, size);*/
 }
 
 static int concept_conditions_apply(grib_handle* h, grib_concept_condition* c, grib_values* values, grib_sarray* sa, int* n)
@@ -399,7 +403,9 @@ static int grib_concept_apply(grib_accessor* a, const char* name)
         return err;
     }
     e  = c->conditions;
-    sa = grib_sarray_new(h->context, 10, 10);
+    //magic number 10 is not documented anywhere...
+    //sa = grib_sarray_new(h->context, 10, 10);
+    sa = grib_sarray_new(h->context, DYN_DEFAULT_SARRAY_SIZE_INIT, DYN_DEFAULT_SARRAY_SIZE_INCR);
     while (e) {
         concept_conditions_apply(h, e, values, sa, &count);
         e = e->next;

--- a/src/grib_accessor_class_hash_array.c
+++ b/src/grib_accessor_class_hash_array.c
@@ -251,7 +251,8 @@ static int unpack_long(grib_accessor* a, long* val, size_t* len)
             }
             *len = self->ha->iarray->n;
             for (i = 0; i < *len; i++)
-                val[i] = self->ha->iarray->v[i];
+                //val[i] = self->ha->iarray->v[i];
+            	val[i] = grib_iarray_get (self->ha->iarray, i );
             break;
 
         default:

--- a/src/grib_accessor_class_long_vector.c
+++ b/src/grib_accessor_class_long_vector.c
@@ -10,6 +10,7 @@
 
 /**************************************
  *  Enrico Fucile
+ *  Modified for Performance Study by: CS GMBH
  **************************************/
 
 

--- a/src/grib_accessor_class_transient_darray.c
+++ b/src/grib_accessor_class_transient_darray.c
@@ -196,7 +196,8 @@ static int unpack_double(grib_accessor* a, double* val, size_t* len)
 
     *len = count;
     for (i = 0; i < *len; i++)
-        val[i] = self->arr->v[i];
+        //val[i] = self->arr->v[i];
+    	val[i] = grib_darray_get ( self->arr, i );
 
 
     return GRIB_SUCCESS;
@@ -216,8 +217,8 @@ static int unpack_long(grib_accessor* a, long* val, size_t* len)
 
     *len = count;
     for (i = 0; i < *len; i++)
-        val[i] = (long)self->arr->v[i];
-
+        //val[i] = (long)self->arr->v[i];
+    	val[i] = ( (long) (grib_darray_get ( self->arr, i )) );
 
     return GRIB_SUCCESS;
 }

--- a/src/grib_api.h
+++ b/src/grib_api.h
@@ -6,6 +6,8 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ * Modified for Performance Study by: CS GMBH
  */
 
 /*! \file grib_api.h

--- a/src/grib_api_internal.h
+++ b/src/grib_api_internal.h
@@ -6,6 +6,8 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ *   Modified for Performance Study by: CS GMBH
  */
 
 /**
@@ -728,69 +730,89 @@ typedef struct grib_trie_with_rank_list grib_trie_with_rank_list;
 typedef struct grib_trie_with_rank grib_trie_with_rank;
 typedef struct grib_itrie grib_itrie;
 
+#define DYN_DEFAULT_SARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_SARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_sarray
 {
-    char** v;
+    char * stA[DYN_DEFAULT_SARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    char** dynA;
 };
+
+#define DYN_DEFAULT_OARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_OARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_oarray
 {
-    void** v;
+    void* stA[DYN_DEFAULT_OARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    void** dynA;
 };
+
+#define DYN_DEFAULT_DARRAY_SIZE_INIT 500 /* Initial size for the double dynamic array */
+#define DYN_DEFAULT_DARRAY_SIZE_INCR 600 /* Increment size for the double dynamic array */
 
 struct grib_darray
 {
-    double* v;
+    double stA[DYN_DEFAULT_DARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    double* dynA;
 };
+
+#define DYN_DEFAULT_IARRAY_SIZE_INIT 5000
+#define DYN_DEFAULT_IARRAY_SIZE_INCR 6000
 
 struct grib_iarray
 {
-    long* v;
+	long stA[DYN_DEFAULT_IARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    size_t number_of_pop_front;
     grib_context* context;
+    long* dynA;
 };
+
+#define DYN_DEFAULT_VDARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_VDARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_vdarray
 {
-    grib_darray** v;
+    grib_darray* stA[DYN_DEFAULT_VDARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    grib_darray** dynA;
 };
+
+#define DYN_DEFAULT_VSARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_VSARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_vsarray
 {
-    grib_sarray** v;
+    grib_sarray* stA[DYN_DEFAULT_VSARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    grib_sarray** dynA;
 };
+
+#define DYN_DEFAULT_VIARRAY_SIZE_INIT 500 /* Initial size for the dynamic array VIARRAY */
+#define DYN_DEFAULT_VIARRAY_SIZE_INCR 600 /* Increment size for the dynamic array VIARRAY */
 
 struct grib_viarray
 {
-    grib_iarray** v;
+	grib_iarray* stA[DYN_DEFAULT_VIARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    grib_iarray** dynA;
 };
 
 /* types of BUFR descriptors used in bufr_descriptor->type*/

--- a/src/grib_api_prototypes.h
+++ b/src/grib_api_prototypes.h
@@ -1,4 +1,14 @@
-
+/*
+ * (C) Copyright 2005- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+ * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ *   Modified for Performance Study by: CS GMBH
+ */
 /* action.c */
 void grib_dump(grib_action* a, FILE* f, int l);
 void grib_xref(grib_action* a, FILE* f, const char* path);
@@ -80,7 +90,7 @@ grib_action* grib_action_create_set(grib_context* context, const char* name, gri
 grib_action* grib_action_create_set_darray(grib_context* context, const char* name, grib_darray* darray);
 
 /* action_class_set_iarray.c */
-grib_action* grib_action_create_set_iarray(grib_context* context, const char* name, grib_iarray* iarray);
+grib_action* grib_action_create_set_iarray(grib_context* context, const char* name, grib_iarray* source);
 
 /* action_class_set_sarray.c */
 grib_action* grib_action_create_set_sarray(grib_context* context, const char* name, grib_sarray* sarray);
@@ -162,7 +172,7 @@ void grib_accessors_list_delete(grib_context* c, grib_accessors_list* al);
 /* grib_concept.c */
 grib_concept_value* grib_concept_value_new(grib_context* c, const char* name, grib_concept_condition* conditions);
 void grib_concept_value_delete(grib_context* c, grib_concept_value* v);
-grib_concept_condition* grib_concept_condition_new(grib_context* c, const char* name, grib_expression* expression, grib_iarray* iarray);
+grib_concept_condition* grib_concept_condition_new(grib_context* c, const char* name, grib_expression* expression, grib_iarray* source);
 void grib_concept_condition_delete(grib_context* c, grib_concept_condition* v);
 
 /* grib_hash_array.c */
@@ -202,6 +212,9 @@ grib_darray* grib_darray_new_from_array(grib_context* c, double* a, size_t size)
 grib_darray* grib_darray_new(grib_context* c, size_t size, size_t incsize);
 grib_darray* grib_darray_resize(grib_context* c, grib_darray* v);
 grib_darray* grib_darray_push(grib_context* c, grib_darray* v, double val);
+double grib_darray_get(grib_darray* source, size_t index);
+double* grib_darray_get_arrays_by_reference(grib_darray* source);
+int grib_darray_put (grib_darray* source, size_t index, double val);
 void grib_darray_delete(grib_context* c, grib_darray* v);
 double* grib_darray_get_array(grib_context* c, grib_darray* v);
 int grib_darray_is_constant(grib_darray* v, double eps);
@@ -211,6 +224,9 @@ size_t grib_darray_used_size(grib_darray* v);
 grib_sarray* grib_sarray_new(grib_context* c, size_t size, size_t incsize);
 grib_sarray* grib_sarray_resize(grib_context* c, grib_sarray* v);
 grib_sarray* grib_sarray_push(grib_context* c, grib_sarray* v, char* val);
+char* grib_sarray_get(grib_sarray* source, size_t index);
+char** grib_sarray_get_arrays_by_reference(grib_sarray* source);
+int grib_sarray_put (grib_sarray* source, size_t index, char* val);
 void grib_sarray_delete(grib_context* c, grib_sarray* v);
 void grib_sarray_delete_content(grib_context* c, grib_sarray* v);
 char** grib_sarray_get_array(grib_context* c, grib_sarray* v);
@@ -218,38 +234,31 @@ size_t grib_sarray_used_size(grib_sarray* v);
 
 /* grib_oarray.c */
 grib_oarray* grib_oarray_new(grib_context* c, size_t size, size_t incsize);
-grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* v);
-grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* v, void* val);
-void grib_oarray_delete(grib_context* c, grib_oarray* v);
-void grib_oarray_delete_content(grib_context* c, grib_oarray* v);
-void** grib_oarray_get_array(grib_context* c, grib_oarray* v);
-void* grib_oarray_get(grib_oarray* v, int i);
-size_t grib_oarray_used_size(grib_oarray* v);
+grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* origin);
+grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* source, void* val);
+void* grib_oarray_get(grib_oarray* source, size_t index);
+int grib_oarray_put (grib_oarray* source, size_t index, void* val);
+void grib_oarray_delete(grib_context* c, grib_oarray* source);
+void grib_oarray_delete_content(grib_context* c, grib_oarray* source);
+size_t grib_oarray_used_size(grib_oarray* source);
 
 /* grib_iarray.c */
-void grib_iarray_print(const char* title, const grib_iarray* iarray);
-grib_iarray* grib_iarray_new_from_array(grib_context* c, long* a, size_t size);
+void grib_iarray_print(const char* title, const grib_iarray* source);
 grib_iarray* grib_iarray_new(grib_context* c, size_t size, size_t incsize);
-long grib_iarray_pop(grib_iarray* a);
-long grib_iarray_pop_front(grib_iarray* a);
-grib_iarray* grib_iarray_resize_to(grib_iarray* v, size_t newsize);
-grib_iarray* grib_iarray_resize(grib_iarray* v);
-grib_iarray* grib_iarray_push(grib_iarray* v, long val);
-grib_iarray* grib_iarray_push_front(grib_iarray* v, long val);
-grib_iarray* grib_iarray_push_array(grib_iarray* v, long* val, size_t size);
-long grib_iarray_get(grib_iarray* a, size_t i);
-void grib_iarray_set(grib_iarray* a, size_t i, long v);
-void grib_iarray_delete(grib_iarray* v);
-void grib_iarray_delete_array(grib_iarray* v);
-long* grib_iarray_get_array(grib_iarray* v);
-size_t grib_iarray_used_size(grib_iarray* v);
-int grib_iarray_is_constant(grib_iarray* v);
+grib_iarray* grib_iarray_push(grib_iarray* source, long val);
+long grib_iarray_get(grib_iarray* source, size_t index);
+long* grib_iarray_get_arrays_by_reference(grib_iarray* source);
+void grib_iarray_delete(grib_iarray* source);
+long* grib_iarray_get_array(grib_iarray* source);
+size_t grib_iarray_used_size(grib_iarray* source);
 
 /* grib_vdarray.c */
 void grib_vdarray_print(const char* title, const grib_vdarray* vdarray);
 grib_vdarray* grib_vdarray_new(grib_context* c, size_t size, size_t incsize);
 grib_vdarray* grib_vdarray_resize(grib_context* c, grib_vdarray* v);
 grib_vdarray* grib_vdarray_push(grib_context* c, grib_vdarray* v, grib_darray* val);
+grib_darray* grib_vdarray_get(grib_vdarray* source, size_t index);
+int grib_vdarray_put (grib_vdarray* source, size_t index, grib_darray* val);
 void grib_vdarray_delete(grib_context* c, grib_vdarray* v);
 void grib_vdarray_delete_content(grib_context* c, grib_vdarray* v);
 grib_darray** grib_vdarray_get_array(grib_context* c, grib_vdarray* v);
@@ -259,15 +268,19 @@ size_t grib_vdarray_used_size(grib_vdarray* v);
 grib_vsarray* grib_vsarray_new(grib_context* c, size_t size, size_t incsize);
 grib_vsarray* grib_vsarray_resize(grib_context* c, grib_vsarray* v);
 grib_vsarray* grib_vsarray_push(grib_context* c, grib_vsarray* v, grib_sarray* val);
+grib_sarray* grib_vsarray_get(grib_vsarray* source, size_t index);
+int grib_vsarray_put (grib_vsarray* source, size_t index, grib_sarray* val);
 void grib_vsarray_delete(grib_context* c, grib_vsarray* v);
 void grib_vsarray_delete_content(grib_context* c, grib_vsarray* v);
 grib_sarray** grib_vsarray_get_array(grib_context* c, grib_vsarray* v);
 size_t grib_vsarray_used_size(grib_vsarray* v);
 
 /* grib_viarray.c */
+void grib_viarray_print(const char* title, const grib_viarray* source);
 grib_viarray* grib_viarray_new(grib_context* c, size_t size, size_t incsize);
 grib_viarray* grib_viarray_resize(grib_context* c, grib_viarray* v);
 grib_viarray* grib_viarray_push(grib_context* c, grib_viarray* v, grib_iarray* val);
+grib_iarray* grib_viarray_get(grib_viarray* source, size_t index);
 void grib_viarray_delete(grib_context* c, grib_viarray* v);
 void grib_viarray_delete_content(grib_context* c, grib_viarray* v);
 grib_iarray** grib_viarray_get_array(grib_context* c, grib_viarray* v);

--- a/src/grib_bufr_descriptors_array.c
+++ b/src/grib_bufr_descriptors_array.c
@@ -10,8 +10,10 @@
 
 #include "grib_api_internal.h"
 
-#define DYN_ARRAY_SIZE_INIT 200 /* Initial size for grib_bufr_descriptors_array_new */
-#define DYN_ARRAY_SIZE_INCR 400 /* Increment size for the above */
+//#define DYN_ARRAY_SIZE_INIT 200 /* Initial size for grib_bufr_descriptors_array_new */
+//#define DYN_ARRAY_SIZE_INCR 400 /* Increment size for the above */
+#define DYN_ARRAY_SIZE_INIT 1000 /* Initial size for grib_bufr_descriptors_array_new */
+#define DYN_ARRAY_SIZE_INCR 1200 /* Increment size for the above */
 
 bufr_descriptors_array* grib_bufr_descriptors_array_new(grib_context* c, size_t size, size_t incsize)
 {

--- a/src/grib_darray.c
+++ b/src/grib_darray.c
@@ -11,132 +11,280 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
 /* For debugging purposes */
-void grib_darray_print(const char* title, const grib_darray* darray)
+void grib_darray_print(const char* title, const grib_darray* source)
 {
     size_t i;
-    Assert(darray);
-    printf("%s: darray.n=%lu  \t", title, (unsigned long)darray->n);
-    for (i = 0; i < darray->n; i++) {
-        printf("darray[%lu]=%g\t", (unsigned long)i, darray->v[i]);
+    Assert(source);
+    printf("%s: darray.n=%lu  \t", title, (unsigned long)source->n);
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1)) {
+    		printf("darray[%lu]=%ld\t", (unsigned long)i, source->stA[i]);
+    	} else {
+    		printf("darray[%lu]=%ld\t", (unsigned long)i, source->dynA[(i-(DYN_DEFAULT_DARRAY_SIZE_INIT))]);
+    	}
     }
     printf("\n");
 }
 
-grib_darray* grib_darray_new_from_array(grib_context* c, double* a, size_t size)
-{
-    size_t i;
-    grib_darray* v;
-
-    if (!c)
-        c = grib_context_get_default();
-
-    v = grib_darray_new(c, size, 100);
-    for (i = 0; i < size; i++)
-        v->v[i] = a[i];
-    v->n       = size;
-    v->context = c;
-    return v;
-}
-
 grib_darray* grib_darray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_darray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_darray*)grib_context_malloc_clear(c, sizeof(grib_darray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_darray_new unable to allocate %d bytes\n", sizeof(grib_darray));
-        return NULL;
-    }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (double*)grib_context_malloc_clear(c, sizeof(double) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_darray_new unable to allocate %d bytes\n", sizeof(double) * size);
-        return NULL;
-    }
-    return v;
-}
-
-grib_darray* grib_darray_resize(grib_context* c, grib_darray* v)
-{
-    int newsize = v->incsize + v->size;
+    grib_darray* result = NULL;
 
     if (!c)
         c = grib_context_get_default();
 
-    v->v    = (double*)grib_context_realloc(c, v->v, newsize * sizeof(double));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_darray_resize unable to allocate %d bytes\n", sizeof(double) * newsize);
-        return NULL;
+    result = (grib_darray*)grib_context_malloc_clear(c, sizeof(grib_darray));
+    if (!result) {
+    	grib_context_log(c, GRIB_LOG_ERROR,
+    			"grib_darray_new unable to allocate %d bytes\n", sizeof(grib_darray));
+    	return NULL;
     }
-    return v;
+
+    if(size > DYN_DEFAULT_DARRAY_SIZE_INIT) {
+
+    	result->dynA       = (double*)grib_context_malloc_clear(c, sizeof(double) * (size-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_darray_new unable to allocate %d bytes\n", sizeof(double) * (size-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+    		return NULL;
+    	}
+
+    	result->size    = size;
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_DARRAY_SIZE_INCR;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_DARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_DARRAY_SIZE_INCR;
+
+    }
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_darray* grib_darray_push(grib_context* c, grib_darray* v, double val)
+grib_darray* grib_darray_resize(grib_context* c, grib_darray* origin)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_darray_new(c, start_size, start_incsize);
+	int newsize;
 
-    if (v->n >= v->size)
-        v = grib_darray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	if (origin == NULL)
+	{
+		return origin;
+	}
+
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA != NULL){
+
+		origin->dynA    = (double*)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) * sizeof(double));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_darray_resize unable to allocate %d bytes\n", sizeof(double) * (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (double*)grib_context_malloc(c, (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) * sizeof(double));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_darray_resize unable to allocate %d bytes\n", sizeof(double) * (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-void grib_darray_delete(grib_context* c, grib_darray* v)
+grib_darray* grib_darray_push(grib_context* c, grib_darray* source, double val)
 {
-    if (!v)
+
+    size_t start_size    = DYN_DEFAULT_DARRAY_SIZE_INIT;
+    size_t start_incsize = DYN_DEFAULT_DARRAY_SIZE_INCR;
+
+    //If the target is empty, initialize it
+    if (!source)
+        source = grib_darray_new(c, start_size, start_incsize);
+
+    //If the actual used size of the target is equal to the allowed size, resize the array
+    if (source->n == source->size) {
+
+    	source = grib_darray_resize(c, source);
+
+    	//Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!
+    	if (source == NULL)
+    	{
+    		return source;
+    	}
+
+    	//insertion in new allocated dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_DARRAY_SIZE_INIT)) ] = val;
+    	source->n++;
+    	return source;
+
+    }
+
+    //insertion in static array
+    if (source->n <= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1) )
+    {
+    	source->stA[source->n] = val;
+    }
+    else {
+    	//insertion in dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_DARRAY_SIZE_INIT)) ] = val;
+    }
+
+    source->n++;
+    return source;
+}
+
+/**
+ * Return the double value at index 'index' for grib_darray 'source'
+ */
+double grib_darray_get(grib_darray* source, size_t index)
+{
+
+	if (!source)
+	    return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_DARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA[(index-DYN_DEFAULT_DARRAY_SIZE_INIT)];
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * The method returns the array currently in use. If the given grib_darray structure pointer is null, it returns NULL.
+ */
+double* grib_darray_get_arrays_by_reference(grib_darray* source)
+{
+	if(!source)
+			return NULL;
+
+	return source->stA;
+
+	/*
+	 * PREVIOUS ATTEMPT
+	if (source->n < DYN_DEFAULT_DARRAY_SIZE_INIT) {
+		return source->stA;// stA is the static array
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA; // dynA is the dynamic array
+		}
+	}
+	return NULL;
+	*/
+
+}
+
+/**
+ * Sets the double value 'val' at index 'index' for grib_darray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_darray_put (grib_darray* source, size_t index, double val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_DARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA != NULL) {
+			source->dynA[(index-DYN_DEFAULT_DARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_darray_delete(grib_context* c, grib_darray* source)
+{
+    if (!source)
         return;
     if (!c)
         grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+
+    if (source->dynA)
+        grib_context_free(c, source->dynA);
+
+    grib_context_free(c, source);
 }
 
-double* grib_darray_get_array(grib_context* c, grib_darray* v)
+/**
+ * The method returns an array of double of size source->n containing all the values contained in the 'source' grib_darray, starting to copy from the static array 'sv' and then copying the dynamic array 'v'.
+ * Data in the result:
+ * 1. From index 0 until index (DYN_DEFAULT_DARRAY_SIZE_INIT -1), data located at the same index in source->sv;
+ * 2. From index DYN_DEFAULT_DARRAY_SIZE_INIT until ( source->n ), data located at index (index - DYN_DEFAULT_DARRAY_SIZE_INIT) in source->v;
+ */
+double* grib_darray_get_array(grib_context* c, grib_darray* source)
 {
-    double* ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (double*)grib_context_malloc_clear(c, sizeof(double) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+	double* result;
+    size_t i;
+
+    result = (double*)grib_context_malloc_clear(c, sizeof(double) * source->n);
+
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1)) {
+    		result[i] = source->stA[i];
+    	} else {
+    		result[i] = source->dynA[(i-(DYN_DEFAULT_DARRAY_SIZE_INIT))];
+    	}
+    }
+
+    return result;
 }
 
-int grib_darray_is_constant(grib_darray* v, double eps)
+int grib_darray_is_constant(grib_darray* source, double eps)
 {
     int i;
     double val;
-    if (v->n == 1)
+    if (source->n == 1)
         return 1;
 
-    val = v->v[0];
-    for (i = 1; i < v->n; i++) {
-        if (fabs(val - v->v[i]) > eps)
-            return 0;
+    val = source->stA[0];
+
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1)) {
+    		if (fabs(val - source->stA[i]) > eps)
+    			return 0;
+    	} else {
+    		if (fabs(val - source->dynA[(i-(DYN_DEFAULT_DARRAY_SIZE_INIT))]) > eps)
+    		    return 0;
+    	}
     }
+
     return 1;
 }
 
-size_t grib_darray_used_size(grib_darray* v)
+size_t grib_darray_used_size(grib_darray* source)
 {
-    return v->n;
+	return source == NULL ? 0 : source->n;
 }

--- a/src/grib_oarray.c
+++ b/src/grib_oarray.c
@@ -11,111 +11,221 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+
 grib_oarray* grib_oarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_oarray* v = NULL;
+    grib_oarray* result = NULL;
+
     if (!c)
         c = grib_context_get_default();
-    v = (grib_oarray*)grib_context_malloc_clear(c, sizeof(grib_oarray));
-    if (!v) {
+
+    result = (grib_oarray*)grib_context_malloc_clear(c, sizeof(grib_oarray));
+    if (!result) {
         grib_context_log(c, GRIB_LOG_ERROR,
                          "grib_oarray_new unable to allocate %d bytes\n", sizeof(grib_oarray));
         return NULL;
     }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (void**)grib_context_malloc_clear(c, sizeof(char*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_oarray_new unable to allocate %d bytes\n", sizeof(char*) * size);
-        return NULL;
+
+    if(size > DYN_DEFAULT_OARRAY_SIZE_INIT) {
+
+    	result->dynA       = (void**)grib_context_malloc_clear(c, sizeof(char *) * (size-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_oarray_new unable to allocate %d bytes\n", sizeof(char *) * (size-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+    		return NULL;
+    	}
+
+    	result->size    = size;
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_OARRAY_SIZE_INIT;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_OARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_OARRAY_SIZE_INCR;
+
     }
-    return v;
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* v)
+grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (origin == NULL)
+	{
+		return origin;
+	}
 
-    v->v    = (void**)grib_context_realloc(c, v->v, newsize * sizeof(char*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_oarray_resize unable to allocate %d bytes\n", sizeof(char*) * newsize);
-        return NULL;
-    }
-    return v;
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA != NULL){
+
+		origin->dynA    = (void**)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_OARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_oarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (void**)grib_context_malloc(c, (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_oarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* v, void* val)
+grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* source, void* val)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_oarray_new(c, start_size, start_incsize);
+	size_t start_size    = DYN_DEFAULT_OARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_OARRAY_SIZE_INCR;
 
-    if (v->n >= v->size)
-        v = grib_oarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	//If the target is empty, initialize it
+	if (!source)
+		source = grib_oarray_new(c, start_size, start_incsize);
+
+	//If the actual used size of the target is equal to the allowed size, resize the array
+	if (source->n == source->size) {
+
+		source = grib_oarray_resize(c, source);
+
+		//Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!
+		if (source == NULL)
+		{
+			return source;
+		}
+
+		//insertion in new allocated dynamic array
+		source->dynA[ (source->n-(DYN_DEFAULT_OARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
+
+	}
+
+	//insertion in static array
+	if (source->n <= (DYN_DEFAULT_OARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		//insertion in dynamic array
+		source->dynA[ (source->n-(DYN_DEFAULT_OARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+	return source;
 }
 
-void grib_oarray_delete(grib_context* c, grib_oarray* v)
+/**
+ * Return the void* value at index 'index' for grib_oarray 'source'
+ */
+void* grib_oarray_get(grib_oarray* source, size_t index)
 {
-    if (!v)
+	if (!source)
+		return;
+
+	if (index < 0)
+		return;
+
+	if (index < DYN_DEFAULT_OARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA[(index-DYN_DEFAULT_OARRAY_SIZE_INIT)];
+		}
+	}
+
+	return;
+}
+
+/**
+ * Sets the void* value 'val' at index 'index' for grib_oarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_oarray_put (grib_oarray* source, size_t index, void* val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_OARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA != NULL) {
+			source->dynA[(index-DYN_DEFAULT_OARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_oarray_delete(grib_context* c, grib_oarray* source)
+{
+    if (!source)
         return;
+
     if (!c)
         grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+
+    if (source->dynA)
+        grib_context_free(c, source->dynA);
+
+    grib_context_free(c, source);
 }
 
-void grib_oarray_delete_content(grib_context* c, grib_oarray* v)
+void grib_oarray_delete_content(grib_context* c, grib_oarray* source)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        if (v->v[i])
-            grib_context_free(c, v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+	int i;
+
+	if (!source)
+		return;
+
+	if (!c)
+		grib_context_get_default();
+
+	//If the actual used size of the target is greater than the allowed size, it is a resized array
+	if (source->n > source->size && ( source->dynA != NULL ) ) {
+		for (i = 0; i < (source->n - DYN_DEFAULT_OARRAY_SIZE_INIT); i++) {
+			grib_sarray_delete(c,source->dynA[i]);
+			source->dynA[i] = 0;
+		}
+	}
+
+	for (i = 0; i < (DYN_DEFAULT_OARRAY_SIZE_INIT); i++) {
+		source->stA[i] = 0;
+	}
+
+	source->n = 0;
 }
 
-void** grib_oarray_get_array(grib_context* c, grib_oarray* v)
+size_t grib_oarray_used_size(grib_oarray* source)
 {
-    void** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (void**)grib_context_malloc_clear(c, sizeof(char*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
-}
-
-void* grib_oarray_get(grib_oarray* v, int i)
-{
-    if (v == NULL || i > v->n - 1)
-        return NULL;
-    return v->v[i];
-}
-
-size_t grib_oarray_used_size(grib_oarray* v)
-{
-    return v->n;
+	return source == NULL ? 0 : source->n;
 }

--- a/src/grib_sarray.c
+++ b/src/grib_sarray.c
@@ -11,6 +11,7 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
@@ -18,97 +19,261 @@
 
 grib_sarray* grib_sarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_sarray* v = NULL;
+    grib_sarray* result = NULL;
+
     if (!c)
         c = grib_context_get_default();
-    v = (grib_sarray*)grib_context_malloc_clear(c, sizeof(grib_sarray));
-    if (!v) {
+
+    result = (grib_sarray*)grib_context_malloc_clear(c, sizeof(grib_sarray));
+    if (!result) {
         grib_context_log(c, GRIB_LOG_ERROR,
                          "grib_sarray_new unable to allocate %d bytes\n", sizeof(grib_sarray));
         return NULL;
     }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (char**)grib_context_malloc_clear(c, sizeof(char*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_sarray_new unable to allocate %d bytes\n", sizeof(char*) * size);
-        return NULL;
+
+    if(size > DYN_DEFAULT_SARRAY_SIZE_INIT) {
+
+    	result->dynA       = (char**)grib_context_malloc_clear(c, sizeof(char *) * (size-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_sarray_new unable to allocate %d bytes\n", sizeof(char *) * (size-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+    		return NULL;
+    	}
+
+    	result->size    = size;
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_SARRAY_SIZE_INCR;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_SARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_SARRAY_SIZE_INCR;
+
     }
-    return v;
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_sarray* grib_sarray_resize(grib_context* c, grib_sarray* v)
+grib_sarray* grib_sarray_resize(grib_context* c, grib_sarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (origin == NULL)
+	{
+		return origin;
+	}
 
-    v->v    = (char**)grib_context_realloc(c, v->v, newsize * sizeof(char*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_sarray_resize unable to allocate %d bytes\n", sizeof(char*) * newsize);
-        return NULL;
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA != NULL){
+
+		origin->dynA    = (char**)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_sarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (char**)grib_context_malloc(c, (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_sarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
+}
+
+grib_sarray* grib_sarray_push(grib_context* c, grib_sarray* source, char* val)
+{
+    size_t start_size    = DYN_DEFAULT_SARRAY_SIZE_INIT;
+    size_t start_incsize = DYN_DEFAULT_SARRAY_SIZE_INCR;
+
+    //If the target is empty, initialize it
+    if (!source)
+    	source = grib_sarray_new(c, start_size, start_incsize);
+
+    //If the actual used size of the target is equal to the allowed size, resize the array
+    if (source->n == source->size) {
+
+    	source = grib_sarray_resize(c, source);
+
+    	//Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!
+    	if (source == NULL)
+    	{
+    		return source;
+    	}
+
+    	//insertion in new allocated dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_SARRAY_SIZE_INIT)) ] = val;
+    	source->n++;
+    	return source;
+
     }
-    return v;
+
+    //insertion in static array
+    if (source->n <= (DYN_DEFAULT_SARRAY_SIZE_INIT - 1) )
+    {
+    	source->stA[source->n] = val;
+    }
+    else {
+    	//insertion in dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_SARRAY_SIZE_INIT)) ] = val;
+    }
+
+    source->n++;
+    return source;
 }
 
-grib_sarray* grib_sarray_push(grib_context* c, grib_sarray* v, char* val)
+/**
+ * Return the char* value at index 'index' for grib_sarray 'source'
+ */
+char* grib_sarray_get(grib_sarray* source, size_t index)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_sarray_new(c, start_size, start_incsize);
 
-    if (v->n >= v->size)
-        v = grib_sarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	if (!source)
+	    return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_SARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA[(index-DYN_DEFAULT_SARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
 }
 
-void grib_sarray_delete(grib_context* c, grib_sarray* v)
+/**
+ * The method returns the array currently in use. If the given grib_sarray structure pointer is null, it returns NULL.
+ */
+char** grib_sarray_get_arrays_by_reference(grib_sarray* source)
 {
-    if (!v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+	if(!source)
+		return NULL;
+
+	return source->stA;
+
+	/* PREVIOUS ATTEMPT
+	if (source->n < DYN_DEFAULT_SARRAY_SIZE_INIT) {
+		return source->stA;//sv is the static array
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA;//v is the dynamic array
+		}
+	}
+
+	return NULL;
+	*/
 }
 
-void grib_sarray_delete_content(grib_context* c, grib_sarray* v)
+/**
+ * Sets the char* value 'val' at index 'index' for grib_sarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_sarray_put (grib_sarray* source, size_t index, char* val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_SARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA != NULL) {
+			source->dynA[(index-DYN_DEFAULT_SARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_sarray_delete(grib_context* c, grib_sarray* source)
+{
+	if (!source)
+		return;
+	if (!c)
+		grib_context_get_default();
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
+	grib_context_free(c, source);
+}
+
+void grib_sarray_delete_content(grib_context* c, grib_sarray* source)
 {
     int i;
-    if (!v || !v->v)
-        return;
+
+    if (!source)
+    	return;
+
+    /* This is not needed: the grib_sarray_delete is already always called after the function grib_sarray_delete_content
     if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        if (v->v[i])
-            grib_context_free(c, v->v[i]);
-        v->v[i] = 0;
+    	grib_context_get_default();
+    */
+
+    //If the actual used size of the target is greater than the allowed size, it is a resized array
+    if (source->n > source->size && ( source->dynA != NULL ) ) {
+    	for (i = 0; i < (source->n - DYN_DEFAULT_SARRAY_SIZE_INIT); i++) {
+    		/* This is not needed: the grib_sarray_delete is already always called after the function grib_sarray_delete_content
+    		 * grib_sarray_delete(c,source->dynA[i]);
+    		 */
+    		source->dynA[i] = 0;
+    	}
     }
-    v->n = 0;
+
+    for (i = 0; i < (DYN_DEFAULT_SARRAY_SIZE_INIT); i++) {
+    	source->stA[i] = 0;
+    }
+
+    source->n = 0;
 }
 
-char** grib_sarray_get_array(grib_context* c, grib_sarray* v)
+/**
+ * The method returns an array of char* of size source->n containing all the values contained in the 'source' grib_sarray, starting to copy from the static array 'sv' and then copying the dynamic array 'v'.
+ * Data in the result:
+ * 1. From index 0 until index (DYN_DEFAULT_SARRAY_SIZE_INIT -1), data located at the same index in source->sv;
+ * 2. From index DYN_DEFAULT_SARRAY_SIZE_INIT until ( source->n ), data located at index (index - DYN_DEFAULT_SARRAY_SIZE_INIT) in source->v;
+ */
+char** grib_sarray_get_array(grib_context* c, grib_sarray* source)
 {
-    char** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (char**)grib_context_malloc_clear(c, sizeof(char*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+    char** result;
+    size_t i;
+
+    result = (char**)grib_context_malloc_clear(c, sizeof(char*) * source->n);
+
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_SARRAY_SIZE_INIT - 1)) {
+    		result[i] = source->stA[i];
+    	} else {
+    		result[i] = source->dynA[(i-(DYN_DEFAULT_SARRAY_SIZE_INIT))];
+    	}
+    }
+
+    return result;
 }
 
-size_t grib_sarray_used_size(grib_sarray* v)
+size_t grib_sarray_used_size(grib_sarray* source)
 {
-    return v->n;
+	return source == NULL ? 0 : source->n;
 }

--- a/src/grib_trie_with_rank.c
+++ b/src/grib_trie_with_rank.c
@@ -483,7 +483,8 @@ int grib_trie_with_rank_insert(grib_trie_with_rank* t, const char* key, void* da
         }
     }
     if (t->objs == NULL)
-        t->objs = grib_oarray_new(t->context, 100, 1000);
+        t->objs = grib_oarray_new(t->context, DYN_DEFAULT_OARRAY_SIZE_INIT, DYN_DEFAULT_OARRAY_SIZE_INCR);
+    	//t->objs = grib_oarray_new(t->context, 100, 1000);
     grib_oarray_push(t->context, t->objs, data);
     /* grib_trie_with_rank_insert_in_list(t,data); */
     GRIB_MUTEX_UNLOCK(&mutex);

--- a/src/grib_value.c
+++ b/src/grib_value.c
@@ -799,18 +799,18 @@ int grib_set_double_array(grib_handle* h, const char* name, const double* val, s
     return __grib_set_double_array(h, name, val, length, /*check=*/1);
 }
 
-static int _grib_set_long_array_internal(grib_handle* h, grib_accessor* a, const long* val, size_t buffer_len, size_t* encoded_length, int check)
+static int _grib_set_long_array_internal(grib_handle* h, grib_accessor* a, const long* iarrayval, size_t iarraysize, size_t* encoded_length, int check)
 {
     if (a) {
-        int err = _grib_set_long_array_internal(h, a->same, val, buffer_len, encoded_length, check);
+        int err = _grib_set_long_array_internal(h, a->same, iarrayval, iarraysize, encoded_length, check);
 
         if (check && (a->flags & GRIB_ACCESSOR_FLAG_READ_ONLY))
             return GRIB_READ_ONLY;
 
         if (err == GRIB_SUCCESS) {
-            size_t len = buffer_len - *encoded_length;
+            size_t len = iarraysize - *encoded_length;
             if (len) {
-                err = grib_pack_long(a, val + *encoded_length, &len);
+                err = grib_pack_long(a, iarrayval + *encoded_length, &len);
                 *encoded_length += len;
             }
             else {
@@ -826,7 +826,7 @@ static int _grib_set_long_array_internal(grib_handle* h, grib_accessor* a, const
     }
 }
 
-static int _grib_set_long_array(grib_handle* h, const char* name, const long* val, size_t length, int check)
+static int _grib_set_long_array(grib_handle* h, const char* name, const long* iarrayval, size_t iarraysize, int check)
 {
     size_t encoded   = 0;
     grib_accessor* a = grib_find_accessor(h, name);
@@ -838,12 +838,12 @@ static int _grib_set_long_array(grib_handle* h, const char* name, const long* va
     if (h->context->debug) {
         size_t i = 0;
         size_t N = 5;
-        if (length <= N)
-            N = length;
-        fprintf(stderr, "ECCODES DEBUG _grib_set_long_array key=%s %ld values (", name, (long)length);
+        if (iarraysize <= N)
+            N = iarraysize;
+        fprintf(stderr, "ECCODES DEBUG _grib_set_long_array key=%s %ld values (", name, (long)iarraysize);
         for (i = 0; i < N; ++i)
-            fprintf(stderr, " %ld,", val[i]);
-        if (N >= length)
+            fprintf(stderr, " %ld,", iarrayval[i]);
+        if (N >= iarraysize)
             fprintf(stderr, " )\n");
         else
             fprintf(stderr, " ... )\n");
@@ -852,13 +852,13 @@ static int _grib_set_long_array(grib_handle* h, const char* name, const long* va
     if (name[0] == '/' || name[0] == '#') {
         if (check && (a->flags & GRIB_ACCESSOR_FLAG_READ_ONLY))
             return GRIB_READ_ONLY;
-        err     = grib_pack_long(a, val, &length);
-        encoded = length;
+        err     = grib_pack_long(a, iarrayval, &iarraysize);
+        encoded = iarraysize;
     }
     else
-        err = _grib_set_long_array_internal(h, a, val, length, &encoded, check);
+        err = _grib_set_long_array_internal(h, a, iarrayval, iarraysize, &encoded, check);
 
-    if (err == GRIB_SUCCESS && length > encoded)
+    if (err == GRIB_SUCCESS && iarraysize > encoded)
         err = GRIB_ARRAY_TOO_SMALL;
 
     if (err == GRIB_SUCCESS)
@@ -876,9 +876,9 @@ int grib_set_long_array_internal(grib_handle* h, const char* name, const long* v
     return ret;
 }
 
-int grib_set_long_array(grib_handle* h, const char* name, const long* val, size_t length)
+int grib_set_long_array(grib_handle* h, const char* name, const long* iarrayval, size_t iarraysize)
 {
-    return _grib_set_long_array(h, name, val, length, 1);
+    return _grib_set_long_array(h, name, iarrayval, iarraysize, 1);
 }
 
 int grib_get_long_internal(grib_handle* h, const char* name, long* val)

--- a/src/grib_vdarray.c
+++ b/src/grib_vdarray.c
@@ -11,117 +11,239 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
 /* For debugging purposes */
-void grib_vdarray_print(const char* title, const grib_vdarray* vdarray)
+void grib_vdarray_print(const char* title, const grib_vdarray* source)
 {
     size_t i;
     char text[100] = {0,};
-    Assert(vdarray);
-    printf("%s: vdarray.n=%lu\n", title, (unsigned long)vdarray->n);
-    for (i = 0; i < vdarray->n; i++) {
+    Assert(source);
+    printf("%s: vdarray.n=%lu\n", title, (unsigned long)source->n);
+    for (i = 0; i < source->n; i++) {
         sprintf(text, " vdarray->v[%lu]", (unsigned long)i);
-        grib_darray_print(text, vdarray->v[i]);
+        //grib_darray_print(text, source->v[i]);
+        if( i<= (DYN_DEFAULT_VDARRAY_SIZE_INIT - 1)) {
+        	grib_darray_print(text, source->stA[i]);
+        } else {
+        	grib_darray_print(text, source->dynA[(i-(DYN_DEFAULT_VDARRAY_SIZE_INIT))]);
+        }
     }
     printf("\n");
 }
 
 grib_vdarray* grib_vdarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_vdarray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_vdarray*)grib_context_malloc_clear(c, sizeof(grib_vdarray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_vdarray));
-        return NULL;
-    }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (grib_darray**)grib_context_malloc_clear(c, sizeof(grib_darray*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_darray*) * size);
-        return NULL;
-    }
-    return v;
+	grib_vdarray* result = NULL;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	result = (grib_vdarray*)grib_context_malloc_clear(c, sizeof(grib_vdarray));
+	if (!result) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_vdarray));
+		return NULL;
+	}
+
+	if(size > DYN_DEFAULT_VDARRAY_SIZE_INIT) {
+
+		result->dynA       = (grib_darray**)grib_context_malloc_clear(c, sizeof(grib_darray*) *  (size-DYN_DEFAULT_VDARRAY_SIZE_INIT)  );
+
+		if (!result->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_darray*) * (size-DYN_DEFAULT_VDARRAY_SIZE_INIT)  );
+			return NULL;
+		}
+		result->size    = size;
+
+		if (incsize > 0)
+			result->incsize             = incsize;
+		else
+			result->incsize             = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+
+	} else {
+
+		result->dynA					= NULL;
+		result->size                = DYN_DEFAULT_VDARRAY_SIZE_INIT;
+		result->incsize             = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+
+	}
+
+	result->n       = 0;
+
+	return result;
 }
 
-grib_vdarray* grib_vdarray_resize(grib_context* c, grib_vdarray* v)
+grib_vdarray* grib_vdarray_resize(grib_context* c, grib_vdarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (origin == NULL)
+	{
+		return origin;
+	}
+	if (!c)
+		c = grib_context_get_default();
 
-    v->v    = (grib_darray**)grib_context_realloc(c, v->v, newsize * sizeof(grib_darray*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vdarray_resize unable to allocate %d bytes\n", sizeof(grib_darray*) * newsize);
-        return NULL;
-    }
-    return v;
+	newsize = origin->incsize + origin->size;
+
+	if (origin->dynA != NULL){
+
+		origin->dynA    = (grib_darray**)grib_context_realloc(c, origin->dynA,  sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vdarray_resize unable to allocate %d bytes\n", sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA      = (grib_darray**)grib_context_malloc(c, sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vdarray_resize unable to allocate %d bytes\n", sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT ) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+    return origin;
 }
 
-grib_vdarray* grib_vdarray_push(grib_context* c, grib_vdarray* v, grib_darray* val)
+grib_vdarray* grib_vdarray_push(grib_context* c, grib_vdarray* source, grib_darray* val)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_vdarray_new(c, start_size, start_incsize);
 
-    if (v->n >= v->size)
-        v = grib_vdarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	size_t start_size    = DYN_DEFAULT_VDARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+
+	if (!source)
+		source = grib_vdarray_new(c, start_size, start_incsize);
+
+	//If the actual used size of the target is equal to the allowed size, resize the array
+	if (source->n == source->size) {
+
+		source = grib_vdarray_resize(c, source);
+
+		//Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!
+		if (source == NULL)
+		{
+			return source;
+		}
+
+		//insertion in new allocated dynamic array
+		source->dynA[ (source->n-(DYN_DEFAULT_VDARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
+
+	}
+
+	//insertion in static array
+	if (source->n <= (DYN_DEFAULT_VDARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		//insertion in dynamic array
+		source->dynA[ (source->n-(DYN_DEFAULT_VDARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+	return source;
 }
 
-void grib_vdarray_delete(grib_context* c, grib_vdarray* v)
+/**
+ * Return the grib_darray* value at index 'index' for grib_vdarray 'source'
+ */
+grib_darray* grib_vdarray_get(grib_vdarray* source, size_t index)
 {
-    if (!v)
+	if (!source)
+	    return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_VDARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA[(index-DYN_DEFAULT_VDARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * Sets the grib_darray* value 'val' at index 'index' for grib_vdarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_vdarray_put (grib_vdarray* source, size_t index, grib_darray* val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_VDARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA != NULL) {
+			source->dynA[(index-DYN_DEFAULT_VDARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_vdarray_delete(grib_context* c, grib_vdarray* source)
+{
+    if (!source)
         return;
     if (!c)
         grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+    if (source->dynA)
+        grib_context_free(c, source->dynA);
+    grib_context_free(c, source);
 }
 
-void grib_vdarray_delete_content(grib_context* c, grib_vdarray* v)
+void grib_vdarray_delete_content(grib_context* c, grib_vdarray* source)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        grib_darray_delete(c, v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+	int i;
+
+	if (!source)
+		return;
+	/*	Not needed: the 	grib_vdarray_delete is always called already, after 	grib_vdarray_delete_content
+	if (!c)
+		grib_context_get_default();
+	*/
+
+	//If the actual used size of the target is greater than the allowed size, it is a resized array
+	if ( (source->n > source->size) && ( source->dynA != NULL ) ) {
+		for (i = 0; i < (source->n - DYN_DEFAULT_VDARRAY_SIZE_INIT); i++) {
+			/*	Not needed: the 	grib_vdarray_delete is always called already, after 	grib_vdarray_delete_content
+			 * grib_vdarray_delete(c, source->dynA[i]);
+			*/
+			source->dynA[i] = 0;
+		}
+	}
+
+	for (i = 0; i < (DYN_DEFAULT_VDARRAY_SIZE_INIT); i++) {
+		source->stA[i] = 0;
+	}
+
+	source->n = 0;
 }
 
-grib_darray** grib_vdarray_get_array(grib_context* c, grib_vdarray* v)
+size_t grib_vdarray_used_size(grib_vdarray* source)
 {
-    grib_darray** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (grib_darray**)grib_context_malloc_clear(c, sizeof(grib_darray*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
-}
-
-size_t grib_vdarray_used_size(grib_vdarray* v)
-{
-    return v->n;
+	return source == NULL ? 0 : source->n;
 }

--- a/src/grib_viarray.c
+++ b/src/grib_viarray.c
@@ -11,103 +11,209 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+/* For debugging purposes */
+void grib_viarray_print(const char* title, const grib_viarray* source)
+{
+	size_t i;
+	char text[100] = {0,};
+	Assert(source);
+	printf("%s: viarray.n=%lu\n", title, (unsigned long)source->n);
+	for (i = 0; i < source->n; i++) {
+		sprintf(text, " viarray->v[%lu]", (unsigned long)i);
+		if( i<= (DYN_DEFAULT_VIARRAY_SIZE_INIT - 1)) {
+			grib_iarray_print(text, source->stA[i]);
+		} else {
+			grib_iarray_print(text, source->dynA[(i-(DYN_DEFAULT_VIARRAY_SIZE_INIT))]);
+		}
+	}
+	printf("\n");
+}
+
 grib_viarray* grib_viarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_viarray* v = NULL;
+    grib_viarray* result = NULL;
+
     if (!c)
         c = grib_context_get_default();
-    v = (grib_viarray*)grib_context_malloc_clear(c, sizeof(grib_viarray));
-    if (!v) {
+
+    result = (grib_viarray*)grib_context_malloc_clear(c, sizeof(grib_viarray));
+    if (!result) {
         grib_context_log(c, GRIB_LOG_ERROR,
                          "grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_viarray));
         return NULL;
     }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (grib_iarray**)grib_context_malloc_clear(c, sizeof(grib_iarray*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_iarray*) * size);
-        return NULL;
+
+    if(size > DYN_DEFAULT_VIARRAY_SIZE_INIT) {
+
+    	result->dynA       = (grib_iarray**)grib_context_malloc_clear(c, sizeof(grib_iarray*) *  (size-DYN_DEFAULT_VIARRAY_SIZE_INIT)  );
+
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_iarray*) * (size-DYN_DEFAULT_VIARRAY_SIZE_INIT)  );
+    		return NULL;
+    	}
+    	result->size    = size;
+
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_VIARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+
     }
-    return v;
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_viarray* grib_viarray_resize(grib_context* c, grib_viarray* v)
+grib_viarray* grib_viarray_resize(grib_context* c, grib_viarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (origin == NULL)
+	{
+		return origin;
+	}
+	if (!c)
+		c = grib_context_get_default();
 
-    v->v    = (grib_iarray**)grib_context_realloc(c, v->v, newsize * sizeof(grib_iarray*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_viarray_resize unable to allocate %d bytes\n", sizeof(grib_iarray*) * newsize);
-        return NULL;
+	newsize = origin->incsize + origin->size;
+
+	if (origin->dynA != NULL){
+
+		origin->dynA    = (grib_iarray**)grib_context_realloc(c, origin->dynA,  sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_viarray_resize unable to allocate %d bytes\n", sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA      = (grib_iarray**)grib_context_malloc(c, sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_viarray_resize unable to allocate %d bytes\n", sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT ) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
+}
+
+grib_viarray* grib_viarray_push(grib_context* c, grib_viarray* source, grib_iarray* val)
+{
+    size_t start_size    = DYN_DEFAULT_VIARRAY_SIZE_INIT;
+    size_t start_incsize = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+
+    //If the target is empty, initialize it
+    if (!source)
+        source = grib_viarray_new(c, start_size, start_incsize);
+
+    //If the actual used size of the target is equal to the allowed size, resize the array
+    if (source->n == source->size) {
+
+    	source = grib_viarray_resize(c, source);
+
+    	//Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!
+    	if (source == NULL)
+    	{
+    		return source;
+    	}
+
+    	//insertion in new allocated dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_VIARRAY_SIZE_INIT)) ] = val;
+    	source->n++;
+    	return source;
+
     }
-    return v;
+
+    //insertion in static array
+    if (source->n <= (DYN_DEFAULT_VIARRAY_SIZE_INIT - 1) )
+    {
+    	source->stA[source->n] = val;
+    }
+    else {
+    	//insertion in dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_VIARRAY_SIZE_INIT)) ] = val;
+    }
+
+    source->n++;
+    return source;
 }
 
-grib_viarray* grib_viarray_push(grib_context* c, grib_viarray* v, grib_iarray* val)
+grib_iarray* grib_viarray_get(grib_viarray* source, size_t index)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_viarray_new(c, start_size, start_incsize);
+	if (!source)
+	    return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_VIARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA[(index-DYN_DEFAULT_VIARRAY_SIZE_INIT)];
+		}
+	}
 
-    if (v->n >= v->size)
-        v = grib_viarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	return NULL;
 }
 
-void grib_viarray_delete(grib_context* c, grib_viarray* v)
+void grib_viarray_delete(grib_context* c, grib_viarray* source)
 {
-    if (!v)
+    if (!source)
         return;
     if (!c)
         grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+    if (source->dynA)
+        grib_context_free(c, source->dynA);
+    grib_context_free(c, source);
 }
 
-void grib_viarray_delete_content(grib_context* c, grib_viarray* v)
+void grib_viarray_delete_content(grib_context* c, grib_viarray* source)
 {
     int i;
-    if (!v || !v->v)
+
+    if (!source)
         return;
+
     if (!c)
         grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        grib_iarray_delete(v->v[i]);
-        v->v[i] = 0;
+
+    //If the actual used size of the target is greater than the allowed size, it is a resized array
+    if ( (source->n > source->size) && ( source->dynA != NULL ) ) {
+    	for (i = 0; i < (source->n - DYN_DEFAULT_VIARRAY_SIZE_INIT); i++) {
+    		grib_iarray_delete(source->dynA[i]);
+    		source->dynA[i] = 0;
+    	}
     }
-    v->n = 0;
+
+    for (i = 0; i < (DYN_DEFAULT_VIARRAY_SIZE_INIT); i++) {
+        source->stA[i] = 0;
+    }
+
+    source->n = 0;
 }
 
-grib_iarray** grib_viarray_get_array(grib_context* c, grib_viarray* v)
+size_t grib_viarray_used_size(grib_viarray* source)
 {
-    grib_iarray** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (grib_iarray**)grib_context_malloc_clear(c, sizeof(grib_iarray*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
-}
-
-size_t grib_viarray_used_size(grib_viarray* v)
-{
-    return v->n;
+	return source == NULL ? 0 : source->n;
 }

--- a/src/grib_vsarray.c
+++ b/src/grib_vsarray.c
@@ -11,6 +11,7 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
@@ -18,97 +19,215 @@
 
 grib_vsarray* grib_vsarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_vsarray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_vsarray*)grib_context_malloc_clear(c, sizeof(grib_vsarray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_vsarray));
-        return NULL;
+	grib_vsarray* result = NULL;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	result = (grib_vsarray*)grib_context_malloc_clear(c, sizeof(grib_vsarray));
+
+	if (!result) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_vsarray));
+		return NULL;
+	}
+
+	if(size > DYN_DEFAULT_VSARRAY_SIZE_INIT) {
+
+		result->dynA       = (grib_sarray**)grib_context_malloc_clear(c, sizeof(grib_sarray*) *  (size-DYN_DEFAULT_VSARRAY_SIZE_INIT)  );
+
+		if (!result->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_sarray*) * (size-DYN_DEFAULT_VSARRAY_SIZE_INIT)  );
+			return NULL;
+		}
+		result->size    = size;
+
+		if (incsize > 0)
+			result->incsize             = incsize;
+		else
+			result->incsize             = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+
+	} else {
+
+		result->dynA					= NULL;
+		result->size                = DYN_DEFAULT_VSARRAY_SIZE_INIT;
+		result->incsize             = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+
+	}
+
+	result->n       = 0;
+
+	return result;
+}
+
+grib_vsarray* grib_vsarray_resize(grib_context* c, grib_vsarray* origin)
+{
+	int newsize;
+
+	if (origin == NULL)
+	{
+		return origin;
+	}
+
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA != NULL){
+
+		origin->dynA    = (grib_sarray**)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_VSARRAY_SIZE_INIT) * sizeof(grib_sarray*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vsarray_resize unable to allocate %d bytes\n", sizeof(grib_sarray*) * (newsize-DYN_DEFAULT_VSARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (grib_sarray**)grib_context_malloc(c, (newsize-DYN_DEFAULT_VSARRAY_SIZE_INIT) * sizeof(grib_sarray*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_sarray_resize unable to allocate %d bytes\n", sizeof(grib_sarray*) * (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
+}
+
+grib_vsarray* grib_vsarray_push(grib_context* c, grib_vsarray* source, grib_sarray* val)
+{
+    size_t start_size    = DYN_DEFAULT_VSARRAY_SIZE_INIT;
+    size_t start_incsize = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+
+    //If the target is empty, initialize it
+    if (!source)
+    	source = grib_vsarray_new(c, start_size, start_incsize);
+
+    //If the actual used size of the target is equal to the allowed size, resize the array
+    if (source->n == source->size) {
+
+    	source = grib_vsarray_resize(c, source);
+
+    	//Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!
+    	if (source == NULL)
+    	{
+    		return source;
+    	}
+
+    	//insertion in new allocated dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_VSARRAY_SIZE_INIT)) ] = val;
+    	source->n++;
+    	return source;
+
     }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (grib_sarray**)grib_context_malloc_clear(c, sizeof(grib_sarray*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_sarray*) * size);
-        return NULL;
+
+    //insertion in static array
+    if (source->n <= (DYN_DEFAULT_VSARRAY_SIZE_INIT - 1) )
+    {
+    	source->stA[source->n] = val;
     }
-    return v;
-}
-
-grib_vsarray* grib_vsarray_resize(grib_context* c, grib_vsarray* v)
-{
-    int newsize = v->incsize + v->size;
-
-    if (!c)
-        c = grib_context_get_default();
-
-    v->v    = (grib_sarray**)grib_context_realloc(c, v->v, newsize * sizeof(grib_sarray*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vsarray_resize unable to allocate %d bytes\n", sizeof(grib_sarray*) * newsize);
-        return NULL;
+    else {
+    	//insertion in dynamic array
+    	source->dynA[ (source->n-(DYN_DEFAULT_VSARRAY_SIZE_INIT)) ] = val;
     }
-    return v;
+
+    source->n++;
+
+    return source;
 }
 
-grib_vsarray* grib_vsarray_push(grib_context* c, grib_vsarray* v, grib_sarray* val)
+/**
+ * Return the grib_sarray* value at index 'index' for grib_vsarray 'source'
+ */
+grib_sarray* grib_vsarray_get(grib_vsarray* source, size_t index)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_vsarray_new(c, start_size, start_incsize);
 
-    if (v->n >= v->size)
-        v = grib_vsarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	if (!source)
+	    return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_VSARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA != NULL) {
+			return source->dynA[(index-DYN_DEFAULT_VSARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
 }
 
-void grib_vsarray_delete(grib_context* c, grib_vsarray* v)
+/**
+ * Sets the grib_sarray* value 'val' at index 'index' for grib_vsarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_vsarray_put (grib_vsarray* source, size_t index, grib_sarray* val)
 {
-    if (!v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_VSARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA != NULL) {
+			source->dynA[(index-DYN_DEFAULT_VSARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
 }
 
-void grib_vsarray_delete_content(grib_context* c, grib_vsarray* v)
+void grib_vsarray_delete(grib_context* c, grib_vsarray* source)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        grib_sarray_delete_content(c, v->v[i]);
-        grib_sarray_delete(c, v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+	if (!source)
+		return;
+	if (!c)
+		grib_context_get_default();
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
+	grib_context_free(c, source);
 }
 
-grib_sarray** grib_vsarray_get_array(grib_context* c, grib_vsarray* v)
+void grib_vsarray_delete_content(grib_context* c, grib_vsarray* source)
 {
-    grib_sarray** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (grib_sarray**)grib_context_malloc_clear(c, sizeof(grib_sarray*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+	int i;
+
+	if (!source)
+		return;
+
+	/*
+	if (!c)
+		grib_context_get_default();
+		*/
+
+	//If the actual used size of the target is greater than the allowed size, it is a resized array
+	if (source->n > source->size && ( source->dynA != NULL ) ) {
+		for (i = 0; i < (source->n - DYN_DEFAULT_VSARRAY_SIZE_INIT); i++) {
+			/* grib_vsarray_delete(c, source->dynA[i]); */
+			source->dynA[i] = 0;
+		}
+	}
+
+	for (i = 0; i < (DYN_DEFAULT_VSARRAY_SIZE_INIT); i++) {
+		source->stA[i] = 0;
+	}
+
+	source->n = 0;
 }
 
-size_t grib_vsarray_used_size(grib_vsarray* v)
+size_t grib_vsarray_used_size(grib_vsarray* source)
 {
-    return v->n;
+	return source == NULL ? 0 : source->n;
 }

--- a/src/makeyacc
+++ b/src/makeyacc
@@ -1,17 +1,40 @@
 set -xe
+yacc --version | head -1 | grep 'bison' >> /dev/null 2>&1
+
+rm -rf ../profiling_parser/ >> /dev/null 2>&1 ;
+#The original grib_lex.c contains adjustements made from eccodes developers: keep them!
+mv grib_lex.c grib_lex.c.orig
+
+mkdir ../profiling_parser/ >> /dev/null 2>&1 ;
 export LEX=flex
 export LEX_OUT=gribl.c
 $LEX -o gribl.c gribl.l
 sed 's/yy/grib_yy/g' < $LEX_OUT | sed 's/static void grib_yyunput/void grib_yyunput/' > grib_lex1.c
 sed 's/fgetc/getc/g' < grib_lex1.c > grib_lex.c
-rm -f grib_lex1.c
-rm -f $LEX_OUT
+
+#rm -f grib_lex1.c
+mv grib_lex1.c ../profiling_parser/
+#rm -f $LEX_OUT
+mv $LEX_OUT ../profiling_parser/
+cp -rp grib_lex.c ../profiling_parser/
+cp -rp grib_lex.c.orig ../profiling_parser/
+
+#Remember to re-establish the original grib_lex.c
+mv grib_lex.c.orig grib_lex.c
 
 yacc -v -d griby.y
 sed 's/yy/grib_yy/g' < y.tab.c > grib_yacc1.c
 sed 's/fgetc/getc/g' < grib_yacc1.c > grib_yacc.c
-rm -f grib_yacc1.c
+
+#rm -f grib_yacc1.c
+mv grib_yacc1.c ../profiling_parser/
+
 sed 's/yy/grib_yy/g' < y.tab.h > grib_yacc.h
-rm -f y.tab.c y.tab.h
+
+#rm -f y.tab.c y.tab.h
+mv y.tab.c ../profiling_parser/ ; mv y.tab.h ../profiling_parser/ ;
+
+mv y.output ../profiling_parser/ ;
+
 echo
 echo ALL OK

--- a/tests/bufr_dump_samples.sh
+++ b/tests/bufr_dump_samples.sh
@@ -22,9 +22,11 @@ touch $fLog
 fJsonTmp=${label}".json.tmp"
 
 # Test sample BUFR files
+echo "ECCODES_SAMPLES_PATH: \""$ECCODES_SAMPLES_PATH"\" ";
+echo "fLog: \""$fLog"\" ";
 for file in $ECCODES_SAMPLES_PATH/BUFR*.tmpl; do
   ${tools_dir}/bufr_dump -O $file >/dev/null
   ${tools_dir}/bufr_dump -d $file >/dev/null
 done
 
-rm -f $fLog
+#rm -f $fLog

--- a/tools/bufr_compare.c
+++ b/tools/bufr_compare.c
@@ -899,8 +899,10 @@ static int compare_values(grib_runtime_options* options, grib_handle* handle1, g
                 int ii;
                 countdiff = 0;
                 for (ii = 0; ii < len1; ii++)
-                    if (lval1[ii] != lval2[ii])
+                    if (lval1[ii] != lval2[ii]) {
+                    	printf("DIFF!!! long [%s][%d]: [%ld] != [%ld]\n", name, ii, lval1[ii], lval2[ii]);
                         countdiff++;
+                    }
 
                 if (countdiff) {
                     printInfo(handle1);
@@ -1037,6 +1039,7 @@ static int compare_values(grib_runtime_options* options, grib_handle* handle1, g
                     printf("  (%d values) tolerance=%g\n", (int)len1, value_tolerance);
                 for (i = 0; i < len1; i++) {
                     if ((diff = compare_double(pv1++, pv2++, &value_tolerance)) != 0) {
+                    	printf("DIFF!!! double [%s][%d]: [%ld] != [%ld]\n", name, i, *pv1, *pv2);
                         countdiff++;
                         if (maxdiff < diff) {
                             maxdiff  = diff;


### PR DESCRIPTION
The motivation of the change and impact on code:
This is the ecCodesMIA B6 version, also referred to as 'Reduction of mallocs: introducing static memory area in dynamic arrays'.
This is a pull request for a branch derived from ecCodes official repository, tag "2.17.0": so please, when merging take into account to not do it against the current ecCodes "develop" HEAD.
The complete changes applied are described in the file "src/ChangesB6.txt".
This code is not operational. Impacts on the code: NOT all automated tests are passing, the complete output is in the file "ctest3.out". This output is also mentioned ad the confluence page 'https://confluence.ecmwf.int/x/bAA1Cw'.
A full report of the ecCodesMIA project is accessible at https://gitlab.eumetsat.int/additional-data-services/eccodes-impact-analysis/-/blob/master/docs/officialdocs/ecCodesMIA_FinalReport_files/ecCodesMIA_FinalReport.md.

The author of changes accepts the "ECMWF Contributors License Agreement".
In particular:
2.1. This code can be redistributed under Apache License 2.0;
2.2. This code doesn't violate anyone IPR' rights;

3.Exception to PR requirements as described in "https://confluence.ecmwf.int/display/SUP/ECMWF+software+on+GitHub":
3.1. Although this code passes most of the automated and regression tests, it is not intended as an operational version, as stated earlier.