### PR TITLE
ecCodesMIA 2.17.0 b7

### DIFF
--- a/ctest3.out
+++ b/ctest3.out
@@ -1,0 +1,590 @@
+Test project /home/eccuser/eccodes-2.17.0-BUILD.B7
+        Start   1: eccodes_t_definitions
+  1/266 Test   #1: eccodes_t_definitions .......................   Passed   11.19 sec
+        Start   2: eccodes_t_grib_calendar
+  2/266 Test   #2: eccodes_t_grib_calendar .....................   Passed    0.55 sec
+        Start   3: eccodes_t_unit_tests
+  3/266 Test   #3: eccodes_t_unit_tests ........................   Passed    0.42 sec
+        Start   4: eccodes_t_md5
+  4/266 Test   #4: eccodes_t_md5 ...............................   Passed    0.28 sec
+        Start   5: eccodes_t_grib_uerra
+  5/266 Test   #5: eccodes_t_grib_uerra ........................   Passed    2.04 sec
+        Start   6: eccodes_t_grib_2nd_order_numValues
+  6/266 Test   #6: eccodes_t_grib_2nd_order_numValues ..........   Passed    0.18 sec
+        Start   7: eccodes_t_grib_ecc-136
+  7/266 Test   #7: eccodes_t_grib_ecc-136 ......................   Passed    0.37 sec
+        Start   8: eccodes_t_grib_ecc-967
+  8/266 Test   #8: eccodes_t_grib_ecc-967 ......................   Passed    0.15 sec
+        Start   9: eccodes_t_grib_ecc-1065
+  9/266 Test   #9: eccodes_t_grib_ecc-1065 .....................   Passed    0.06 sec
+        Start  10: eccodes_t_julian
+ 10/266 Test  #10: eccodes_t_julian ............................   Passed    2.34 sec
+        Start  11: eccodes_t_bufr_dump_samples
+ 11/266 Test  #11: eccodes_t_bufr_dump_samples .................   Passed    0.31 sec
+        Start  12: eccodes_t_bufr_json_samples
+ 12/266 Test  #12: eccodes_t_bufr_json_samples .................***Failed    0.57 sec
+        Start  13: eccodes_t_bufr_ecc-359
+ 13/266 Test  #13: eccodes_t_bufr_ecc-359 ......................   Passed    0.10 sec
+        Start  14: eccodes_t_bufr_ecc-517
+ 14/266 Test  #14: eccodes_t_bufr_ecc-517 ......................   Passed    0.16 sec
+        Start  15: eccodes_t_bufr_rdbSubTypes
+ 15/266 Test  #15: eccodes_t_bufr_rdbSubTypes ..................   Passed    0.19 sec
+        Start  16: eccodes_t_grib_efas
+ 16/266 Test  #16: eccodes_t_grib_efas .........................   Passed    1.80 sec
+        Start  17: eccodes_t_grib_sh_imag
+ 17/266 Test  #17: eccodes_t_grib_sh_imag ......................   Passed    0.07 sec
+        Start  18: eccodes_t_diag
+ 18/266 Test  #18: eccodes_t_diag ..............................***Failed    0.21 sec
+        Start  19: eccodes_t_grib_lambert_conformal
+ 19/266 Test  #19: eccodes_t_grib_lambert_conformal ............   Passed    0.87 sec
+        Start 262: eccodes_download_gribs
+ 20/266 Test #262: eccodes_download_gribs ......................   Passed    4.70 sec
+        Start 263: eccodes_download_tigge_gribs
+ 21/266 Test #263: eccodes_download_tigge_gribs ................   Passed   10.96 sec
+        Start 264: eccodes_download_bufrs
+ 22/266 Test #264: eccodes_download_bufrs ......................   Passed   23.88 sec
+        Start 265: eccodes_download_metars
+ 23/266 Test #265: eccodes_download_metars .....................   Passed    0.13 sec
+        Start 266: eccodes_download_gts
+ 24/266 Test #266: eccodes_download_gts ........................   Passed    0.09 sec
+        Start  20: eccodes_t_grib_data_quality_checks
+ 25/266 Test  #20: eccodes_t_grib_data_quality_checks ..........   Passed    2.76 sec
+        Start  21: eccodes_t_bpv_limit
+ 26/266 Test  #21: eccodes_t_bpv_limit .........................   Passed    0.41 sec
+        Start  22: eccodes_t_grib_complex
+ 27/266 Test  #22: eccodes_t_grib_complex ......................   Passed    0.12 sec
+        Start  23: eccodes_t_grib_double_cmp
+ 28/266 Test  #23: eccodes_t_grib_double_cmp ...................   Passed    0.08 sec
+        Start  24: eccodes_t_grib_change_packing
+ 29/266 Test  #24: eccodes_t_grib_change_packing ...............   Passed    0.61 sec
+        Start  25: eccodes_t_bufr_dump_data
+ 30/266 Test  #25: eccodes_t_bufr_dump_data ....................   Passed    1.92 sec
+        Start  26: eccodes_t_bufr_dump_descriptors
+ 31/266 Test  #26: eccodes_t_bufr_dump_descriptors .............   Passed    7.00 sec
+        Start  27: eccodes_t_bufr_dump_subset
+ 32/266 Test  #27: eccodes_t_bufr_dump_subset ..................   Passed    3.86 sec
+        Start  28: eccodes_t_bufr_dump_decode_filter
+ 33/266 Test  #28: eccodes_t_bufr_dump_decode_filter ...........***Failed    0.20 sec
+        Start  29: eccodes_t_bufr_dump_encode_filter
+ 34/266 Test  #29: eccodes_t_bufr_dump_encode_filter ...........***Failed    0.21 sec
+        Start  30: eccodes_t_bufrdc_desc_ref
+ 35/266 Test  #30: eccodes_t_bufrdc_desc_ref ...................   Passed    3.43 sec
+        Start  31: eccodes_t_bufrdc_ref
+ 36/266 Test  #31: eccodes_t_bufrdc_ref ........................***Failed    0.31 sec
+        Start  32: eccodes_t_bufr_compare
+ 37/266 Test  #32: eccodes_t_bufr_compare ......................   Passed    0.44 sec
+        Start  33: eccodes_t_bufr_copy
+ 38/266 Test  #33: eccodes_t_bufr_copy .........................   Passed    0.17 sec
+        Start  34: eccodes_t_bufr_count
+ 39/266 Test  #34: eccodes_t_bufr_count ........................   Passed    0.06 sec
+        Start  35: eccodes_t_bufr_get
+ 40/266 Test  #35: eccodes_t_bufr_get ..........................***Failed    0.38 sec
+        Start  36: eccodes_t_bufr_filter
+ 41/266 Test  #36: eccodes_t_bufr_filter .......................***Failed    4.22 sec
+        Start  37: eccodes_t_bufr_filter_extract_datetime
+ 42/266 Test  #37: eccodes_t_bufr_filter_extract_datetime ......***Failed    0.20 sec
+        Start  38: eccodes_t_bufr_filter_extract_area
+ 43/266 Test  #38: eccodes_t_bufr_filter_extract_area ..........***Failed    0.20 sec
+        Start  39: eccodes_t_bufr_json_data
+ 44/266 Test  #39: eccodes_t_bufr_json_data ....................***Failed    0.34 sec
+        Start  40: eccodes_t_bufr_ls
+ 45/266 Test  #40: eccodes_t_bufr_ls ...........................   Passed    1.75 sec
+        Start  41: eccodes_t_bufr_ls_json
+ 46/266 Test  #41: eccodes_t_bufr_ls_json ......................   Passed    1.86 sec
+        Start  42: eccodes_t_bufr_change_edition
+ 47/266 Test  #42: eccodes_t_bufr_change_edition ...............***Failed    0.46 sec
+        Start  43: eccodes_t_bufr_keys_iter
+ 48/266 Test  #43: eccodes_t_bufr_keys_iter ....................***Failed    0.37 sec
+        Start  44: eccodes_t_bufr_get_element
+ 49/266 Test  #44: eccodes_t_bufr_get_element ..................***Failed    0.35 sec
+        Start  45: eccodes_t_bufr_wmo_tables
+ 50/266 Test  #45: eccodes_t_bufr_wmo_tables ...................***Failed    0.68 sec
+        Start  46: eccodes_t_bufr_extract_headers
+ 51/266 Test  #46: eccodes_t_bufr_extract_headers ..............   Passed    3.73 sec
+        Start  47: eccodes_t_bufr_ecc-673
+ 52/266 Test  #47: eccodes_t_bufr_ecc-673 ......................***Failed    0.44 sec
+        Start  48: eccodes_t_bufr_ecc-428
+ 53/266 Test  #48: eccodes_t_bufr_ecc-428 ......................***Failed    0.24 sec
+        Start  49: eccodes_t_bufr_ecc-286
+ 54/266 Test  #49: eccodes_t_bufr_ecc-286 ......................   Passed    0.05 sec
+        Start  50: eccodes_t_bufr_ecc-288
+ 55/266 Test  #50: eccodes_t_bufr_ecc-288 ......................   Passed    0.08 sec
+        Start  51: eccodes_t_bufr_ecc-313
+ 56/266 Test  #51: eccodes_t_bufr_ecc-313 ......................   Passed    0.23 sec
+        Start  52: eccodes_t_bufr_ecc-616
+ 57/266 Test  #52: eccodes_t_bufr_ecc-616 ......................   Passed    0.13 sec
+        Start  53: eccodes_t_bufr_ecc-686
+ 58/266 Test  #53: eccodes_t_bufr_ecc-686 ......................   Passed    0.26 sec
+        Start  54: eccodes_t_bufr_ecc-690
+ 59/266 Test  #54: eccodes_t_bufr_ecc-690 ......................***Failed    0.26 sec
+        Start  55: eccodes_t_bufr_ecc-379
+ 60/266 Test  #55: eccodes_t_bufr_ecc-379 ......................***Failed    0.10 sec
+        Start  56: eccodes_t_bufr_ecc-393
+ 61/266 Test  #56: eccodes_t_bufr_ecc-393 ......................***Failed    0.23 sec
+        Start  57: eccodes_t_bufr_ecc-433
+ 62/266 Test  #57: eccodes_t_bufr_ecc-433 ......................   Passed    0.10 sec
+        Start  58: eccodes_t_bufr_ecc-750
+ 63/266 Test  #58: eccodes_t_bufr_ecc-750 ......................   Passed    0.18 sec
+        Start  59: eccodes_t_bufr_ecc-765
+ 64/266 Test  #59: eccodes_t_bufr_ecc-765 ......................   Passed    0.01 sec
+        Start  60: eccodes_t_bufr_ecc-875
+ 65/266 Test  #60: eccodes_t_bufr_ecc-875 ......................   Passed    0.38 sec
+        Start  61: eccodes_t_bufr_ecc-887
+ 66/266 Test  #61: eccodes_t_bufr_ecc-887 ......................   Passed    0.06 sec
+        Start  62: eccodes_t_grib_ecc-490
+ 67/266 Test  #62: eccodes_t_grib_ecc-490 ......................   Passed    0.23 sec
+        Start  63: eccodes_t_grib_ecc-756
+ 68/266 Test  #63: eccodes_t_grib_ecc-756 ......................   Passed    1.13 sec
+        Start  64: eccodes_t_grib_ecc-873
+ 69/266 Test  #64: eccodes_t_grib_ecc-873 ......................   Passed    0.34 sec
+        Start  65: eccodes_t_grib_ecc-600
+ 70/266 Test  #65: eccodes_t_grib_ecc-600 ......................   Passed    0.11 sec
+        Start  66: eccodes_t_grib_ecc-923
+ 71/266 Test  #66: eccodes_t_grib_ecc-923 ......................   Passed    0.17 sec
+        Start  67: eccodes_t_grib_ecc-979
+ 72/266 Test  #67: eccodes_t_grib_ecc-979 ......................   Passed    0.23 sec
+        Start  68: eccodes_t_grib_ecc-984
+ 73/266 Test  #68: eccodes_t_grib_ecc-984 ......................   Passed    0.08 sec
+        Start  69: eccodes_t_grib_ecc-1000
+ 74/266 Test  #69: eccodes_t_grib_ecc-1000 .....................   Passed    0.19 sec
+        Start  70: eccodes_t_grib_ecc-1001
+ 75/266 Test  #70: eccodes_t_grib_ecc-1001 .....................   Passed    0.40 sec
+        Start  71: eccodes_t_grib_ecc-1030
+ 76/266 Test  #71: eccodes_t_grib_ecc-1030 .....................   Passed    0.07 sec
+        Start  72: eccodes_t_bufr_ecc-556
+ 77/266 Test  #72: eccodes_t_bufr_ecc-556 ......................   Passed    0.02 sec
+        Start  73: eccodes_t_gts_get
+ 78/266 Test  #73: eccodes_t_gts_get ...........................   Passed    0.15 sec
+        Start  74: eccodes_t_gts_ls
+ 79/266 Test  #74: eccodes_t_gts_ls ............................   Passed    0.23 sec
+        Start  75: eccodes_t_gts_count
+ 80/266 Test  #75: eccodes_t_gts_count .........................   Passed    0.04 sec
+        Start  76: eccodes_t_gts_compare
+ 81/266 Test  #76: eccodes_t_gts_compare .......................   Passed    0.72 sec
+        Start  77: eccodes_t_metar_ls
+ 82/266 Test  #77: eccodes_t_metar_ls ..........................   Passed    0.38 sec
+        Start  78: eccodes_t_metar_get
+ 83/266 Test  #78: eccodes_t_metar_get .........................   Passed    0.18 sec
+        Start  79: eccodes_t_metar_dump
+ 84/266 Test  #79: eccodes_t_metar_dump ........................   Passed    0.34 sec
+        Start  80: eccodes_t_metar_compare
+ 85/266 Test  #80: eccodes_t_metar_compare .....................   Passed    0.31 sec
+        Start  81: eccodes_t_bufr_set
+ 86/266 Test  #81: eccodes_t_bufr_set ..........................   Passed    0.19 sec
+        Start  82: eccodes_t_ieee
+ 87/266 Test  #82: eccodes_t_ieee ..............................***Failed    0.09 sec
+        Start  83: eccodes_t_grib_sh_ieee64
+ 88/266 Test  #83: eccodes_t_grib_sh_ieee64 ....................   Passed    0.03 sec
+        Start  84: eccodes_t_grib_optimize_scaling
+ 89/266 Test  #84: eccodes_t_grib_optimize_scaling .............   Passed    0.21 sec
+        Start  85: eccodes_t_grib_optimize_scaling_sh
+ 90/266 Test  #85: eccodes_t_grib_optimize_scaling_sh ..........   Passed    0.03 sec
+        Start  86: eccodes_t_grib_lam_bf
+ 91/266 Test  #86: eccodes_t_grib_lam_bf .......................   Passed    0.33 sec
+        Start  87: eccodes_t_grib_lam_gp
+ 92/266 Test  #87: eccodes_t_grib_lam_gp .......................   Passed    0.20 sec
+        Start  88: eccodes_t_grib1to2
+ 93/266 Test  #88: eccodes_t_grib1to2 ..........................   Passed    4.24 sec
+        Start  89: eccodes_t_grib2to1
+ 94/266 Test  #89: eccodes_t_grib2to1 ..........................***Failed    3.27 sec
+        Start  90: eccodes_t_grib1to3
+ 95/266 Test  #90: eccodes_t_grib1to3 ..........................   Passed    0.67 sec
+        Start  91: eccodes_t_grib2to3
+ 96/266 Test  #91: eccodes_t_grib2to3 ..........................   Passed    0.16 sec
+        Start  92: eccodes_t_grib3_templates
+ 97/266 Test  #92: eccodes_t_grib3_templates ...................   Passed    0.47 sec
+        Start  93: eccodes_t_badgrib
+ 98/266 Test  #93: eccodes_t_badgrib ...........................   Passed    0.08 sec
+        Start  94: eccodes_t_grib_ls
+ 99/266 Test  #94: eccodes_t_grib_ls ...........................   Passed    2.24 sec
+        Start  95: eccodes_t_grib_ls_json
+100/266 Test  #95: eccodes_t_grib_ls_json ......................   Passed    8.66 sec
+        Start  96: eccodes_t_grib_filter
+101/266 Test  #96: eccodes_t_grib_filter .......................***Failed    0.62 sec
+        Start  97: eccodes_t_grib_multi
+102/266 Test  #97: eccodes_t_grib_multi ........................   Passed    0.29 sec
+        Start  98: eccodes_t_grib_nearest_test
+103/266 Test  #98: eccodes_t_grib_nearest_test .................   Passed    0.14 sec
+        Start  99: eccodes_t_budg
+104/266 Test  #99: eccodes_t_budg ..............................   Passed    0.03 sec
+        Start 100: eccodes_t_grib_gridType
+105/266 Test #100: eccodes_t_grib_gridType .....................   Passed    0.19 sec
+        Start 101: eccodes_t_grib_octahedral
+106/266 Test #101: eccodes_t_grib_octahedral ...................   Passed   23.74 sec
+        Start 102: eccodes_t_grib_global
+107/266 Test #102: eccodes_t_grib_global .......................   Passed    0.50 sec
+        Start 103: eccodes_t_grib_concept
+108/266 Test #103: eccodes_t_grib_concept ......................   Passed    1.54 sec
+        Start 104: eccodes_t_grib_decimalPrecision
+109/266 Test #104: eccodes_t_grib_decimalPrecision .............   Passed    0.27 sec
+        Start 105: eccodes_t_grib_bitsPerValue
+110/266 Test #105: eccodes_t_grib_bitsPerValue .................   Passed    3.72 sec
+        Start 106: eccodes_t_get_fail
+111/266 Test #106: eccodes_t_get_fail ..........................   Passed    0.04 sec
+        Start 107: eccodes_t_grib_missing
+112/266 Test #107: eccodes_t_grib_missing ......................   Passed    0.12 sec
+        Start 108: eccodes_t_grib_local
+113/266 Test #108: eccodes_t_grib_local ........................   Passed    7.64 sec
+        Start 109: eccodes_t_grib_step
+114/266 Test #109: eccodes_t_grib_step .........................   Passed    1.18 sec
+        Start 110: eccodes_t_grib_set
+115/266 Test #110: eccodes_t_grib_set ..........................   Passed    0.40 sec
+        Start 111: eccodes_t_grib_iterator
+116/266 Test #111: eccodes_t_grib_iterator .....................   Passed    1.54 sec
+        Start 112: eccodes_t_grib_compare
+117/266 Test #112: eccodes_t_grib_compare ......................   Passed    0.73 sec
+        Start 113: eccodes_t_grib_copy
+118/266 Test #113: eccodes_t_grib_copy .........................   Passed    0.22 sec
+        Start 114: eccodes_t_grib_level
+119/266 Test #114: eccodes_t_grib_level ........................   Passed    1.52 sec
+        Start 115: eccodes_t_index
+120/266 Test #115: eccodes_t_index .............................   Passed    2.03 sec
+        Start 116: eccodes_t_grib_bitmap
+121/266 Test #116: eccodes_t_grib_bitmap .......................***Failed    0.96 sec
+        Start 117: eccodes_t_grib_list
+122/266 Test #117: eccodes_t_grib_list .........................***Failed    0.07 sec
+        Start 118: eccodes_t_grib_second_order
+123/266 Test #118: eccodes_t_grib_second_order .................   Passed    2.07 sec
+        Start 119: eccodes_t_grib_multi_from_message
+124/266 Test #119: eccodes_t_grib_multi_from_message ...........   Passed    0.44 sec
+        Start 120: eccodes_t_grib_change_scanning
+125/266 Test #120: eccodes_t_grib_change_scanning ..............***Failed    0.12 sec
+        Start 121: eccodes_t_grib_statistics
+126/266 Test #121: eccodes_t_grib_statistics ...................***Failed    0.07 sec
+        Start 122: eccodes_t_grib_tigge
+127/266 Test #122: eccodes_t_grib_tigge ........................   Passed   14.29 sec
+        Start 123: eccodes_t_read_any
+128/266 Test #123: eccodes_t_read_any ..........................   Passed    0.20 sec
+        Start 124: eccodes_t_grib_dump
+129/266 Test #124: eccodes_t_grib_dump .........................   Passed    1.35 sec
+        Start 125: eccodes_t_grib_dump_debug
+130/266 Test #125: eccodes_t_grib_dump_debug ...................   Passed   15.59 sec
+        Start 126: eccodes_t_grib_dump_json
+131/266 Test #126: eccodes_t_grib_dump_json ....................   Passed   17.33 sec
+        Start 127: eccodes_t_grib_local_MeteoFrance
+132/266 Test #127: eccodes_t_grib_local_MeteoFrance ............   Passed    0.08 sec
+        Start 128: eccodes_t_grib_neg_fctime
+133/266 Test #128: eccodes_t_grib_neg_fctime ...................   Passed    0.66 sec
+        Start 129: eccodes_t_codes_split_file
+134/266 Test #129: eccodes_t_codes_split_file ..................   Passed    2.01 sec
+        Start 130: eccodes_t_grib_mars_types
+135/266 Test #130: eccodes_t_grib_mars_types ...................   Passed    9.05 sec
+        Start 131: eccodes_t_bufr_dump_encode_fortran
+136/266 Test #131: eccodes_t_bufr_dump_encode_fortran ..........***Failed    0.37 sec
+        Start 132: eccodes_t_bufr_dump_decode_fortran
+137/266 Test #132: eccodes_t_bufr_dump_decode_fortran ..........***Failed    0.20 sec
+        Start 133: eccodes_t_grib_util_set_spec
+138/266 Test #133: eccodes_t_grib_util_set_spec ................   Passed    0.69 sec
+        Start 134: eccodes_t_grib_padding
+139/266 Test #134: eccodes_t_grib_padding ......................   Passed   56.89 sec
+        Start 135: eccodes_t_grib_tigge_conversions
+140/266 Test #135: eccodes_t_grib_tigge_conversions ............   Passed   31.23 sec
+        Start 136: eccodes_t_bufr_dump_encode_C
+141/266 Test #136: eccodes_t_bufr_dump_encode_C ................***Failed    0.35 sec
+        Start 137: eccodes_t_bufr_dump_decode_C
+142/266 Test #137: eccodes_t_bufr_dump_decode_C ................***Failed    0.17 sec
+        Start 138: eccodes_t_bufr_dump_encode_python
+143/266 Test #138: eccodes_t_bufr_dump_encode_python ...........***Failed    0.17 sec
+        Start 139: eccodes_t_bufr_dump_decode_python
+144/266 Test #139: eccodes_t_bufr_dump_decode_python ...........***Failed    0.19 sec
+        Start 140: eccodes_t_grib_lamb_az_eq_area
+145/266 Test #140: eccodes_t_grib_lamb_az_eq_area ..............***Failed    0.13 sec
+        Start 141: eccodes_t_tools_data_from_stdin
+146/266 Test #141: eccodes_t_tools_data_from_stdin .............   Passed    0.05 sec
+        Start 142: eccodes_t_bufr_ecc-197
+147/266 Test #142: eccodes_t_bufr_ecc-197 ......................   Passed    0.15 sec
+        Start 143: eccodes_t_grib_check_param_concepts
+148/266 Test #143: eccodes_t_grib_check_param_concepts .........   Passed    0.01 sec
+        Start 144: eccodes_c_grib_multi
+149/266 Test #144: eccodes_c_grib_multi ........................   Passed    0.18 sec
+        Start 145: eccodes_c_grib_set_data
+150/266 Test #145: eccodes_c_grib_set_data .....................   Passed    0.02 sec
+        Start 146: eccodes_c_large_grib1
+151/266 Test #146: eccodes_c_large_grib1 .......................   Passed    0.30 sec
+        Start 147: eccodes_c_grib_sections_copy
+152/266 Test #147: eccodes_c_grib_sections_copy ................   Passed    0.24 sec
+        Start 148: eccodes_c_get_product_kind_samples
+153/266 Test #148: eccodes_c_get_product_kind_samples ..........   Passed    0.04 sec
+        Start 149: eccodes_c_grib_iterator
+154/266 Test #149: eccodes_c_grib_iterator .....................   Passed    0.08 sec
+        Start 150: eccodes_c_grib_get_keys
+155/266 Test #150: eccodes_c_grib_get_keys .....................   Passed    0.03 sec
+        Start 151: eccodes_c_grib_print_data
+156/266 Test #151: eccodes_c_grib_print_data ...................   Passed    0.16 sec
+        Start 152: eccodes_c_grib_set_keys
+157/266 Test #152: eccodes_c_grib_set_keys .....................   Passed    0.04 sec
+        Start 153: eccodes_c_grib_keys_iterator
+158/266 Test #153: eccodes_c_grib_keys_iterator ................   Passed    0.30 sec
+        Start 154: eccodes_c_grib_multi_write
+159/266 Test #154: eccodes_c_grib_multi_write ..................   Passed    0.13 sec
+        Start 155: eccodes_c_grib_precision
+160/266 Test #155: eccodes_c_grib_precision ....................   Passed    0.02 sec
+        Start 156: eccodes_c_grib_clone
+161/266 Test #156: eccodes_c_grib_clone ........................   Passed    0.08 sec
+        Start 157: eccodes_c_grib_copy_message
+162/266 Test #157: eccodes_c_grib_copy_message .................   Passed    0.08 sec
+        Start 158: eccodes_c_grib_ensemble_index
+163/266 Test #158: eccodes_c_grib_ensemble_index ...............   Passed    0.52 sec
+        Start 159: eccodes_c_grib_set_pv
+164/266 Test #159: eccodes_c_grib_set_pv .......................   Passed    0.06 sec
+        Start 160: eccodes_c_grib_set_bitmap
+165/266 Test #160: eccodes_c_grib_set_bitmap ...................   Passed    0.05 sec
+        Start 161: eccodes_c_grib_list
+166/266 Test #161: eccodes_c_grib_list .........................   Passed    0.08 sec
+        Start 162: eccodes_c_grib_get_data
+167/266 Test #162: eccodes_c_grib_get_data .....................   Passed    0.31 sec
+        Start 163: eccodes_c_grib_nearest_multiple
+168/266 Test #163: eccodes_c_grib_nearest_multiple .............   Passed    0.04 sec
+        Start 164: eccodes_c_set_missing
+169/266 Test #164: eccodes_c_set_missing .......................   Passed    0.03 sec
+        Start 165: eccodes_c_bufr_attributes
+170/266 Test #165: eccodes_c_bufr_attributes ...................   Passed    0.03 sec
+        Start 166: eccodes_c_bufr_copy_data
+171/266 Test #166: eccodes_c_bufr_copy_data ....................***Failed    0.03 sec
+        Start 167: eccodes_c_bufr_clone
+172/266 Test #167: eccodes_c_bufr_clone ........................   Passed    0.05 sec
+        Start 168: eccodes_c_bufr_expanded
+173/266 Test #168: eccodes_c_bufr_expanded .....................   Passed    0.02 sec
+        Start 169: eccodes_c_bufr_get_keys
+174/266 Test #169: eccodes_c_bufr_get_keys .....................   Passed    0.03 sec
+        Start 170: eccodes_c_bufr_get_string_array
+175/266 Test #170: eccodes_c_bufr_get_string_array .............***Failed    0.27 sec
+        Start 171: eccodes_c_bufr_keys_iterator
+176/266 Test #171: eccodes_c_bufr_keys_iterator ................   Passed    0.03 sec
+        Start 172: eccodes_c_bufr_missing
+177/266 Test #172: eccodes_c_bufr_missing ......................   Passed    0.03 sec
+        Start 173: eccodes_c_bufr_read_header
+178/266 Test #173: eccodes_c_bufr_read_header ..................   Passed    0.03 sec
+        Start 174: eccodes_c_bufr_read_scatterometer
+179/266 Test #174: eccodes_c_bufr_read_scatterometer ...........***Failed    0.32 sec
+        Start 175: eccodes_c_bufr_read_synop
+180/266 Test #175: eccodes_c_bufr_read_synop ...................   Passed    0.03 sec
+        Start 176: eccodes_c_bufr_read_temp
+181/266 Test #176: eccodes_c_bufr_read_temp ....................   Passed    0.04 sec
+        Start 177: eccodes_c_bufr_set_keys
+182/266 Test #177: eccodes_c_bufr_set_keys .....................   Passed    0.08 sec
+        Start 178: eccodes_c_bufr_subset
+183/266 Test #178: eccodes_c_bufr_subset .......................   Passed    0.05 sec
+        Start 179: eccodes_c_get_product_kind
+184/266 Test #179: eccodes_c_get_product_kind ..................   Passed    0.04 sec
+        Start 180: eccodes_c_new_sample
+185/266 Test #180: eccodes_c_new_sample ........................   Passed    0.04 sec
+        Start 181: eccodes_f_grib_set_pv
+186/266 Test #181: eccodes_f_grib_set_pv .......................   Passed    0.17 sec
+        Start 182: eccodes_f_grib_set_data
+187/266 Test #182: eccodes_f_grib_set_data .....................   Passed    0.03 sec
+        Start 183: eccodes_f_grib_ecc-671
+188/266 Test #183: eccodes_f_grib_ecc-671 ......................   Passed    0.03 sec
+        Start 184: eccodes_f_grib_index
+189/266 Test #184: eccodes_f_grib_index ........................   Passed    2.01 sec
+        Start 185: eccodes_f_grib_copy_message
+190/266 Test #185: eccodes_f_grib_copy_message .................   Passed    0.08 sec
+        Start 186: eccodes_f_bufr_copy_message
+191/266 Test #186: eccodes_f_bufr_copy_message .................   Passed    0.06 sec
+        Start 187: eccodes_f_grib_get_keys
+192/266 Test #187: eccodes_f_grib_get_keys .....................   Passed    0.06 sec
+        Start 188: eccodes_f_grib_get_data
+193/266 Test #188: eccodes_f_grib_get_data .....................   Passed    0.74 sec
+        Start 189: eccodes_f_get_pl
+194/266 Test #189: eccodes_f_get_pl ............................   Passed    0.06 sec
+        Start 190: eccodes_f_get_pv
+195/266 Test #190: eccodes_f_get_pv ............................   Passed    0.04 sec
+        Start 191: eccodes_f_grib_keys_iterator
+196/266 Test #191: eccodes_f_grib_keys_iterator ................   Passed    0.08 sec
+        Start 192: eccodes_f_grib_multi_write
+197/266 Test #192: eccodes_f_grib_multi_write ..................   Passed    0.07 sec
+        Start 193: eccodes_f_grib_multi
+198/266 Test #193: eccodes_f_grib_multi ........................   Passed    0.16 sec
+        Start 194: eccodes_f_grib_nearest
+199/266 Test #194: eccodes_f_grib_nearest ......................   Passed    0.06 sec
+        Start 195: eccodes_f_grib_precision
+200/266 Test #195: eccodes_f_grib_precision ....................   Passed    0.03 sec
+        Start 196: eccodes_f_grib_print_data
+201/266 Test #196: eccodes_f_grib_print_data ...................   Passed    0.46 sec
+        Start 197: eccodes_f_grib_set_keys
+202/266 Test #197: eccodes_f_grib_set_keys .....................   Passed    0.24 sec
+        Start 198: eccodes_f_grib_set_bitmap
+203/266 Test #198: eccodes_f_grib_set_bitmap ...................   Passed    0.05 sec
+        Start 199: eccodes_f_grib_set_missing
+204/266 Test #199: eccodes_f_grib_set_missing ..................   Passed    0.03 sec
+        Start 200: eccodes_f_grib_samples
+205/266 Test #200: eccodes_f_grib_samples ......................   Passed    0.06 sec
+        Start 201: eccodes_f_grib_count_messages
+206/266 Test #201: eccodes_f_grib_count_messages ...............   Passed    0.08 sec
+        Start 202: eccodes_f_grib_count_messages_multi
+207/266 Test #202: eccodes_f_grib_count_messages_multi .........   Passed    0.06 sec
+        Start 203: eccodes_f_grib_copy_namespace
+208/266 Test #203: eccodes_f_grib_copy_namespace ...............   Passed    0.07 sec
+        Start 204: eccodes_f_read_message
+209/266 Test #204: eccodes_f_read_message ......................   Passed    0.88 sec
+        Start 205: eccodes_f_read_from_file
+210/266 Test #205: eccodes_f_read_from_file ....................   Passed    0.02 sec
+        Start 206: eccodes_f_get_set_uuid
+211/266 Test #206: eccodes_f_get_set_uuid ......................   Passed    0.06 sec
+        Start 207: eccodes_f_grib_clone
+212/266 Test #207: eccodes_f_grib_clone ........................   Passed    0.03 sec
+        Start 208: eccodes_f_bufr_attributes
+213/266 Test #208: eccodes_f_bufr_attributes ...................   Passed    0.04 sec
+        Start 209: eccodes_f_bufr_copy_data
+214/266 Test #209: eccodes_f_bufr_copy_data ....................***Failed    0.04 sec
+        Start 210: eccodes_f_bufr_clone
+215/266 Test #210: eccodes_f_bufr_clone ........................   Passed    0.04 sec
+        Start 211: eccodes_f_bufr_expanded
+216/266 Test #211: eccodes_f_bufr_expanded .....................   Passed    0.03 sec
+        Start 212: eccodes_f_bufr_get_keys
+217/266 Test #212: eccodes_f_bufr_get_keys .....................   Passed    0.04 sec
+        Start 213: eccodes_f_bufr_get_string_array
+218/266 Test #213: eccodes_f_bufr_get_string_array .............***Failed    0.36 sec
+        Start 214: eccodes_f_bufr_keys_iterator
+219/266 Test #214: eccodes_f_bufr_keys_iterator ................   Passed    0.03 sec
+        Start 215: eccodes_f_bufr_read_header
+220/266 Test #215: eccodes_f_bufr_read_header ..................   Passed    0.02 sec
+        Start 216: eccodes_f_bufr_read_scatterometer
+221/266 Test #216: eccodes_f_bufr_read_scatterometer ...........***Failed    0.46 sec
+        Start 217: eccodes_f_bufr_read_synop
+222/266 Test #217: eccodes_f_bufr_read_synop ...................   Passed    0.03 sec
+        Start 218: eccodes_f_bufr_read_temp
+223/266 Test #218: eccodes_f_bufr_read_temp ....................   Passed    0.03 sec
+        Start 219: eccodes_f_bufr_read_tropical_cyclone
+224/266 Test #219: eccodes_f_bufr_read_tropical_cyclone ........***Failed    0.35 sec
+        Start 220: eccodes_f_bufr_set_keys
+225/266 Test #220: eccodes_f_bufr_set_keys .....................   Passed    0.05 sec
+        Start 221: eccodes_f_bufr_copy_keys
+226/266 Test #221: eccodes_f_bufr_copy_keys ....................   Passed    0.04 sec
+        Start 222: eccodes_f_bufr_subset
+227/266 Test #222: eccodes_f_bufr_subset .......................   Passed    0.04 sec
+        Start 223: eccodes_f_get_product_kind
+228/266 Test #223: eccodes_f_get_product_kind ..................   Passed    0.04 sec
+        Start 224: eccodes_p_grib_set_pv_test
+229/266 Test #224: eccodes_p_grib_set_pv_test ..................   Passed    0.24 sec
+        Start 225: eccodes_p_grib_read_sample_test
+230/266 Test #225: eccodes_p_grib_read_sample_test .............   Passed    0.22 sec
+        Start 226: eccodes_p_bufr_read_sample_test
+231/266 Test #226: eccodes_p_bufr_read_sample_test .............   Passed    0.22 sec
+        Start 227: eccodes_p_bufr_ecc-869_test
+232/266 Test #227: eccodes_p_bufr_ecc-869_test .................   Passed    0.38 sec
+        Start 228: eccodes_p_grib_clone_test
+233/266 Test #228: eccodes_p_grib_clone_test ...................   Passed    0.18 sec
+        Start 229: eccodes_p_grib_count_messages_test
+234/266 Test #229: eccodes_p_grib_count_messages_test ..........   Passed    0.22 sec
+        Start 230: eccodes_p_grib_get_message_offset_test
+235/266 Test #230: eccodes_p_grib_get_message_offset_test ......   Passed    0.20 sec
+        Start 231: eccodes_p_grib_get_keys_test
+236/266 Test #231: eccodes_p_grib_get_keys_test ................   Passed    0.20 sec
+        Start 232: eccodes_p_grib_index_test
+237/266 Test #232: eccodes_p_grib_index_test ...................   Passed    1.98 sec
+        Start 233: eccodes_p_grib_iterator_test
+238/266 Test #233: eccodes_p_grib_iterator_test ................   Passed    5.91 sec
+        Start 234: eccodes_p_grib_keys_iterator_test
+239/266 Test #234: eccodes_p_grib_keys_iterator_test ...........   Passed    0.24 sec
+        Start 235: eccodes_p_grib_multi_write_test
+240/266 Test #235: eccodes_p_grib_multi_write_test .............   Passed    0.13 sec
+        Start 236: eccodes_p_grib_nearest_test
+241/266 Test #236: eccodes_p_grib_nearest_test .................   Passed    0.13 sec
+        Start 237: eccodes_p_grib_print_data_test
+242/266 Test #237: eccodes_p_grib_print_data_test ..............   Passed    0.16 sec
+        Start 238: eccodes_p_grib_samples_test
+243/266 Test #238: eccodes_p_grib_samples_test .................   Passed    0.12 sec
+        Start 239: eccodes_p_grib_set_missing_test
+244/266 Test #239: eccodes_p_grib_set_missing_test .............   Passed    0.12 sec
+        Start 240: eccodes_p_binary_message_test
+245/266 Test #240: eccodes_p_binary_message_test ...............   Passed    0.57 sec
+        Start 241: eccodes_p_grib_set_bitmap_test
+246/266 Test #241: eccodes_p_grib_set_bitmap_test ..............   Passed    0.12 sec
+        Start 242: eccodes_p_bufr_attributes_test
+247/266 Test #242: eccodes_p_bufr_attributes_test ..............   Passed    0.12 sec
+        Start 243: eccodes_p_bufr_clone_test
+248/266 Test #243: eccodes_p_bufr_clone_test ...................   Passed    0.13 sec
+        Start 244: eccodes_p_bufr_copy_data_test
+249/266 Test #244: eccodes_p_bufr_copy_data_test ...............***Failed    0.19 sec
+        Start 245: eccodes_p_bufr_expanded_test
+250/266 Test #245: eccodes_p_bufr_expanded_test ................   Passed    0.12 sec
+        Start 246: eccodes_p_bufr_get_keys_test
+251/266 Test #246: eccodes_p_bufr_get_keys_test ................   Passed    0.13 sec
+        Start 247: eccodes_p_bufr_keys_iterator_test
+252/266 Test #247: eccodes_p_bufr_keys_iterator_test ...........   Passed    0.12 sec
+        Start 248: eccodes_p_bufr_read_header_test
+253/266 Test #248: eccodes_p_bufr_read_header_test .............   Passed    0.38 sec
+        Start 249: eccodes_p_bufr_read_scatterometer_test
+254/266 Test #249: eccodes_p_bufr_read_scatterometer_test ......***Failed    0.67 sec
+        Start 250: eccodes_p_bufr_read_tropical_cyclone_test
+255/266 Test #250: eccodes_p_bufr_read_tropical_cyclone_test ...***Failed    0.50 sec
+        Start 251: eccodes_p_bufr_read_synop_test
+256/266 Test #251: eccodes_p_bufr_read_synop_test ..............   Passed    0.13 sec
+        Start 252: eccodes_p_bufr_read_temp_test
+257/266 Test #252: eccodes_p_bufr_read_temp_test ...............   Passed    0.17 sec
+        Start 253: eccodes_p_bufr_set_keys_test
+258/266 Test #253: eccodes_p_bufr_set_keys_test ................   Passed    0.14 sec
+        Start 254: eccodes_p_bufr_subset_test
+259/266 Test #254: eccodes_p_bufr_subset_test ..................   Passed    0.14 sec
+        Start 255: eccodes_p_get_product_kind_test
+260/266 Test #255: eccodes_p_get_product_kind_test .............   Passed    0.13 sec
+        Start 256: eccodes_p_gts_get_keys_test
+261/266 Test #256: eccodes_p_gts_get_keys_test .................   Passed    0.30 sec
+        Start 257: eccodes_p_metar_get_keys_test
+262/266 Test #257: eccodes_p_metar_get_keys_test ...............   Passed    0.27 sec
+        Start 258: eccodes_p_bufr_ecc-448_test
+263/266 Test #258: eccodes_p_bufr_ecc-448_test .................   Passed    0.13 sec
+        Start 259: eccodes_p_high_level_api_test
+264/266 Test #259: eccodes_p_high_level_api_test ...............   Passed    0.59 sec
+        Start 260: eccodes_p_grib_set_keys_test
+265/266 Test #260: eccodes_p_grib_set_keys_test ................   Passed    0.14 sec
+        Start 261: eccodes_p_bufr_encode_flight_test
+266/266 Test #261: eccodes_p_bufr_encode_flight_test ...........***Failed    0.36 sec
+
+83% tests passed, 44 tests failed out of 266
+
+Label Time Summary:
+download_data    =  39.76 sec*proc (5 tests)
+eccodes          = 355.50 sec*proc (266 tests)
+executable       =   0.04 sec*proc (1 test)
+script           = 315.70 sec*proc (260 tests)
+
+Total Test time (real) = 356.17 sec
+
+The following tests FAILED:
+	 12 - eccodes_t_bufr_json_samples (Failed)
+	 18 - eccodes_t_diag (Failed)
+	 28 - eccodes_t_bufr_dump_decode_filter (Failed)
+	 29 - eccodes_t_bufr_dump_encode_filter (Failed)
+	 31 - eccodes_t_bufrdc_ref (Failed)
+	 35 - eccodes_t_bufr_get (Failed)
+	 36 - eccodes_t_bufr_filter (Failed)
+	 37 - eccodes_t_bufr_filter_extract_datetime (Failed)
+	 38 - eccodes_t_bufr_filter_extract_area (Failed)
+	 39 - eccodes_t_bufr_json_data (Failed)
+	 42 - eccodes_t_bufr_change_edition (Failed)
+	 43 - eccodes_t_bufr_keys_iter (Failed)
+	 44 - eccodes_t_bufr_get_element (Failed)
+	 45 - eccodes_t_bufr_wmo_tables (Failed)
+	 47 - eccodes_t_bufr_ecc-673 (Failed)
+	 48 - eccodes_t_bufr_ecc-428 (Failed)
+	 54 - eccodes_t_bufr_ecc-690 (Failed)
+	 55 - eccodes_t_bufr_ecc-379 (Failed)
+	 56 - eccodes_t_bufr_ecc-393 (Failed)
+	 82 - eccodes_t_ieee (Failed)
+	 89 - eccodes_t_grib2to1 (Failed)
+	 96 - eccodes_t_grib_filter (Failed)
+	116 - eccodes_t_grib_bitmap (Failed)
+	117 - eccodes_t_grib_list (Failed)
+	120 - eccodes_t_grib_change_scanning (Failed)
+	121 - eccodes_t_grib_statistics (Failed)
+	131 - eccodes_t_bufr_dump_encode_fortran (Failed)
+	132 - eccodes_t_bufr_dump_decode_fortran (Failed)
+	136 - eccodes_t_bufr_dump_encode_C (Failed)
+	137 - eccodes_t_bufr_dump_decode_C (Failed)
+	138 - eccodes_t_bufr_dump_encode_python (Failed)
+	139 - eccodes_t_bufr_dump_decode_python (Failed)
+	140 - eccodes_t_grib_lamb_az_eq_area (Failed)
+	166 - eccodes_c_bufr_copy_data (Failed)
+	170 - eccodes_c_bufr_get_string_array (Failed)
+	174 - eccodes_c_bufr_read_scatterometer (Failed)
+	209 - eccodes_f_bufr_copy_data (Failed)
+	213 - eccodes_f_bufr_get_string_array (Failed)
+	216 - eccodes_f_bufr_read_scatterometer (Failed)
+	219 - eccodes_f_bufr_read_tropical_cyclone (Failed)
+	244 - eccodes_p_bufr_copy_data_test (Failed)
+	249 - eccodes_p_bufr_read_scatterometer_test (Failed)
+	250 - eccodes_p_bufr_read_tropical_cyclone_test (Failed)
+	261 - eccodes_p_bufr_encode_flight_test (Failed)
+Errors while running CTest

--- a/src/ChangesB7.txt
+++ b/src/ChangesB7.txt
@@ -1,0 +1,262 @@
+Compilation
+---------------
+unlink eccodes-2.17.0-Source; unlink eccodes-2.17.0-BUILD; unlink eccodes-2.17.0-INSTALL ; 
+ln -fs eccodes-2.17.0-Source.B7 eccodes-2.17.0-Source ; ln -fs eccodes-2.17.0-BUILD.B7 eccodes-2.17.0-BUILD ; ln -fs eccodes-2.17.0-INSTALL.B7 eccodes-2.17.0-INSTALL ; 
+
+#DEBUG OFF
+rm -rf cmake.out ;cmake3 -DENABLE_NETCDF=OFF -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_PREFIX=/home/eccuser/eccodes-2.17.0-INSTALL.B7 -DENABLE_EXTRA_TESTS=1 /home/eccuser/eccodes-2.17.0-Source.B7 >> cmake.out 2>&1 ; egrep -i "error|fail" cmake.out
+
+#DEBUG ON
+rm -rf cmake.out ;cmake3 -DCMAKE_C_FLAGS="-g -O0" -DENABLE_NETCDF=OFF -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_PREFIX=/home/eccuser/eccodes-2.17.0-INSTALL.B7  -DCMAKE_BUILD_TYPE=Debug -DENABLE_EXTRA_TESTS=1 -DDEVELOPER_MODE=1 /home/eccuser/eccodes-2.17.0-Source.B7 >> cmake.out 2>&1 ; egrep -i "error|fail" cmake.out
+
+rm -rf make.out; make >> make.out 2>&1; egrep -i "error|fail" make.out;
+
+rm -rf ctest3.out; ctest3 >> ctest3.out 2>&1 ; egrep -i "error|fail" ctest3.out; 
+
+rm -rf make_install.out; make install >> make_install.out 2>&1 ; egrep -i "error|fail" make_install.out;
+
+Base version
+-------------
+The base version for this version is B6.
+
+Differences/Rules
+-----------------
+The Rules 1 to 5 are applied to the dynamic array structs of:  
+* grib_vdarray.c  
+* grib_viarray.c  
+* grib_vsarray.c 
+
+* Rule 1. Introduce in the dynamic array struct an initialization method for the static area of the struct: this doesn't require the use of malloc to allocate dynamic memory.
+* Rule 2. Introduce in the dynamic array struct a destroy method for the dynamic area of the struct: this method will not invoke "free" on the whole struct, but only on the dynamic part of the struct.
+* Rule 3. Substitute the references to grib_vdarray, grib_viarray, grib_vsarray inside the data structures "grib_accessor_bufr_data_array" and "grib_accessor_bufr_data_element" in this way: from pointers, to which allocate dynamic memory, to variables meant to hold static memory.
+* Rule 4. Substitute the dynamic allocation for the substitutions done in Rule 3 with static initializations.
+* Rule 5. Substitue the call of "delete" method for the substitutions done in Rule 3 with the call to "free_dynamic", addedd in Rule 2.
+
+The Rules 6 to 9 are applied in order to preallocate a static pool of data structures, when the application is starting.
+At the moment, these rules are applied for preallocating a pool of grib_iarray data structures:
+
+* Rule 6. Introduce in eccodes start points the declaration of an "extern" to the static preallocated grib_iarray pool.
+* Rule 7. Introduce in eccodes start points the initialization of default values for the static preallocated grib_iarray pool.
+* Rule 8. Introduce in eccodes grib_iarray data structure the static preallocated grib_iarray pool management method.
+* Rule 9. Introduce in eccodes grib_iarray data structure "push" method the selection of a free array in the static preallocated grib_iarray pool.
+
+Corrections
+-----------
+* delete_content function for the dynamic arrays of:  
+* grib_vdarray.c  
+* grib_viarray.c  
+* grib_vsarray.c 
+have been changed in two respects:
+	1. The setting of zeroes with the for cycles was substituted with memset. Testing showed it is on average bringing at the same processing time but it is more maintanable.
+	2. The check on the context has been commented. The context is never used, consider to remove the context from inputs.
+
+Examples
+----------
+* Rule 1 and Rule 2, example for grib_vdarray.c:
+
+int grib_vdarray_init(grib_vdarray* source)
+{
+
+	if (source == NULL)
+	{
+		return 0;
+	}
+
+	memset(source->sv,0,sizeof(grib_vdarray*)*DYN_DEFAULT_VDARRAY_SIZE_INIT);
+	source->size 				= DYN_DEFAULT_VDARRAY_SIZE_INIT;
+	source->incsize             = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+	source->n					= 0;
+
+	return 1;
+}
+
+void grib_vdarray_free_dynamic ( grib_vdarray* source)
+{
+    if (!source)
+        return;
+
+    if (source->v)
+        free(source->v);
+}
+
+* Rule 3 examples for grib_accessor_bufr_data_array.
+The new structure is
+
+typedef struct grib_accessor_bufr_data_array
+{
+    grib_accessor att;
+    /* Members defined in gen */
+    /* Members defined in bufr_data_array */
+    const char* bufrDataEncodedName;
+    const char* numberOfSubsetsName;
+    const char* expandedDescriptorsName;
+    const char* flagsName;
+    const char* unitsName;
+    const char* elementsDescriptorsIndexName;
+    const char* compressedDataName;
+    bufr_descriptors_array* expanded;
+    grib_accessor* expandedAccessor;
+    int* canBeMissing;
+    long numberOfSubsets;
+    long compressedData;
+    grib_vdarray numericValues;
+    grib_vsarray stringValues;
+    grib_viarray elementsDescriptorsIndex;
+    int do_decode;
+    int bitmapStartElementsDescriptorsIndex;
+    int bitmapCurrentElementsDescriptorsIndex;
+    int bitmapSize;
+    int bitmapStart;
+    int bitmapCurrent;
+    grib_accessors_list* dataAccessors;
+    int unpackMode;
+    int bitsToEndData;
+    grib_section* dataKeys;
+    double* inputBitmap;
+    int nInputBitmap;
+    int iInputBitmap;
+    long* inputReplications;
+    int nInputReplications;
+    int iInputReplications;
+    long* inputExtendedReplications;
+    int nInputExtendedReplications;
+    int iInputExtendedReplications;
+    long* inputShortReplications;
+    int nInputShortReplications;
+    int iInputShortReplications;
+    grib_iarray* iss_list;
+    grib_trie_with_rank* dataAccessorsTrie;
+    grib_sarray* tempStrings;
+    int change_ref_value_operand;
+    size_t refValListSize;
+    long* refValList;
+    long refValIndex;
+    bufr_tableb_override* tableb_override;
+    int set_to_missing_if_out_of_range;
+} grib_accessor_bufr_data_array;
+
+* Rule 4
+In the init method
+static void init(grib_accessor* a, const long v, grib_arguments* params)
+the new initializations are
+  
+    /*self->elementsDescriptorsIndex = 0;*/
+    self->elementsDescriptorsIndex = (grib_viarray){ .sv = { [0 ... (DYN_DEFAULT_VIARRAY_SIZE_INIT-1)] = 0}, .size = DYN_DEFAULT_VIARRAY_SIZE_INIT, .n = 0, .incsize = DYN_DEFAULT_VIARRAY_SIZE_INCR, .v = 0 };
+    /*self->numericValues            = 0;*/
+    /*grib_vdarray_init(&(self->numericValues), DYN_DEFAULT_VDARRAY_SIZE_INIT, DYN_DEFAULT_VDARRAY_SIZE_INCR);*//* TBD: check the return pointer */
+    self->numericValues = (grib_vdarray){ .sv = { [0 ... (DYN_DEFAULT_VDARRAY_SIZE_INIT-1)] = 0}, .size = DYN_DEFAULT_VDARRAY_SIZE_INIT, .n = 0, .incsize = DYN_DEFAULT_VDARRAY_SIZE_INCR, .v = 0 };
+    /*self->stringValues             = 0;*/
+    self->stringValues  = (grib_vsarray){ .sv = { [0 ... (DYN_DEFAULT_VSARRAY_SIZE_INIT-1)] = 0}, .size = DYN_DEFAULT_VSARRAY_SIZE_INIT, .n = 0, .incsize = DYN_DEFAULT_VSARRAY_SIZE_INCR, .v = 0 };
+
+* Rule 5
+In the clearing method
+static void self_clear(grib_context* c, grib_accessor_bufr_data_array* self)
+the final clearing of dynamic allocation has changed:
+    /* grib_vdarray_delete(c, self->numericValues); */
+    grib_vdarray_free_dynamic(&(self->numericValues));
+    /* if (self->stringValues) { grib_vsarray_delete_content(c, self->stringValues); */
+        grib_vsarray_delete_content(c, &(self->stringValues) );
+        grib_vsarray_free_dynamic(&(self->stringValues));
+        /* grib_vsarray_delete(c, self->stringValues); */
+    /* } */
+    grib_viarray_delete_content(c, &(self->elementsDescriptorsIndex) );
+    /*grib_viarray_delete(c, self->elementsDescriptorsIndex);*/
+    grib_viarray_free_dynamic( &(self->elementsDescriptorsIndex) );
+
+* Rule 6 and Rule 7
+
+Declaration:
+
+/home/eccuser/eccodes-2.17.0-Source.B7/tools/grib_tools.c:53
+
+extern grib_iarrayPOOL iarrayPOOL;
+
+Initialization with default values:
+
+/home/eccuser/eccodes-2.17.0-Source.B7/tools/grib_tools.c:168
+
+iarrayPoolInit(c);
+
+* Rule 8 and Rule 9
+
+Management methods:
+
+/home/eccuser/eccodes-2.17.0-Source.B7/src/grib_iarray.c:126
+
+void iarrayPoolInit(grib_context* c)
+{
+	int i;
+	grib_context* poolContext = c ? c : 0 ;
+
+	for (i=0; i<DYN_DEFAULT_IARRAY_POOL_SIZE; i++) {
+		iarrayPOOL.arrayPOOL[i].context=poolContext;
+		iarrayPOOL.arrayPOOL[i].size=DYN_DEFAULT_IARRAY_SIZE_INIT;
+		iarrayPOOL.arrayPOOL[i].n=0;
+		iarrayPOOL.arrayPOOL[i].incsize=DYN_DEFAULT_IARRAY_SIZE_INCR;
+		iarrayPOOL.arrayPOOL[i].dynA=0;
+	}
+}
+
+push method change in case of unallocated source:
+
+/home/eccuser/eccodes-2.17.0-Source.B7/src/grib_iarray.c:148
+
+if (!source) {
+		if(iarrayPOOL.poolCounter != (DYN_DEFAULT_IARRAY_POOL_SIZE - 1) ) {
+			grib_context* c = grib_context_get_default();
+			iarrayPOOL.arrayPOOL[iarrayPOOL.poolCounter].context=c;
+			source = &(iarrayPOOL.arrayPOOL[iarrayPOOL.poolCounter]);
+			iarrayPOOL.poolCounter++;
+		} else {
+			source = grib_iarray_new(0, start_size, start_incsize);
+		}
+}
+
+Differences/List
+----------------
+Difference between original code contained in eccodes-2.17.0 and B7:
+action_class_set_darray.c
+action_class_set_iarray.c
+action_class_set_sarray.c
+bufr_util.c
+grib_accessor_class_bufr_data_array.c
+grib_accessor_class_bufr_data_element.c
+grib_accessor_class_bufr_string_values.c
+grib_accessor_class_concept.c
+grib_accessor_class_hash_array.c
+grib_accessor_class_long_vector.c
+grib_accessor_class_transient_darray.c
+grib_api.h
+grib_api_internal.h
+grib_api_prototypes.h
+grib_bufr_descriptors_array.c
+grib_darray.c
+grib_iarray.c
+grib_oarray.c
+grib_sarray.c
+grib_trie_with_rank.c
+grib_vdarray.c
+grib_viarray.c
+grib_vsarray.c
+
+Difference between original code contained in eccodes-2.17.0 and B6:
+action_class_set_darray.c
+action_class_set_iarray.c
+action_class_set_sarray.c
+bufr_util.c
+grib_accessor_class_bufr_data_array.c
+grib_accessor_class_bufr_data_element.c
+grib_accessor_class_bufr_string_values.c
+grib_accessor_class_concept.c
+grib_accessor_class_hash_array.c
+grib_accessor_class_transient_darray.c
+grib_api_prototypes.h
+grib_bufr_descriptors_array.c
+grib_darray.c
+grib_iarray.c
+grib_oarray.c
+grib_sarray.c
+grib_trie_with_rank.c
+grib_vdarray.c
+grib_viarray.c
+grib_vsarray.c

--- a/src/action_class_set_darray.c
+++ b/src/action_class_set_darray.c
@@ -9,7 +9,8 @@
  */
 
 /***************************************************************************
- *  Enrico Fucile                                                                         *
+ *  Enrico Fucile
+ *  Modified for Performance Study by: CS GMBH
  ***************************************************************************/
 #include "grib_api_internal.h"
 /*
@@ -107,7 +108,8 @@ static int execute(grib_action* a, grib_handle* h)
 {
     grib_action_set_darray* self = (grib_action_set_darray*)a;
 
-    return grib_set_double_array(h, self->name, self->darray->v, self->darray->n);
+    return grib_set_double_array(h, self->name, grib_darray_get_arrays_by_reference(self->darray), self->darray->n);
+    /*return grib_set_double_array(h, self->name, self->darray->v, self->darray->n);*/
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/action_class_set_iarray.c
+++ b/src/action_class_set_iarray.c
@@ -9,7 +9,8 @@
  */
 
 /***************************************************************************
- *  Enrico Fucile                                                                         *
+ *  Enrico Fucile
+ *  Modified for Performance Study by: CS GMBH
  ***************************************************************************/
 #include "grib_api_internal.h"
 /*
@@ -106,8 +107,9 @@ grib_action* grib_action_create_set_iarray(grib_context* context,
 static int execute(grib_action* a, grib_handle* h)
 {
     grib_action_set_iarray* self = (grib_action_set_iarray*)a;
-
-    return grib_set_long_array(h, self->name, self->iarray->v, self->iarray->n);
+    size_t size = grib_iarray_used_size(self->iarray);
+    /*return grib_set_long_array(h, self->name, self->iarray->v, self->iarray->n);*/
+    return grib_set_long_array(h, self->name, grib_iarray_get_arrays_by_reference(self->iarray), size);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/action_class_set_sarray.c
+++ b/src/action_class_set_sarray.c
@@ -9,7 +9,8 @@
  */
 
 /***************************************************************************
- *  Enrico Fucile                                                                         *
+ *  Enrico Fucile
+ *  Modified for Performance Study by: CS GMBH                                                              *
  ***************************************************************************/
 #include "grib_api_internal.h"
 /*
@@ -106,8 +107,9 @@ grib_action* grib_action_create_set_sarray(grib_context* context,
 static int execute(grib_action* a, grib_handle* h)
 {
     grib_action_set_sarray* self = (grib_action_set_sarray*)a;
-
-    return grib_set_string_array(h, self->name, (const char**)self->sarray->v, self->sarray->n);
+    size_t size = grib_sarray_used_size(self->sarray);
+    /*return grib_set_string_array(h, self->name, (const char**)self->sarray->v, self->sarray->n);*/
+    return grib_set_string_array(h, self->name, (const char**)grib_sarray_get_arrays_by_reference(self->sarray), size);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/action_class_transient_darray.c
+++ b/src/action_class_transient_darray.c
@@ -121,7 +121,8 @@ static int execute(grib_action* act, grib_handle* h)
     if (a->flags & GRIB_ACCESSOR_FLAG_CONSTRAINT)
         grib_dependency_observe_arguments(a, act->default_value);
 
-    return grib_pack_double(a, self->darray->v, &len);
+    /*return grib_pack_double(a, self->darray->dynA, &len);*/
+    return grib_pack_double(a,  grib_darray_get_arrays_by_reference(self->darray), &len);
 }
 
 static void dump(grib_action* act, FILE* f, int lvl)

--- a/src/bufr_util.c
+++ b/src/bufr_util.c
@@ -70,7 +70,9 @@ char** codes_bufr_copy_data_return_copied_keys(grib_handle* hin, grib_handle* ho
     kiter = codes_bufr_data_section_keys_iterator_new(hin);
     if (!kiter)
         return NULL;
-    k = grib_sarray_new(hin->context, 50, 10);
+    /* magic numbers 50 and 10 are not documented anywhere... */
+    /* k = grib_sarray_new(hin->context, 50, 10); */
+    k = grib_sarray_new(hin->context, 50, 60);
 
     while (codes_bufr_keys_iterator_next(kiter)) {
         name = codes_bufr_keys_iterator_get_name(kiter);

--- a/src/grib_accessor_class.c
+++ b/src/grib_accessor_class.c
@@ -51,6 +51,10 @@ struct table_entry
     grib_accessor_class** cclass;
 };
 
+/* grib_vdarrayPOOL vdarrayPOOL; */
+/* grib_vsarrayPOOL vsarrayPOOL; */
+/* grib_viarrayPOOL viarrayPOOL; */
+
 #ifdef ACCESSOR_FACTORY_USE_TRIE
 /* Note: A fast cut-down version of strcmp which does NOT return -1 */
 /* 0 means input strings are equal and 1 means not equal */
@@ -177,6 +181,10 @@ grib_accessor* grib_accessor_factory(grib_section* p, grib_action* creator,
     }
 
     a->cclass = c;
+
+    /* vdarrayPoolInit(); grib_vdarrayPOOL vdarrayPOOL; */
+    /* vsarrayPoolInit(); grib_vsarrayPOOL vsarrayPOOL; */
+    /* viarrayPoolInit(); grib_viarrayPOOL viarrayPOOL; */
 
     grib_init_accessor(a, len, params);
     size = grib_get_next_position_offset(a);

--- a/src/grib_accessor_class_bufr_data_array.c
+++ b/src/grib_accessor_class_bufr_data_array.c
@@ -6,6 +6,7 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *   Modified for Performance Study by: CS GMBH
  */
 
 #include "grib_api_internal.h"
@@ -99,6 +100,12 @@ static void init(grib_accessor*, const long, grib_arguments*);
 static void init_class(grib_accessor_class*);
 static int compare(grib_accessor*, grib_accessor*);
 
+extern grib_vdarrayPOOL vdarrayPOOL;
+extern grib_vsarrayPOOL vsarrayPOOL;
+extern grib_viarrayPOOL viarrayPOOL;
+
+extern grib_darrayPOOL darrayPOOL;
+
 typedef struct grib_accessor_bufr_data_array
 {
     grib_accessor att;
@@ -116,9 +123,9 @@ typedef struct grib_accessor_bufr_data_array
     int* canBeMissing;
     long numberOfSubsets;
     long compressedData;
-    grib_vdarray* numericValues;
-    grib_vsarray* stringValues;
-    grib_viarray* elementsDescriptorsIndex;
+    grib_vdarray *numericValues;
+    grib_vsarray *stringValues;
+    grib_viarray *elementsDescriptorsIndex;
     int do_decode;
     int bitmapStartElementsDescriptorsIndex;
     int bitmapCurrentElementsDescriptorsIndex;
@@ -374,9 +381,6 @@ static void tableB_override_dump(grib_accessor_bufr_data_array *self)
 }
  */
 
-#define DYN_ARRAY_SIZE_INIT 1000 /* Initial size for grib_iarray_new and grib_darray_new */
-#define DYN_ARRAY_SIZE_INCR 1000 /* Increment size for grib_iarray_new and grib_darray_new */
-
 static void init(grib_accessor* a, const long v, grib_arguments* params)
 {
     grib_accessor_bufr_data_array* self = (grib_accessor_bufr_data_array*)a;
@@ -395,9 +399,9 @@ static void init(grib_accessor* a, const long v, grib_arguments* params)
     dataKeysAcc                    = grib_find_accessor(grib_handle_of_accessor(a), dataKeysName);
     self->dataKeys                 = dataKeysAcc->parent;
     self->do_decode                = 1;
-    self->elementsDescriptorsIndex = 0;
-    self->numericValues            = 0;
-    self->stringValues             = 0;
+    self->elementsDescriptorsIndex = 0; /* &(viarrayPOOL.arrayPOOL[0]); */
+    self->numericValues = 0; /* &(vdarrayPOOL.arrayPOOL[0]); */
+    self->stringValues = 0; /* &(vsarrayPOOL.arrayPOOL[0]); */
     cancel_bitmap(self);
     self->expanded                       = 0;
     self->expandedAccessor               = 0;
@@ -414,6 +418,9 @@ static void init(grib_accessor* a, const long v, grib_arguments* params)
     self->unpackMode    = CODES_BUFR_UNPACK_STRUCTURE;
 
     /* Assert(a->length>=0); */
+    /* vdarrayPoolInit(); grib_vdarrayPOOL vdarrayPOOL; */
+    /* vsarrayPoolInit(); grib_vsarrayPOOL vsarrayPOOL; */
+    /* viarrayPoolInit(); grib_viarrayPOOL viarrayPOOL; */
 }
 
 /*
@@ -441,13 +448,14 @@ static void self_clear(grib_context* c, grib_accessor_bufr_data_array* self)
 {
     grib_context_free(c, self->canBeMissing);
     grib_vdarray_delete_content(c, self->numericValues);
-    grib_vdarray_delete(c, self->numericValues);
+    grib_vdarray_delete(c, self->numericValues); /* grib_vdarray_free_dynamic(c, self->numericValues); */
     if (self->stringValues) {
-        grib_vsarray_delete_content(c, self->stringValues);
-        grib_vsarray_delete(c, self->stringValues);
+    	grib_vsarray_delete_content(c, self->stringValues);
+        grib_vsarray_delete(c, self->stringValues); /* grib_vsarray_free_dynamic(c, self->stringValues); */
     }
-    grib_viarray_delete_content(c, self->elementsDescriptorsIndex);
-    grib_viarray_delete(c, self->elementsDescriptorsIndex);
+    grib_viarray_delete_content(c, self->elementsDescriptorsIndex );
+    grib_viarray_delete(c, self->elementsDescriptorsIndex); /* grib_viarray_free_dynamic(c, self->elementsDescriptorsIndex ); */
+
     if (self->inputReplications)
         grib_context_free(c, self->inputReplications);
     if (self->inputExtendedReplications)
@@ -508,7 +516,8 @@ grib_vsarray* accessor_bufr_data_array_get_stringValues(grib_accessor* a)
     grib_accessor_bufr_data_array* self = (grib_accessor_bufr_data_array*)a;
     process_elements(a, PROCESS_DECODE, 0, 0, 0);
 
-    return self->stringValues;
+    /*return self->stringValues;*/
+    return (self->stringValues);
 }
 
 grib_accessors_list* accessor_bufr_data_array_get_dataAccessors(grib_accessor* a)
@@ -562,6 +571,7 @@ static int decode_string_array(grib_context* c, unsigned char* data, long* pos, 
     int* err   = &ret;
     char* sval = 0;
     int j, modifiedWidth, width;
+    /*grib_sarray* sa                        = grib_sarray_new(c, self->numberOfSubsets, 10);*/
     grib_sarray* sa                        = grib_sarray_new(c, self->numberOfSubsets, 10);
     int bufr_multi_element_constant_arrays = c->bufr_multi_element_constant_arrays;
 
@@ -635,7 +645,7 @@ static grib_darray* decode_double_array(grib_context* c, unsigned char* data, lo
         dval = GRIB_MISSING_DOUBLE;
         lval = 0;
         grib_context_log(c, GRIB_LOG_DEBUG, " modifiedWidth=%ld lval=%ld dval=%g", modifiedWidth, lval, dval);
-        ret = grib_darray_new(c, DYN_ARRAY_SIZE_INIT, DYN_ARRAY_SIZE_INCR);
+        ret = grib_darray_new(c, DYN_DEFAULT_DARRAY_SIZE_INIT, DYN_DEFAULT_DARRAY_SIZE_INCR);
         grib_darray_push(c, ret, dval);
         *err = 0;
         return ret;
@@ -644,14 +654,21 @@ static grib_darray* decode_double_array(grib_context* c, unsigned char* data, lo
     localReference = (long)lval + modifiedReference;
     localWidth     = grib_decode_unsigned_long(data, pos, 6);
     grib_context_log(c, GRIB_LOG_DEBUG, "BUFR data decoding: \tlocalWidth=%ld", localWidth);
-    ret = grib_darray_new(c, self->numberOfSubsets, 50);
+    /* ret = grib_darray_new(c, self->numberOfSubsets, 50); */
+    /* ret = grib_darray_new(c, self->numberOfSubsets, self->numberOfSubsets); */
+    if(darrayPOOL.poolCounter != (DYN_DEFAULT_DARRAY_POOL_SIZE - 1) ) {
+    	ret = &(darrayPOOL.arrayPOOL[darrayPOOL.poolCounter]);
+    	darrayPOOL.poolCounter++;
+    } else {
+    	ret = grib_darray_new(c, self->numberOfSubsets, self->numberOfSubsets);
+    }
     if (localWidth) {
         CHECK_END_DATA_RETURN(c, self, localWidth * self->numberOfSubsets, NULL);
         if (*err) {
             dval = GRIB_MISSING_DOUBLE;
             lval = 0;
             grib_context_log(c, GRIB_LOG_DEBUG, " modifiedWidth=%ld lval=%ld dval=%g", modifiedWidth, lval, dval);
-            ret = grib_darray_new(c, DYN_ARRAY_SIZE_INIT, DYN_ARRAY_SIZE_INCR);
+            ret = grib_darray_new(c, DYN_DEFAULT_DARRAY_SIZE_INIT, DYN_DEFAULT_DARRAY_SIZE_INCR);
             grib_darray_push(c, ret, dval);
             *err = 0;
             return ret;
@@ -717,7 +734,8 @@ static int encode_string_array(grib_context* c, grib_buffer* buff, long* pos, bu
         ival = 0;
     }
     else {
-        ival = self->iss_list->v[0];
+        /*ival = self->iss_list->v[0];*/
+        ival = grib_iarray_get(self->iss_list, 0);
     }
 
     if (n > grib_sarray_used_size(stringValues))
@@ -726,7 +744,8 @@ static int encode_string_array(grib_context* c, grib_buffer* buff, long* pos, bu
     modifiedWidth = bd->width;
 
     grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + modifiedWidth);
-    grib_encode_string(buff->data, pos, modifiedWidth / 8, stringValues->v[ival]);
+    /* grib_encode_string(buff->data, pos, modifiedWidth / 8, stringValues->dynA[ival]); */
+    grib_encode_string(buff->data, pos, modifiedWidth / 8, grib_sarray_get(stringValues,ival) );
     width = n > 1 ? modifiedWidth : 0;
 
     grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + 6);
@@ -734,8 +753,10 @@ static int encode_string_array(grib_context* c, grib_buffer* buff, long* pos, bu
     if (width) {
         grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + width * n);
         for (j = 0; j < n; j++) {
-            k = self->iss_list->v[j];
-            grib_encode_string(buff->data, pos, width / 8, stringValues->v[k]);
+            /*k = self->iss_list->v[j];*/
+            k = grib_iarray_get(self->iss_list, j);
+            /* grib_encode_string(buff->data, pos, width / 8, stringValues->dynA[k]); */
+            grib_encode_string(buff->data, pos, width / 8, grib_sarray_get(stringValues,k) );
         }
     }
     return err;
@@ -745,8 +766,10 @@ static void set_missing_long_to_double(grib_darray* dvalues)
 {
     size_t i, n = grib_darray_used_size(dvalues);
     for (i = 0; i < n; i++) {
-        if (dvalues->v[i] == GRIB_MISSING_LONG)
-            dvalues->v[i] = GRIB_MISSING_DOUBLE;
+        /*if (dvalues->v[i] == GRIB_MISSING_LONG)*/
+        /*    dvalues->v[i] = GRIB_MISSING_DOUBLE;*/
+        if ( grib_darray_get(dvalues, i) == GRIB_MISSING_LONG)
+        	grib_darray_put(dvalues, i, GRIB_MISSING_DOUBLE);
     }
 }
 
@@ -775,7 +798,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
     size_t ii, index_of_min, index_of_max;
     int nvals  = 0;
     double min = 0, max = 0, maxAllowed, minAllowed;
-    double* v           = NULL;
+    double* v           = NULL; /* ATTEMPT: double value              = 0.0; double* dvaluesPtr  = NULL;*/
     double* values      = NULL;
     int thereIsAMissing = 0;
     int is_constant;
@@ -801,32 +824,32 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
 
     set_missing_long_to_double(dvalues);
 
-    v = dvalues->v;
+    v = grib_darray_get_arrays_by_reference(dvalues);/* ATTEMPT: v = dvalues->v; value = grib_darray_get(dvalues,0);  */
 
     /* is constant */
     if (grib_darray_is_constant(dvalues, modifiedFactor * .5)) {
         localWidth = 0;
         grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + modifiedWidth);
-        if (*v == GRIB_MISSING_DOUBLE) {
+        if (*v == GRIB_MISSING_DOUBLE) { /* ATTEMPT: if (value == GRIB_MISSING_DOUBLE)  */
             grib_set_bits_on(buff->data, pos, modifiedWidth);
         }
         else {
-            if (*v > maxAllowed || *v < minAllowed) {
+        	if (*v > maxAllowed || *v < minAllowed) { /* ATTEMPT: if (value > maxAllowed || value < minAllowed)  */
                 if (dont_fail_if_out_of_range) {
                     fprintf(stderr,
                             "ECCODES WARNING :  encode_double_array: %s. Value (%g) out of range (minAllowed=%g, maxAllowed=%g)."
                             " Setting it to missing value\n",
-                            bd->shortName, *v, minAllowed, maxAllowed);
+							bd->shortName, *v, minAllowed, maxAllowed); /* ATTEMPT: bd->shortName, value, minAllowed, maxAllowed); */
                     grib_set_bits_on(buff->data, pos, modifiedWidth);
                 }
                 else {
                     grib_context_log(c, GRIB_LOG_ERROR, "encode_double_array: %s. Value (%g) out of range (minAllowed=%g, maxAllowed=%g).",
-                                     bd->shortName, *v, minAllowed, maxAllowed);
+                    		bd->shortName, *v, minAllowed, maxAllowed); /* ATTEMPT: bd->shortName, value, minAllowed, maxAllowed); */
                     return GRIB_OUT_OF_RANGE; /* ECC-611 */
                 }
             }
             else {
-                lval = round(*v * inverseFactor) - modifiedReference;
+            	lval = round(*v * inverseFactor) - modifiedReference; /* ATTEMPT: lval = round(value * inverseFactor) - modifiedReference; */
                 grib_encode_size_tb(buff->data, lval, pos, modifiedWidth);
             }
         }
@@ -838,14 +861,14 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
     if (nvals > grib_darray_used_size(dvalues))
         return GRIB_ARRAY_TOO_SMALL;
     values      = (double*)grib_context_malloc_clear(c, sizeof(double) * nvals);
-    val0        = dvalues->v[self->iss_list->v[0]];
+    val0              = grib_darray_get(dvalues, (size_t)(grib_iarray_get(self->iss_list, 0)) ); /* ORIGINAL: val0        = dvalues->v[self->iss_list->v[0]]; */
     is_constant = 1;
     for (i = 0; i < nvals; i++) {
-        values[i] = dvalues->v[self->iss_list->v[i]];
+    	values[i] = grib_darray_get(dvalues, grib_iarray_get(self->iss_list, i)); /* ORIGINAL: values[i] = dvalues->v[self->iss_list->v[i]]; */
         if (val0 != values[i])
             is_constant = 0;
     }
-    v = values;
+    v = values; /*ATTEMPT: dvaluesPtr = values;*/
 
     /* encoding a range with constant values*/
     if (is_constant == 1) {
@@ -855,7 +878,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
             grib_set_bits_on(buff->data, pos, modifiedWidth);
         }
         else {
-            lval = round(*v * inverseFactor) - modifiedReference;
+        	lval = round(*v * inverseFactor) - modifiedReference;
             grib_encode_size_tb(buff->data, lval, pos, modifiedWidth);
         }
         grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + 6);
@@ -873,15 +896,15 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
     if (dont_fail_if_out_of_range) {
         while (ii < nvals) {
             /* Turn out-of-range values into 'missing' */
-            if (*v != GRIB_MISSING_DOUBLE && (*v < minAllowed || *v > maxAllowed)) {
+        	if (*v != GRIB_MISSING_DOUBLE && (*v < minAllowed || *v > maxAllowed)) {
                 fprintf(stderr,
                         "ECCODES WARNING :  encode_double_array: %s. Value at index %ld (%g) out of range (minAllowed=%g, maxAllowed=%g)."
                         " Setting it to missing value\n",
-                        bd->shortName, (long)ii, *v, minAllowed, maxAllowed);
+						bd->shortName, (long)ii, *v, minAllowed, maxAllowed);
                 *v = GRIB_MISSING_DOUBLE;
             }
             ii++;
-            v++;
+            *v = GRIB_MISSING_DOUBLE;
         }
     }
     /* Determine min and max values. */
@@ -895,17 +918,17 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
     }
     ii           = 0;
     index_of_min = index_of_max = 0;
-    v                           = values;
+    v   = values;
     while (ii < nvals) {
-        if (*v < min && *v != GRIB_MISSING_DOUBLE) {
-            min          = *v;
+    	if (*v < min && *v != GRIB_MISSING_DOUBLE) {
+    		min          = *v;
             index_of_min = ii;
         }
-        if (*v > max && *v != GRIB_MISSING_DOUBLE) {
-            max          = *v;
+    	if (*v > max && *v != GRIB_MISSING_DOUBLE) {
+    		max          = *v;
             index_of_max = ii;
         }
-        if (*v == GRIB_MISSING_DOUBLE)
+    	if (*v == GRIB_MISSING_DOUBLE)
             thereIsAMissing = 1;
         ii++;
         v++;
@@ -1124,6 +1147,7 @@ static int decode_element(grib_context* c, grib_accessor_bufr_data_array* self, 
         if (self->compressedData) {
             err   = decode_string_array(c, data, pos, bd, self);
             index = grib_vsarray_used_size(self->stringValues);
+            /*dar   = grib_darray_new(c, self->numberOfSubsets, 10);*/
             dar   = grib_darray_new(c, self->numberOfSubsets, 10);
             index = self->numberOfSubsets * (index - 1);
             for (ii = 1; ii <= self->numberOfSubsets; ii++) {
@@ -1141,7 +1165,8 @@ static int decode_element(grib_context* c, grib_accessor_bufr_data_array* self, 
             stringValuesLen = grib_vsarray_used_size(self->stringValues);
             index           = 0;
             for (ii = 0; ii < stringValuesLen; ii++) {
-                index += grib_sarray_used_size(self->stringValues->v[ii]);
+                /*index += grib_sarray_used_size(self->stringValues->v[ii]);*/
+                index += grib_sarray_used_size( grib_vsarray_get (self->stringValues, ii) );
             }
             cdval = index * 1000 + bd->width / 8;
             grib_darray_push(c, dval, cdval);
@@ -1220,7 +1245,8 @@ static int decode_replication(grib_context* c, grib_accessor_bufr_data_array* se
         }
     }
     if (self->compressedData) {
-        dval = grib_darray_new(c, 1, 100);
+        /*dval = grib_darray_new(c, 1, 100);*/
+        dval = grib_darray_new(c, self->numberOfSubsets, self->numberOfSubsets);
         if (c->bufr_multi_element_constant_arrays) {
             long j;
             for (j = 0; j < self->numberOfSubsets; j++) {
@@ -1444,43 +1470,59 @@ static int encode_element(grib_context* c, grib_accessor_bufr_data_array* self, 
         /* grib_context_log(c, GRIB_LOG_DEBUG,"BUFR data encoding: \t %s = %s",
                  bd->shortName,csval); */
         if (self->compressedData) {
-            idx = ((int)self->numericValues->v[elementIndex]->v[0] / 1000 - 1) / self->numberOfSubsets;
-            err = encode_string_array(c, buff, pos, bd, self, self->stringValues->v[idx]);
+            /* idx = ((int)self->numericValues->v[elementIndex]->v[0] / 1000 - 1) / self->numberOfSubsets; */
+            /* idx = ((int) grib_darray_get ( self->numericValues->v[elementIndex], 0) / 1000 - 1) / self->numberOfSubsets; */
+            idx = (( ((int) grib_darray_get ( grib_vdarray_get (self->numericValues, elementIndex), 0)))/1000 - 1) / self->numberOfSubsets;
+            /*err = encode_string_array(c, buff, pos, bd, self, self->stringValues->v[idx]);*/
+            err = encode_string_array(c, buff, pos, bd, self, grib_vsarray_get ( self->stringValues, idx) );
         }
         else {
-            if (self->numericValues->v[subsetIndex] == NULL) {
-                grib_context_log(c, GRIB_LOG_ERROR, "Invalid subset index %d (number of subsets=%ld)", subsetIndex, self->numberOfSubsets);
+            /*if (self->numericValues->v[subsetIndex] == NULL) {*/
+            if (grib_vdarray_get (self->numericValues, subsetIndex) == NULL) {
+        		grib_context_log(c, GRIB_LOG_ERROR, "Invalid subset index %d (number of subsets=%ld)", subsetIndex, self->numberOfSubsets);
                 return GRIB_INVALID_ARGUMENT;
             }
-            idx = (int)self->numericValues->v[subsetIndex]->v[elementIndex] / 1000 - 1;
-            if (idx < 0 || idx >= self->stringValues->n) {
+            /*idx = (int)self->numericValues->v[subsetIndex]->v[elementIndex] / 1000 - 1;*/
+            /*idx = ( ( (int) grib_darray_get ( self->numericValues->v[subsetIndex], elementIndex) ) / 1000 ) -1;*/
+            idx = (((int) grib_darray_get ( grib_vdarray_get (self->numericValues, subsetIndex), elementIndex))/1000) -1;
+
+            if (idx < 0 || idx >= grib_vsarray_used_size(self->stringValues)) {
                 grib_context_log(c, GRIB_LOG_ERROR, "encode_element: %s: Invalid index %d", bd->shortName, idx);
                 return GRIB_INVALID_ARGUMENT;
             }
-            err = encode_string_value(c, buff, pos, bd, self, self->stringValues->v[idx]->v[0]);
+            /*err = encode_string_value(c, buff, pos, bd, self, self->stringValues->v[idx]->v[0]);*/
+            err = encode_string_value(c, buff, pos, bd, self, grib_sarray_get ( grib_vsarray_get ( self->stringValues, idx), 0));
         }
     }
     else {
         /* numeric or codetable or flagtable */
         if (self->compressedData) {
-            err = encode_double_array(c, buff, pos, bd, self, self->numericValues->v[elementIndex]);
+            /*err = encode_double_array(c, buff, pos, bd, self, self->numericValues->v[elementIndex]);*/
+            err = encode_double_array(c, buff, pos, bd, self,  grib_vdarray_get (self->numericValues, elementIndex)   );
             if (err) {
                 grib_context_log(c, GRIB_LOG_ERROR, "encoding %s ( code=%6.6ld width=%ld scale=%ld reference=%ld )",
                                  bd->shortName, bd->code, bd->width,
                                  bd->scale, bd->reference);
-                for (j = 0; j < grib_darray_used_size(self->numericValues->v[elementIndex]); j++)
-                    grib_context_log(c, GRIB_LOG_ERROR, "value[%d]\t= %g", j, self->numericValues->v[elementIndex]->v[j]);
+                /*for (j = 0; j < grib_darray_used_size(self->numericValues->v[elementIndex]); j++)*/
+                for (j = 0; j < grib_darray_used_size( grib_vdarray_get (self->numericValues, elementIndex) ); j++)
+                	/*grib_context_log(c, GRIB_LOG_ERROR, "value[%d]\t= %g", j, self->numericValues->v[elementIndex]->v[j]);*/
+                	/*grib_context_log(c, GRIB_LOG_ERROR, "value[%d]\t= %g", j, grib_darray_get (self->numericValues->v[elementIndex], j) );*/
+                	grib_context_log(c, GRIB_LOG_ERROR, "value[%d]\t= %g", j, grib_darray_get (grib_vdarray_get (self->numericValues, elementIndex), j) );
             }
         }
         else {
-            if (self->numericValues->v[subsetIndex] == NULL) {
+        	/*if (self->numericValues->v[subsetIndex] == NULL) {*/
+            if ( grib_vdarray_get (self->numericValues, subsetIndex) == NULL) {
                 grib_context_log(c, GRIB_LOG_ERROR, "Invalid subset index %d (number of subsets=%ld)", subsetIndex, self->numberOfSubsets);
                 return GRIB_INVALID_ARGUMENT;
             }
-            err = encode_double_value(c, buff, pos, bd, self, self->numericValues->v[subsetIndex]->v[elementIndex]);
+            /*err = encode_double_value(c, buff, pos, bd, self, self->numericValues->v[subsetIndex]->v[elementIndex]);*/
+            err = encode_double_value(c, buff, pos, bd, self, grib_darray_get ( grib_vdarray_get (self->numericValues, subsetIndex) , elementIndex) );
+
             if (err) {
                 grib_context_log(c, GRIB_LOG_ERROR, "Cannot encode %s=%g (subset=%d)", /*subsetIndex starts from 0*/
-                                 bd->shortName, self->numericValues->v[subsetIndex]->v[elementIndex], subsetIndex + 1);
+                			bd->shortName, grib_darray_get( grib_vdarray_get (self->numericValues, subsetIndex), elementIndex ), subsetIndex + 1);
+                                /* bd->shortName, self->numericValues->v[subsetIndex]->v[elementIndex], subsetIndex + 1);*/
             }
         }
     }
@@ -1492,11 +1534,16 @@ static int encode_replication(grib_context* c, grib_accessor_bufr_data_array* se
 {
     /* Assert( buff->data == data); */
     if (self->compressedData) {
-        DebugAssert(grib_darray_used_size(self->numericValues->v[elementIndex]) == 1);
-        *numberOfRepetitions = self->numericValues->v[elementIndex]->v[0];
+        /* DebugAssert(grib_darray_used_size(self->numericValues->v[elementIndex]) == 1); */
+        DebugAssert(grib_darray_used_size(grib_vdarray_get (self->numericValues, elementIndex)) == 1);
+        /* *numberOfRepetitions = self->numericValues->v[elementIndex]->v[0]; */
+        /* *numberOfRepetitions = grib_darray_get (self->numericValues->v[elementIndex], 0); */
+        *numberOfRepetitions = grib_darray_get (grib_vdarray_get (self->numericValues, elementIndex), 0);
     }
     else {
-        *numberOfRepetitions = self->numericValues->v[subsetIndex]->v[elementIndex];
+        /* *numberOfRepetitions = self->numericValues->v[subsetIndex]->v[elementIndex]; */
+        /* *numberOfRepetitions = grib_darray_get (self->numericValues->v[subsetIndex], elementIndex); */
+        *numberOfRepetitions = grib_darray_get (grib_vdarray_get (self->numericValues, subsetIndex), elementIndex);
     }
 
     return encode_element(c, self, subsetIndex, buff, data, pos, i, 0, elementIndex, dval, 0);
@@ -1510,7 +1557,8 @@ static int build_bitmap(grib_accessor_bufr_data_array* self, unsigned char* data
     grib_accessor* a              = (grib_accessor*)self;
     grib_context* c               = a->context;
     bufr_descriptor** descriptors = self->expanded->v;
-    long* edi                     = elementsDescriptorsIndex->v;
+    /* long* edi                     = elementsDescriptorsIndex->v; */
+    long descriptorVal = NULL;
     /* int iel=grib_iarray_used_size(elementsDescriptorsIndex)-1; */
     int err = 0;
 
@@ -1522,11 +1570,14 @@ static int build_bitmap(grib_accessor_bufr_data_array* self, unsigned char* data
             if (iel < 0) {
                 return GRIB_ENCODING_ERROR;
             }
-            while (descriptors[edi[iel]]->code >= 100000 || iel == 0) {
+            descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+            /* while (descriptors[edi[iel]]->code >= 100000 || iel == 0) { */
+            while (descriptors[descriptorVal]->code >= 100000 || iel == 0) {
                 iel--;
                 if (iel < 0) {
                     return GRIB_ENCODING_ERROR;
                 }
+                descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
             }
             bitmapEndElementsDescriptorsIndex = iel;
             /*looking for another bitmap and pointing before it.
@@ -1534,11 +1585,17 @@ static int build_bitmap(grib_accessor_bufr_data_array* self, unsigned char* data
           ECC-243
          */
             while (iel > 0) {
-                while (descriptors[edi[iel]]->code != 236000 && descriptors[edi[iel]]->code != 222000 && descriptors[edi[iel]]->code != 223000 && iel != 0)
+            	descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                /* while (descriptors[edi[iel]]->code != 236000 && descriptors[edi[iel]]->code != 222000 && descriptors[edi[iel]]->code != 223000 && iel != 0) */
+                while (descriptors[descriptorVal]->code != 236000 && descriptors[descriptorVal]->code != 222000 && descriptors[descriptorVal]->code != 223000 && iel != 0)
                     iel--;
                 if (iel != 0) {
-                    while (descriptors[edi[iel]]->code >= 100000 && iel != 0)
+                	descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                    /* while (descriptors[edi[iel]]->code >= 100000 && iel != 0) */
+                    while (descriptors[descriptorVal]->code >= 100000 && iel != 0) {
                         iel--;
+                        descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                    }
                     bitmapEndElementsDescriptorsIndex = iel;
                 }
             }
@@ -1584,7 +1641,9 @@ static int build_bitmap(grib_accessor_bufr_data_array* self, unsigned char* data
             iel = bitmapEndElementsDescriptorsIndex;
             n   = bitmapSize - 1;
             while (n > 0 && iel >= 0) {
-                if (descriptors[edi[iel]]->code < 100000)
+            	descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                /* if (descriptors[edi[iel]]->code < 100000) */
+                if (descriptors[descriptorVal]->code < 100000)
                     n--;
                 iel--;
             }
@@ -1638,20 +1697,26 @@ static int build_bitmap_new_data(grib_accessor_bufr_data_array* self, unsigned c
     grib_accessor* a              = (grib_accessor*)self;
     grib_context* c               = a->context;
     bufr_descriptor** descriptors = self->expanded->v;
-    long* edi                     = elementsDescriptorsIndex->v;
+    /*long* edi                     = elementsDescriptorsIndex->v;*/
+    long descriptorVal = NULL;
 
     switch (descriptors[iBitmapOperator]->code) {
         case 222000:
         case 223000:
         case 236000:
+
             if (iel < 0) {
                 return GRIB_ENCODING_ERROR;
             }
-            while (descriptors[edi[iel]]->code >= 100000) {
+
+            descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+            /* while (descriptors[edi[iel]]->code >= 100000) { */
+            while (descriptors[descriptorVal]->code >= 100000) {
                 iel--;
                 if (iel < 0) {
                     return GRIB_ENCODING_ERROR;
                 }
+                descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
             }
             bitmapEndElementsDescriptorsIndex = iel;
             /*looking for another bitmap and pointing before it.
@@ -1659,11 +1724,16 @@ static int build_bitmap_new_data(grib_accessor_bufr_data_array* self, unsigned c
           ECC-243
          */
             while (iel > 0) {
-                while (descriptors[edi[iel]]->code != 236000 && descriptors[edi[iel]]->code != 222000 && descriptors[edi[iel]]->code != 223000 && iel != 0)
+            	descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                /* while (descriptors[edi[iel]]->code != 236000 && descriptors[edi[iel]]->code != 222000 && descriptors[edi[iel]]->code != 223000 && iel != 0) */
+                while (descriptors[descriptorVal]->code != 236000 && descriptors[descriptorVal]->code != 222000 && descriptors[descriptorVal]->code != 223000 && iel != 0)
                     iel--;
                 if (iel != 0) {
-                    while (descriptors[edi[iel]]->code >= 100000 && iel != 0)
+                	descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                    while (descriptors[descriptorVal]->code >= 100000 && iel != 0){
                         iel--;
+                        descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                    }
                     bitmapEndElementsDescriptorsIndex = iel;
                 }
             }
@@ -1700,7 +1770,9 @@ static int build_bitmap_new_data(grib_accessor_bufr_data_array* self, unsigned c
             iel = bitmapEndElementsDescriptorsIndex;
             n   = bitmapSize - 1;
             while (n > 0 && iel >= 0) {
-                if (descriptors[edi[iel]]->code < 100000)
+            	descriptorVal = grib_iarray_get(elementsDescriptorsIndex,iel);
+                /* if (descriptors[edi[iel]]->code < 100000) */
+                if (descriptors[descriptorVal]->code < 100000)
                     n--;
                 iel--;
             }
@@ -1731,7 +1803,8 @@ static int get_next_bitmap_descriptor_index_new_bitmap(grib_accessor_bufr_data_a
         while (self->inputBitmap[i] == 1) {
             self->bitmapCurrent++;
             self->bitmapCurrentElementsDescriptorsIndex++;
-            while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000)
+            /* while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000) */
+            while (descriptors[ grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ]->code > 100000)
                 self->bitmapCurrentElementsDescriptorsIndex++;
             i++;
         }
@@ -1742,14 +1815,17 @@ static int get_next_bitmap_descriptor_index_new_bitmap(grib_accessor_bufr_data_a
         while (self->inputBitmap[i] == 1) {
             self->bitmapCurrent++;
             self->bitmapCurrentElementsDescriptorsIndex++;
-            while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000)
+            /* while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000) */
+            while (descriptors[ grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ]->code > 100000)
                 self->bitmapCurrentElementsDescriptorsIndex++;
             i++;
         }
     }
-    while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000)
+    /* while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000) */
+    while (descriptors[ grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ]->code > 100000)
         self->bitmapCurrentElementsDescriptorsIndex++;
-    return elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex];
+    /* return elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]; */
+    return grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ;
 }
 
 static int get_next_bitmap_descriptor_index(grib_accessor_bufr_data_array* self, grib_iarray* elementsDescriptorsIndex, grib_darray* numericValues)
@@ -1758,17 +1834,22 @@ static int get_next_bitmap_descriptor_index(grib_accessor_bufr_data_array* self,
     bufr_descriptor** descriptors = self->expanded->v;
 
     if (self->compressedData) {
-        if (self->numericValues->n == 0)
+        /* if (self->numericValues->n == 0) */
+        if (grib_vdarray_used_size (self->numericValues) == 0)
             return get_next_bitmap_descriptor_index_new_bitmap(self, elementsDescriptorsIndex, 1);
 
         self->bitmapCurrent++;
         self->bitmapCurrentElementsDescriptorsIndex++;
         i = self->bitmapCurrent + self->bitmapStart;
-        DebugAssert(i < self->numericValues->n);
-        while (self->numericValues->v[i]->v[0] == 1) {
+        /* DebugAssert(i < self->numericValues->n); */
+        DebugAssert(i < grib_vdarray_used_size (self->numericValues));
+        /* while (self->numericValues->v[i]->v[0] == 1) { */
+        /* while ( grib_darray_get (self->numericValues->v[i], 0) == 1) { */
+        while ( grib_darray_get (grib_vdarray_get (self->numericValues, i), 0) == 1) {
             self->bitmapCurrent++;
             self->bitmapCurrentElementsDescriptorsIndex++;
-            while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000)
+            /* while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000) */
+            while (descriptors[ grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ]->code > 100000)
                 self->bitmapCurrentElementsDescriptorsIndex++;
             i++;
         }
@@ -1780,18 +1861,23 @@ static int get_next_bitmap_descriptor_index(grib_accessor_bufr_data_array* self,
         self->bitmapCurrent++;
         self->bitmapCurrentElementsDescriptorsIndex++;
         i = self->bitmapCurrent + self->bitmapStart;
-        DebugAssert(i < numericValues->n);
-        while (numericValues->v[i] == 1) {
+        DebugAssert(i < grib_vdarray_used_size (self->numericValues));
+        /* while (numericValues->v[i] == 1) { */
+        while (	grib_darray_get(numericValues,i) == 1){
             self->bitmapCurrent++;
             self->bitmapCurrentElementsDescriptorsIndex++;
-            while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000)
+            /* while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000) */
+            while (descriptors[ grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ]->code > 100000)
                 self->bitmapCurrentElementsDescriptorsIndex++;
             i++;
         }
     }
-    while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000)
+    /* while (descriptors[elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]]->code > 100000) { */
+    while (descriptors [ grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ]->code > 100000) {
         self->bitmapCurrentElementsDescriptorsIndex++;
-    return elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex];
+    }
+    /* return elementsDescriptorsIndex->v[self->bitmapCurrentElementsDescriptorsIndex]; */
+    return grib_iarray_get(elementsDescriptorsIndex, self->bitmapCurrentElementsDescriptorsIndex) ;
 }
 
 static void push_zero_element(grib_accessor_bufr_data_array* self, grib_darray* dval)
@@ -1956,7 +2042,11 @@ static grib_accessor* create_accessor_from_descriptor(grib_accessor* a, grib_acc
         operatorCreator.flags |= GRIB_ACCESSOR_FLAG_DUMP;
     }
 
-    idx = self->compressedData ? self->elementsDescriptorsIndex->v[0]->v[ide] : self->elementsDescriptorsIndex->v[subset]->v[ide];
+    /*idx = self->compressedData ? self->elementsDescriptorsIndex->v[0]->v[ide] : self->elementsDescriptorsIndex->v[subset]->v[ide];*/
+	/*idx = self->compressedData ? (grib_iarray_get(self->elementsDescriptorsIndex->v[0],ide)) : (grib_iarray_get(self->elementsDescriptorsIndex->v[subset],ide));*/
+	idx = self->compressedData ?
+			(grib_iarray_get(  grib_viarray_get ( self->elementsDescriptorsIndex, 0),ide)) :
+			(grib_iarray_get( grib_viarray_get ( self->elementsDescriptorsIndex, subset),ide));
 
     switch (self->expanded->v[idx]->F) {
         case 0:
@@ -1972,8 +2062,8 @@ static grib_accessor* create_accessor_from_descriptor(grib_accessor* a, grib_acc
             accessor_bufr_data_element_set_index(elementAccessor, ide);
             accessor_bufr_data_element_set_descriptors(elementAccessor, self->expanded);
             accessor_bufr_data_element_set_elementsDescriptorsIndex(elementAccessor, self->elementsDescriptorsIndex);
-            accessor_bufr_data_element_set_numericValues(elementAccessor, self->numericValues);
-            accessor_bufr_data_element_set_stringValues(elementAccessor, self->stringValues);
+            accessor_bufr_data_element_set_numericValues(elementAccessor, self->numericValues );
+            accessor_bufr_data_element_set_stringValues(elementAccessor, self->stringValues );
             accessor_bufr_data_element_set_compressedData(elementAccessor, self->compressedData);
             accessor_bufr_data_element_set_type(elementAccessor, self->expanded->v[idx]->type);
             accessor_bufr_data_element_set_numberOfSubsets(elementAccessor, self->numberOfSubsets);
@@ -2036,7 +2126,7 @@ static grib_accessor* create_accessor_from_descriptor(grib_accessor* a, grib_acc
                 accessor_bufr_data_element_set_descriptors(elementAccessor, self->expanded);
                 accessor_bufr_data_element_set_elementsDescriptorsIndex(elementAccessor, self->elementsDescriptorsIndex);
                 accessor_bufr_data_element_set_numericValues(elementAccessor, self->numericValues);
-                accessor_bufr_data_element_set_stringValues(elementAccessor, self->stringValues);
+                accessor_bufr_data_element_set_stringValues(elementAccessor, self->stringValues );
                 accessor_bufr_data_element_set_compressedData(elementAccessor, self->compressedData);
                 accessor_bufr_data_element_set_type(elementAccessor, self->expanded->v[idx]->type);
                 accessor_bufr_data_element_set_numberOfSubsets(elementAccessor, self->numberOfSubsets);
@@ -2070,8 +2160,8 @@ static grib_accessor* create_accessor_from_descriptor(grib_accessor* a, grib_acc
             accessor_bufr_data_element_set_index(elementAccessor, ide);
             accessor_bufr_data_element_set_descriptors(elementAccessor, self->expanded);
             accessor_bufr_data_element_set_elementsDescriptorsIndex(elementAccessor, self->elementsDescriptorsIndex);
-            accessor_bufr_data_element_set_numericValues(elementAccessor, self->numericValues);
-            accessor_bufr_data_element_set_stringValues(elementAccessor, self->stringValues);
+            accessor_bufr_data_element_set_numericValues(elementAccessor, self->numericValues );
+            accessor_bufr_data_element_set_stringValues(elementAccessor, self->stringValues );
             accessor_bufr_data_element_set_compressedData(elementAccessor, self->compressedData);
             accessor_bufr_data_element_set_type(elementAccessor, self->expanded->v[idx]->type);
             accessor_bufr_data_element_set_numberOfSubsets(elementAccessor, self->numberOfSubsets);
@@ -2193,7 +2283,8 @@ static void grib_convert_to_attribute(grib_accessor* a)
 
 static grib_iarray* set_subset_list(grib_context* c, grib_accessor_bufr_data_array* self, long onlySubset, long startSubset, long endSubset, long* subsetList, size_t subsetListSize)
 {
-    grib_iarray* list = grib_iarray_new(c, self->numberOfSubsets, 10);
+    /*grib_iarray* list = grib_iarray_new(c, self->numberOfSubsets, 10);*/
+    grib_iarray* list = grib_iarray_new(c, self->numberOfSubsets, self->numberOfSubsets);
     long s;
 
     if (startSubset > 0) {
@@ -2450,7 +2541,8 @@ static int create_keys(grib_accessor* a, long onlySubset, long startSubset, long
         grib_sarray_delete(c, self->tempStrings);
         self->tempStrings = NULL;
     }
-    self->tempStrings = grib_sarray_new(c, self->numberOfSubsets, 500);
+    /* magic number 500 is not even documented anywhere... */
+    self->tempStrings = grib_sarray_new(c, self->numberOfSubsets, DYN_DEFAULT_SARRAY_SIZE_INCR);
 
     end         = self->compressedData ? 1 : self->numberOfSubsets;
     groupNumber = 1;
@@ -2477,7 +2569,9 @@ static int create_keys(grib_accessor* a, long onlySubset, long startSubset, long
     for (iss = 0; iss < end; iss++) {
         qualityPresent = 0;
         /*forceGroupClosure=0;*/
-        elementsInSubset = self->compressedData ? grib_iarray_used_size(self->elementsDescriptorsIndex->v[0]) : grib_iarray_used_size(self->elementsDescriptorsIndex->v[iss]);
+        /* elementsInSubset = self->compressedData ? grib_iarray_used_size(self->elementsDescriptorsIndex->v[0]) : grib_iarray_used_size(self->elementsDescriptorsIndex->v[iss]); */
+        elementsInSubset = self->compressedData ? (grib_iarray_used_size (grib_viarray_get(self->elementsDescriptorsIndex,0))) : (grib_iarray_used_size(grib_viarray_get(self->elementsDescriptorsIndex,iss)));
+
         /*if (associatedFieldAccessor) grib_accessor_delete(c, associatedFieldAccessor);*/
         associatedFieldAccessor = NULL;
         if (associatedFieldSignificanceAccessor) {
@@ -2485,7 +2579,11 @@ static int create_keys(grib_accessor* a, long onlySubset, long startSubset, long
             associatedFieldSignificanceAccessor = NULL;
         }
         for (ide = 0; ide < elementsInSubset; ide++) {
-            idx = self->compressedData ? self->elementsDescriptorsIndex->v[0]->v[ide] : self->elementsDescriptorsIndex->v[iss]->v[ide];
+            /* idx = self->compressedData ? self->elementsDescriptorsIndex->v[0]->v[ide] : self->elementsDescriptorsIndex->v[iss]->v[ide]; */
+            /* idx = self->compressedData ? (grib_iarray_get(self->elementsDescriptorsIndex->v[0],ide)) : (grib_iarray_get(self->elementsDescriptorsIndex->v[iss],ide)); */
+            idx = self->compressedData ?
+            		grib_iarray_get ( grib_viarray_get (self->elementsDescriptorsIndex, 0), ide) :
+					grib_iarray_get ( grib_viarray_get (self->elementsDescriptorsIndex, iss), ide);
 
             descriptor = self->expanded->v[idx];
             if (descriptor->nokey == 1) {
@@ -2880,19 +2978,24 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
     descriptors = self->expanded->v;
 
     if (do_clean == 1 && self->numericValues) {
-        grib_vdarray_delete_content(c, self->numericValues);
-        grib_vdarray_delete(c, self->numericValues);
-        grib_vsarray_delete_content(c, self->stringValues);
-        grib_vsarray_delete(c, self->stringValues);
+    /*if (do_clean == 1 && grib_vdarray_used_size(self->numericValues) ) { */
+        grib_vdarray_delete_content(c, self->numericValues );
+        grib_vdarray_delete(c, self->numericValues); /* grib_vdarray_free_dynamic(c, self->numericValues); */
+        grib_vsarray_delete_content(c, self->stringValues );
+        grib_vsarray_delete (c, self->stringValues ); /* grib_vsarray_free_dynamic(c, self->stringValues); */
     }
 
     if (flag != PROCESS_ENCODE) {
-        self->numericValues = grib_vdarray_new(c, 1000, 1000);
-        self->stringValues  = grib_vsarray_new(c, 10, 10);
+        /* self->numericValues = grib_vdarray_new(c, 1000, 1000); )*/
+        self->numericValues = grib_vdarray_new(c, DYN_DEFAULT_VDARRAY_SIZE_INIT, DYN_DEFAULT_VDARRAY_SIZE_INCR);
+        /* self->stringValues  = grib_vsarray_new(c, 10, 10); */
+        self->stringValues  = grib_vsarray_new(c, DYN_DEFAULT_VSARRAY_SIZE_INIT, DYN_DEFAULT_VSARRAY_SIZE_INCR);
 
-        if (self->elementsDescriptorsIndex)
-            grib_viarray_delete(c, self->elementsDescriptorsIndex);
-        self->elementsDescriptorsIndex = grib_viarray_new(c, 100, 100);
+    	if (self->elementsDescriptorsIndex) {
+    		grib_viarray_delete_content(c, self->elementsDescriptorsIndex);
+    		grib_viarray_delete(c, self->elementsDescriptorsIndex); /* grib_viarray_free_dynamic(c, self->elementsDescriptorsIndex); */
+    	}
+        self->elementsDescriptorsIndex = grib_viarray_new(c, DYN_DEFAULT_VIARRAY_SIZE_INIT, DYN_DEFAULT_VIARRAY_SIZE_INCR);
     }
 
     if (flag != PROCESS_DECODE) { /* Operator 203YYY: key OVERRIDDEN_REFERENCE_VALUES_KEY */
@@ -2925,7 +3028,8 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
     for (iiss = 0; iiss < end; iiss++) {
         icount = 1;
         if (self->compressedData == 0 && self->iss_list) {
-            iss = self->iss_list->v[iiss];
+            /* iss = self->iss_list->v[iiss]; */
+        	iss = grib_iarray_get(self->iss_list, iiss);
         }
         else {
             iss = iiss;
@@ -2935,18 +3039,20 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
         self->refValIndex = 0;
 
         if (flag != PROCESS_ENCODE) {
-            elementsDescriptorsIndex = grib_iarray_new(c, DYN_ARRAY_SIZE_INIT, DYN_ARRAY_SIZE_INCR);
+            elementsDescriptorsIndex = grib_iarray_new(c, DYN_DEFAULT_IARRAY_SIZE_INIT, DYN_DEFAULT_IARRAY_SIZE_INCR);
             if (!self->compressedData) {
-                dval = grib_darray_new(c, DYN_ARRAY_SIZE_INIT, DYN_ARRAY_SIZE_INCR);
-                /* sval=grib_sarray_new(c,10,10); */
+                dval = grib_darray_new(c, DYN_DEFAULT_DARRAY_SIZE_INIT, DYN_DEFAULT_DARRAY_SIZE_INCR);
+                /* THIS CODE WA ALREADY COMMENTED OUT IN THE ORIGINAL CODE sval=grib_sarray_new(c,10,10); */
             }
         }
         else {
-            if (self->elementsDescriptorsIndex == NULL) {
-                return GRIB_ENCODING_ERROR; /* See ECC-359 */
-            }
-            elementsDescriptorsIndex = self->elementsDescriptorsIndex->v[iss];
-            dval                     = self->numericValues->v[iss];
+            /* if (self->elementsDescriptorsIndex == NULL) { */
+                /*return GRIB_ENCODING_ERROR;*/ /* See ECC-359 */
+            /* } */
+            /* elementsDescriptorsIndex = self->elementsDescriptorsIndex->v[iss]; */
+            elementsDescriptorsIndex = grib_viarray_get(self->elementsDescriptorsIndex, iss);
+            /* dval                     = self->numericValues->v[iss]; */
+            dval                     = grib_vdarray_get(self->numericValues, iss);
         }
         elementIndex = 0;
 
@@ -2960,7 +3066,7 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
                     if (flag != PROCESS_ENCODE)
                         grib_iarray_push(elementsDescriptorsIndex, i);
                     if (descriptors[i]->code == 31031 && !is_bitmap_start_defined(self)) {
-                        /* self->bitmapStart=grib_iarray_used_size(elementsDescriptorsIndex)-1; */
+                        /* THIS CODE WA ALREADY COMMENTED OUT IN THE ORIGINAL CODE self->bitmapStart=grib_iarray_used_size(elementsDescriptorsIndex)-1; */
                         self->bitmapStart = elementIndex;
                     }
 
@@ -3117,7 +3223,7 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
                                 err   = codec_element(c, self, iss, buffer, data, &pos, index, 0, elementIndex, dval, sval);
                                 if (err)
                                     return err;
-                                /* self->expanded->v[index] */
+                                /* THIS CODE WA ALREADY COMMENTED OUT IN THE ORIGINAL CODE self->expanded->v[index] */
                                 if (flag != PROCESS_ENCODE)
                                     grib_iarray_push(elementsDescriptorsIndex, i);
                                 elementIndex++;
@@ -3137,7 +3243,7 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
                                 err   = codec_element(c, self, iss, buffer, data, &pos, index, 0, elementIndex, dval, sval);
                                 if (err)
                                     return err;
-                                /* self->expanded->v[index] */
+                                /* THIS CODE WA ALREADY COMMENTED OUT IN THE ORIGINAL CODE  self->expanded->v[index] */
                                 if (flag != PROCESS_ENCODE)
                                     grib_iarray_push(elementsDescriptorsIndex, i);
                                 elementIndex++;
@@ -3179,7 +3285,7 @@ static int process_elements(grib_accessor* a, int flag, long onlySubset, long st
                                 grib_bufr_descriptor_delete(bd);
                                 if (err)
                                     return err;
-                                /* self->expanded->v[index] */
+                                /* THIS CODE WA ALREADY COMMENTED OUT IN THE ORIGINAL CODE  self->expanded->v[index] */
                                 if (flag != PROCESS_ENCODE)
                                     grib_iarray_push(elementsDescriptorsIndex, i);
                                 elementIndex++;
@@ -3349,8 +3455,10 @@ static int value_count(grib_accessor* a, long* count)
     }
     else {
         *count = 0;
-        for (i = 0; i < self->numberOfSubsets; i++)
-            *count += grib_iarray_used_size(self->elementsDescriptorsIndex->v[i]);
+        for (i = 0; i < self->numberOfSubsets; i++) {
+            /* *count += grib_iarray_used_size(self->elementsDescriptorsIndex->v[i]); */
+            *count += grib_iarray_used_size( grib_viarray_get ( self->elementsDescriptorsIndex, i) );
+        }
     }
 
     return err;
@@ -3386,16 +3494,25 @@ static int unpack_double(grib_accessor* a, double* val, size_t* len)
         ii = 0;
         for (k = 0; k < numberOfSubsets; k++) {
             for (i = 0; i < l; i++) {
-                val[ii++] = self->numericValues->v[i]->n > 1 ? self->numericValues->v[i]->v[k] : self->numericValues->v[i]->v[0];
+            	/* val[ii++] = self->numericValues->v[i]->n > 1 ? self->numericValues->v[i]->v[k] : self->numericValues->v[i]->v[0]; */
+            	/* val[ii++] = self->numericValues->v[i]->n > 1 ?
+               		grib_darray_get (self->numericValues->v[i], k) :
+						grib_darray_get (self->numericValues->v[i], 0);*/
+            	val[ii++] = grib_darray_used_size(grib_vdarray_get (self->numericValues, i)) > 1 ?
+            	                		grib_darray_get (grib_vdarray_get (self->numericValues, i), k) :
+            							grib_darray_get (grib_vdarray_get (self->numericValues, i), 0);
             }
         }
     }
     else {
         ii = 0;
         for (k = 0; k < numberOfSubsets; k++) {
-            elementsInSubset = grib_iarray_used_size(self->elementsDescriptorsIndex->v[k]);
+            /* elementsInSubset = grib_iarray_used_size(self->elementsDescriptorsIndex->v[k]); */
+            elementsInSubset = grib_iarray_used_size( grib_viarray_get ( self->elementsDescriptorsIndex, k) );
             for (i = 0; i < elementsInSubset; i++) {
-                val[ii++] = self->numericValues->v[k]->v[i];
+                /* val[ii++] = self->numericValues->v[k]->v[i]; */
+                /* val[ii++] = grib_darray_get (self->numericValues->v[k], i); */
+                val[ii++] = grib_darray_get (grib_vdarray_get (self->numericValues, k), i);
             }
         }
     }

--- a/src/grib_accessor_class_bufr_extract_area_subsets.c
+++ b/src/grib_accessor_class_bufr_extract_area_subsets.c
@@ -323,7 +323,7 @@ static int select_area(grib_accessor* a)
 
     grib_context_free(c, lat);
     grib_context_free(c, lon);
-    grib_iarray_delete(subsets);
+    grib_iarray_delete(subsets); /* CSGMB: deallocate array after the set ? */
     subsets = 0;
 
     return ret;

--- a/src/grib_accessor_class_bufr_extract_datetime_subsets.c
+++ b/src/grib_accessor_class_bufr_extract_datetime_subsets.c
@@ -457,7 +457,7 @@ static int select_datetime(grib_accessor* a)
     grib_context_free(c, hour);
     grib_context_free(c, minute);
     grib_context_free(c, second);
-    grib_iarray_delete(subsets);
+    grib_iarray_delete(subsets); /* CSGMB: deallocate array after the set ? */
     subsets = 0;
 
     return ret;

--- a/src/grib_accessor_class_bufr_string_values.c
+++ b/src/grib_accessor_class_bufr_string_values.c
@@ -14,6 +14,11 @@
    Expanded descriptors cannot contain sequences and only delayed replication
    can appear
 */
+/***************************************************************************
+ *
+ *   Modified for Performance Study by: CS GMBH
+ *
+ ***************************************************************************/
 
 #include "grib_api_internal.h"
 /*
@@ -188,14 +193,16 @@ static int unpack_string_array(grib_accessor* a, char** buffer, size_t* len)
 
     tl = 0;
     for (j = 0; j < n; j++) {
-        l = grib_sarray_used_size(stringValues->v[j]);
+        /* l = grib_sarray_used_size(stringValues->v[j]); */
+        l = grib_sarray_used_size(grib_vsarray_get (stringValues, j) );
         tl += l;
 
         if (tl > *len)
             return GRIB_ARRAY_TOO_SMALL;
 
         for (i = 0; i < l; i++) {
-            *(b++) = grib_context_strdup(c, stringValues->v[j]->v[i]);
+            /* *(b++) = grib_context_strdup(c, stringValues->v[j]->v[i]); */
+        	*(b++) = grib_context_strdup(c, grib_sarray_get (  grib_vsarray_get (stringValues, j), i)  );
         }
     }
     *len = tl;

--- a/src/grib_accessor_class_hash_array.c
+++ b/src/grib_accessor_class_hash_array.c
@@ -11,6 +11,7 @@
 
 /*******************************************************
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  ******************************************************/
 
 #include "grib_api_internal.h"
@@ -251,7 +252,8 @@ static int unpack_long(grib_accessor* a, long* val, size_t* len)
             }
             *len = self->ha->iarray->n;
             for (i = 0; i < *len; i++)
-                val[i] = self->ha->iarray->v[i];
+                /* val[i] = self->ha->iarray->v[i]; */
+            	val[i] = grib_iarray_get (self->ha->iarray, i );
             break;
 
         default:

--- a/src/grib_accessor_class_long_vector.c
+++ b/src/grib_accessor_class_long_vector.c
@@ -10,6 +10,7 @@
 
 /**************************************
  *  Enrico Fucile
+ *  Modified for Performance Study by: CS GMBH
  **************************************/
 
 

--- a/src/grib_accessor_class_transient_darray.c
+++ b/src/grib_accessor_class_transient_darray.c
@@ -8,6 +8,9 @@
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
  */
 
+/*******************************************************
+ *   Modified for Performance Study by: CS GMBH
+ ******************************************************/
 #include "grib_api_internal.h"
 
 /*
@@ -196,7 +199,8 @@ static int unpack_double(grib_accessor* a, double* val, size_t* len)
 
     *len = count;
     for (i = 0; i < *len; i++)
-        val[i] = self->arr->v[i];
+        /* val[i] = self->arr->v[i]; */
+    	val[i] = grib_darray_get ( self->arr, i );
 
 
     return GRIB_SUCCESS;
@@ -216,8 +220,8 @@ static int unpack_long(grib_accessor* a, long* val, size_t* len)
 
     *len = count;
     for (i = 0; i < *len; i++)
-        val[i] = (long)self->arr->v[i];
-
+        /* val[i] = (long)self->arr->v[i]; */
+    	val[i] = ( (long) (grib_darray_get ( self->arr, i )) );
 
     return GRIB_SUCCESS;
 }

--- a/src/grib_api.h
+++ b/src/grib_api.h
@@ -6,6 +6,8 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ * Modified for Performance Study by: CS GMBH
  */
 
 /*! \file grib_api.h
@@ -234,6 +236,12 @@ typedef struct grib_viarray grib_viarray;
 typedef struct bufr_descriptor bufr_descriptor;
 typedef struct bufr_descriptors_array bufr_descriptors_array;
 typedef struct bufr_descriptors_map_list bufr_descriptors_map_list;
+
+typedef struct grib_iarrayPOOL grib_iarrayPOOL;
+typedef struct grib_darrayPOOL grib_darrayPOOL;
+typedef struct grib_viarrayPOOL grib_viarrayPOOL;
+typedef struct grib_vdarrayPOOL grib_vdarrayPOOL;
+typedef struct grib_vsarrayPOOL grib_vsarrayPOOL;
 
 grib_fieldset* grib_fieldset_new_from_files(grib_context* c, char* filenames[], int nfiles, char** keys, int nkeys, const char* where_string, const char* order_by_string, int* err);
 void grib_fieldset_delete(grib_fieldset* set);

--- a/src/grib_api_internal.h
+++ b/src/grib_api_internal.h
@@ -6,6 +6,8 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ *   Modified for Performance Study by: CS GMBH
  */
 
 /**
@@ -728,69 +730,129 @@ typedef struct grib_trie_with_rank_list grib_trie_with_rank_list;
 typedef struct grib_trie_with_rank grib_trie_with_rank;
 typedef struct grib_itrie grib_itrie;
 
+#define DYN_DEFAULT_SARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_SARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_sarray
 {
-    char** v;
+    char * stA[DYN_DEFAULT_SARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    char** dynA;
 };
+
+#define DYN_DEFAULT_OARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_OARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_oarray
 {
-    void** v;
+    void* stA[DYN_DEFAULT_OARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    void** dynA;
 };
+
+#define DYN_DEFAULT_DARRAY_SIZE_INIT 500 /* Initial size for the double dynamic array */
+#define DYN_DEFAULT_DARRAY_SIZE_INCR 600 /* Increment size for the double dynamic array */
 
 struct grib_darray
 {
-    double* v;
+    double stA[DYN_DEFAULT_DARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    double* dynA;
 };
+
+#define DYN_DEFAULT_DARRAY_POOL_SIZE 1000
+
+struct grib_darrayPOOL
+{
+	grib_darray arrayPOOL[DYN_DEFAULT_DARRAY_POOL_SIZE];
+	int poolCounter;
+};
+
+#define DYN_DEFAULT_IARRAY_SIZE_INIT 5000
+#define DYN_DEFAULT_IARRAY_SIZE_INCR 6000
 
 struct grib_iarray
 {
-    long* v;
+	long stA[DYN_DEFAULT_IARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    size_t number_of_pop_front;
     grib_context* context;
+    long* dynA;
 };
+
+#define DYN_DEFAULT_IARRAY_POOL_SIZE 1000
+
+struct grib_iarrayPOOL
+{
+	grib_iarray arrayPOOL[DYN_DEFAULT_IARRAY_POOL_SIZE];
+	int poolCounter;
+};
+
+#define DYN_DEFAULT_VDARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_VDARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_vdarray
 {
-    grib_darray** v;
+    grib_darray* stA[DYN_DEFAULT_VDARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    grib_darray** dynA;
 };
+
+#define DYN_DEFAULT_VDARRAY_POOL_SIZE 10
+
+struct grib_vdarrayPOOL
+{
+	grib_vdarray arrayPOOL[DYN_DEFAULT_VDARRAY_POOL_SIZE];
+	int poolCounter;
+};
+
+#define DYN_DEFAULT_VSARRAY_SIZE_INIT 500 /* Initial size for the dynamic array */
+#define DYN_DEFAULT_VSARRAY_SIZE_INCR 600 /* Increment size for the dynamic array */
 
 struct grib_vsarray
 {
-    grib_sarray** v;
+    grib_sarray* stA[DYN_DEFAULT_VSARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    grib_sarray** dynA;
 };
+
+#define DYN_DEFAULT_VSARRAY_POOL_SIZE 10
+
+struct grib_vsarrayPOOL
+{
+	grib_vsarray arrayPOOL[DYN_DEFAULT_VSARRAY_POOL_SIZE];
+	int poolCounter;
+};
+
+#define DYN_DEFAULT_VIARRAY_SIZE_INIT 500 /* Initial size for the dynamic array VIARRAY */
+#define DYN_DEFAULT_VIARRAY_SIZE_INCR 600 /* Increment size for the dynamic array VIARRAY */
 
 struct grib_viarray
 {
-    grib_iarray** v;
+	grib_iarray* stA[DYN_DEFAULT_VIARRAY_SIZE_INIT];
     size_t size;
     size_t n;
     size_t incsize;
-    grib_context* context;
+    grib_iarray** dynA;
+};
+
+#define DYN_DEFAULT_VIARRAY_POOL_SIZE 10
+
+struct grib_viarrayPOOL
+{
+	grib_viarray arrayPOOL[DYN_DEFAULT_VIARRAY_POOL_SIZE];
+	int poolCounter;
 };
 
 /* types of BUFR descriptors used in bufr_descriptor->type*/

--- a/src/grib_api_prototypes.h
+++ b/src/grib_api_prototypes.h
@@ -1,4 +1,14 @@
-
+/*
+ * (C) Copyright 2005- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+ * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ *   Modified for Performance Study by: CS GMBH
+ */
 /* action.c */
 void grib_dump(grib_action* a, FILE* f, int l);
 void grib_xref(grib_action* a, FILE* f, const char* path);
@@ -80,7 +90,7 @@ grib_action* grib_action_create_set(grib_context* context, const char* name, gri
 grib_action* grib_action_create_set_darray(grib_context* context, const char* name, grib_darray* darray);
 
 /* action_class_set_iarray.c */
-grib_action* grib_action_create_set_iarray(grib_context* context, const char* name, grib_iarray* iarray);
+grib_action* grib_action_create_set_iarray(grib_context* context, const char* name, grib_iarray* source);
 
 /* action_class_set_sarray.c */
 grib_action* grib_action_create_set_sarray(grib_context* context, const char* name, grib_sarray* sarray);
@@ -162,7 +172,7 @@ void grib_accessors_list_delete(grib_context* c, grib_accessors_list* al);
 /* grib_concept.c */
 grib_concept_value* grib_concept_value_new(grib_context* c, const char* name, grib_concept_condition* conditions);
 void grib_concept_value_delete(grib_context* c, grib_concept_value* v);
-grib_concept_condition* grib_concept_condition_new(grib_context* c, const char* name, grib_expression* expression, grib_iarray* iarray);
+grib_concept_condition* grib_concept_condition_new(grib_context* c, const char* name, grib_expression* expression, grib_iarray* source);
 void grib_concept_condition_delete(grib_context* c, grib_concept_condition* v);
 
 /* grib_hash_array.c */
@@ -197,20 +207,30 @@ bufr_descriptor** grib_bufr_descriptors_array_get_array(bufr_descriptors_array* 
 size_t grib_bufr_descriptors_array_used_size(bufr_descriptors_array* v);
 
 /* grib_darray.c */
-void grib_darray_print(const char* title, const grib_darray* darray);
+void grib_darray_print(const char* title, const grib_darray* source);
+void grib_darray_completePrint (const grib_darray* source);
+int grib_darray_init(grib_darray* source);
+void grib_darray_free_dynamic ( grib_darray* source);
 grib_darray* grib_darray_new_from_array(grib_context* c, double* a, size_t size);
 grib_darray* grib_darray_new(grib_context* c, size_t size, size_t incsize);
-grib_darray* grib_darray_resize(grib_context* c, grib_darray* v);
-grib_darray* grib_darray_push(grib_context* c, grib_darray* v, double val);
+grib_darray* grib_darray_resize(grib_context* c, grib_darray* source);
+void darrayPoolInit();
+grib_darray* grib_darray_push(grib_context* c, grib_darray* source, double val);
+double grib_darray_get(const grib_darray* source, size_t index);
+double* grib_darray_get_arrays_by_reference(grib_darray* source);
+int grib_darray_put (grib_darray* source, size_t index, double val);
 void grib_darray_delete(grib_context* c, grib_darray* v);
-double* grib_darray_get_array(grib_context* c, grib_darray* v);
-int grib_darray_is_constant(grib_darray* v, double eps);
-size_t grib_darray_used_size(grib_darray* v);
+double* grib_darray_get_array( grib_context* c, const grib_darray* source);
+int grib_darray_is_constant(const grib_darray* source, double eps);
+size_t grib_darray_used_size(const grib_darray* source);
 
 /* grib_sarray.c */
 grib_sarray* grib_sarray_new(grib_context* c, size_t size, size_t incsize);
 grib_sarray* grib_sarray_resize(grib_context* c, grib_sarray* v);
 grib_sarray* grib_sarray_push(grib_context* c, grib_sarray* v, char* val);
+char* grib_sarray_get(const grib_sarray* source, size_t index);
+char** grib_sarray_get_arrays_by_reference(const grib_sarray* source);
+int grib_sarray_put (grib_sarray* source, size_t index, char* val);
 void grib_sarray_delete(grib_context* c, grib_sarray* v);
 void grib_sarray_delete_content(grib_context* c, grib_sarray* v);
 char** grib_sarray_get_array(grib_context* c, grib_sarray* v);
@@ -218,56 +238,64 @@ size_t grib_sarray_used_size(grib_sarray* v);
 
 /* grib_oarray.c */
 grib_oarray* grib_oarray_new(grib_context* c, size_t size, size_t incsize);
-grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* v);
-grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* v, void* val);
-void grib_oarray_delete(grib_context* c, grib_oarray* v);
-void grib_oarray_delete_content(grib_context* c, grib_oarray* v);
-void** grib_oarray_get_array(grib_context* c, grib_oarray* v);
-void* grib_oarray_get(grib_oarray* v, int i);
-size_t grib_oarray_used_size(grib_oarray* v);
+grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* origin);
+grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* source, void* val);
+void* grib_oarray_get(const grib_oarray* source, size_t index);
+int grib_oarray_put (grib_oarray* source, size_t index, void* val);
+void grib_oarray_delete(grib_context* c, grib_oarray* source);
+void grib_oarray_delete_content(grib_context* c, grib_oarray* source);
+size_t grib_oarray_used_size(grib_oarray* source);
 
 /* grib_iarray.c */
-void grib_iarray_print(const char* title, const grib_iarray* iarray);
-grib_iarray* grib_iarray_new_from_array(grib_context* c, long* a, size_t size);
+void grib_iarray_print(const char* title, const grib_iarray* source);
 grib_iarray* grib_iarray_new(grib_context* c, size_t size, size_t incsize);
-long grib_iarray_pop(grib_iarray* a);
-long grib_iarray_pop_front(grib_iarray* a);
-grib_iarray* grib_iarray_resize_to(grib_iarray* v, size_t newsize);
-grib_iarray* grib_iarray_resize(grib_iarray* v);
-grib_iarray* grib_iarray_push(grib_iarray* v, long val);
-grib_iarray* grib_iarray_push_front(grib_iarray* v, long val);
-grib_iarray* grib_iarray_push_array(grib_iarray* v, long* val, size_t size);
-long grib_iarray_get(grib_iarray* a, size_t i);
-void grib_iarray_set(grib_iarray* a, size_t i, long v);
-void grib_iarray_delete(grib_iarray* v);
-void grib_iarray_delete_array(grib_iarray* v);
-long* grib_iarray_get_array(grib_iarray* v);
-size_t grib_iarray_used_size(grib_iarray* v);
-int grib_iarray_is_constant(grib_iarray* v);
+void iarrayPoolInit(grib_context* c);
+grib_iarray* grib_iarray_push(grib_iarray* source, long val);
+long grib_iarray_get(const grib_iarray* source, size_t index);
+void grib_iarray_delete(grib_iarray* source);
+long* grib_iarray_get_array(grib_iarray* source);
+size_t grib_iarray_used_size(grib_iarray* source);
+long* grib_iarray_get_arrays_by_reference(const grib_iarray* source);
 
 /* grib_vdarray.c */
-void grib_vdarray_print(const char* title, const grib_vdarray* vdarray);
+void grib_vdarray_print(const char* title, const grib_vdarray* source);
+void grib_vdarray_completePrint (const grib_vdarray* source);
+int grib_vdarray_init(grib_vdarray* source);
+void grib_vdarray_free_dynamic (grib_context* c,  grib_vdarray* source);
 grib_vdarray* grib_vdarray_new(grib_context* c, size_t size, size_t incsize);
 grib_vdarray* grib_vdarray_resize(grib_context* c, grib_vdarray* v);
+void vdarrayPoolInit();
 grib_vdarray* grib_vdarray_push(grib_context* c, grib_vdarray* v, grib_darray* val);
+grib_darray* grib_vdarray_get(const grib_vdarray* source, size_t index);
+int grib_vdarray_put (grib_vdarray* source, size_t index, grib_darray* val);
 void grib_vdarray_delete(grib_context* c, grib_vdarray* v);
 void grib_vdarray_delete_content(grib_context* c, grib_vdarray* v);
 grib_darray** grib_vdarray_get_array(grib_context* c, grib_vdarray* v);
 size_t grib_vdarray_used_size(grib_vdarray* v);
 
 /* grib_vsarray.c */
+int grib_vsarray_init(grib_vsarray* source);
+void grib_vsarray_free_dynamic (grib_context* c,  grib_vsarray* source);
 grib_vsarray* grib_vsarray_new(grib_context* c, size_t size, size_t incsize);
 grib_vsarray* grib_vsarray_resize(grib_context* c, grib_vsarray* v);
+void vsarrayPoolInit();
 grib_vsarray* grib_vsarray_push(grib_context* c, grib_vsarray* v, grib_sarray* val);
+grib_sarray* grib_vsarray_get(const grib_vsarray* source, size_t index);
+int grib_vsarray_put (grib_vsarray* source, size_t index, grib_sarray* val);
 void grib_vsarray_delete(grib_context* c, grib_vsarray* v);
 void grib_vsarray_delete_content(grib_context* c, grib_vsarray* v);
 grib_sarray** grib_vsarray_get_array(grib_context* c, grib_vsarray* v);
 size_t grib_vsarray_used_size(grib_vsarray* v);
 
 /* grib_viarray.c */
+void grib_viarray_print(const char* title, const grib_viarray* source);
+int grib_viarray_init(grib_viarray* source);
+void grib_viarray_free_dynamic (grib_context* c,  grib_viarray* source);
 grib_viarray* grib_viarray_new(grib_context* c, size_t size, size_t incsize);
 grib_viarray* grib_viarray_resize(grib_context* c, grib_viarray* v);
+void viarrayPoolInit();
 grib_viarray* grib_viarray_push(grib_context* c, grib_viarray* v, grib_iarray* val);
+grib_iarray* grib_viarray_get(const grib_viarray* source, size_t index);
 void grib_viarray_delete(grib_context* c, grib_viarray* v);
 void grib_viarray_delete_content(grib_context* c, grib_viarray* v);
 grib_iarray** grib_viarray_get_array(grib_context* c, grib_viarray* v);

--- a/src/grib_bufr_descriptors_array.c
+++ b/src/grib_bufr_descriptors_array.c
@@ -8,10 +8,14 @@
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
  */
 
+/***************************************************************************
+ *  Modified for Performance Study by: CS GMBH
+ ***************************************************************************/
+
 #include "grib_api_internal.h"
 
-#define DYN_ARRAY_SIZE_INIT 200 /* Initial size for grib_bufr_descriptors_array_new */
-#define DYN_ARRAY_SIZE_INCR 400 /* Increment size for the above */
+#define DYN_ARRAY_SIZE_INIT 1000 /* Initial size for grib_bufr_descriptors_array_new */
+#define DYN_ARRAY_SIZE_INCR 1200 /* Increment size for the above */
 
 bufr_descriptors_array* grib_bufr_descriptors_array_new(grib_context* c, size_t size, size_t incsize)
 {

--- a/src/grib_darray.c
+++ b/src/grib_darray.c
@@ -11,132 +11,348 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+extern grib_darrayPOOL darrayPOOL;
+
 /* For debugging purposes */
-void grib_darray_print(const char* title, const grib_darray* darray)
+void grib_darray_print(const char* title, const grib_darray* source)
 {
     size_t i;
-    Assert(darray);
-    printf("%s: darray.n=%lu  \t", title, (unsigned long)darray->n);
-    for (i = 0; i < darray->n; i++) {
-        printf("darray[%lu]=%g\t", (unsigned long)i, darray->v[i]);
+    Assert(source);
+    printf("grib_darray_print %s: darray.n=%lu  \t", title, (unsigned long)source->n);
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1)) {
+    		printf("darray[%lu]=%ld\t", (unsigned long)i, source->stA[i]);
+    	} else {
+    		printf("darray[%lu]=%ld\t", (unsigned long)i, source->dynA[(i-(DYN_DEFAULT_DARRAY_SIZE_INIT))]);
+    	}
     }
     printf("\n");
 }
 
-grib_darray* grib_darray_new_from_array(grib_context* c, double* a, size_t size)
+void grib_darray_completePrint (const grib_darray* source)
 {
-    size_t i;
-    grib_darray* v;
+    if(source) {
+	    size_t i;
 
-    if (!c)
-        c = grib_context_get_default();
+	    printf("grib_darray_completePrint static-array size: %d darray.size=%lu, darray.incsize=%lu, darray.n=%lu \n",
+		(unsigned long)DYN_DEFAULT_DARRAY_SIZE_INIT, (unsigned long)source->size, (unsigned long)source->incsize, (unsigned long)source->n);
 
-    v = grib_darray_new(c, size, 100);
-    for (i = 0; i < size; i++)
-        v->v[i] = a[i];
-    v->n       = size;
-    v->context = c;
-    return v;
+	    for (i = 0; i < source->n; i++) {
+	        printf("darray[%lu]=%g\n", (unsigned long)i, grib_darray_get (source, i ));
+	    }
+
+	    printf("static-array address: %p, dynamic array address: %p", source->stA, source->dynA);
+
+	    printf("\n---\n");
+    }
+}
+
+int grib_darray_init(grib_darray* source)
+{
+
+	if (!source)
+	{
+		return 0;
+	}
+
+	memset(source->stA,0,sizeof(double)*DYN_DEFAULT_DARRAY_SIZE_INIT);
+	source->size 				= DYN_DEFAULT_DARRAY_SIZE_INIT;
+	source->incsize             = DYN_DEFAULT_DARRAY_SIZE_INCR;
+	source->n					= 0;
+	source->dynA				= 0;
+
+	return 1;
+
+}
+
+void grib_darray_free_dynamic ( grib_darray* source)
+{
+    if (!source)
+        return;
+
+    if (source->dynA)
+        free(source->dynA);
+
+    /*free(source);*/
 }
 
 grib_darray* grib_darray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_darray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_darray*)grib_context_malloc_clear(c, sizeof(grib_darray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_darray_new unable to allocate %d bytes\n", sizeof(grib_darray));
-        return NULL;
-    }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (double*)grib_context_malloc_clear(c, sizeof(double) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_darray_new unable to allocate %d bytes\n", sizeof(double) * size);
-        return NULL;
-    }
-    return v;
-}
-
-grib_darray* grib_darray_resize(grib_context* c, grib_darray* v)
-{
-    int newsize = v->incsize + v->size;
+    grib_darray* result = NULL;
 
     if (!c)
         c = grib_context_get_default();
 
-    v->v    = (double*)grib_context_realloc(c, v->v, newsize * sizeof(double));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_darray_resize unable to allocate %d bytes\n", sizeof(double) * newsize);
-        return NULL;
+    result = (grib_darray*)grib_context_malloc_clear(c, sizeof(grib_darray));
+    if (!result) {
+    	grib_context_log(c, GRIB_LOG_ERROR,
+    			"grib_darray_new unable to allocate %d bytes\n", sizeof(grib_darray));
+    	return NULL;
     }
-    return v;
+
+    if(size > DYN_DEFAULT_DARRAY_SIZE_INIT) {
+
+    	result->dynA       = (double*)grib_context_malloc_clear(c, sizeof(double) * (size-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_darray_new unable to allocate %d bytes\n", sizeof(double) * (size-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+    		return NULL;
+    	}
+
+    	result->size    = size;
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_DARRAY_SIZE_INCR;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_DARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_DARRAY_SIZE_INCR;
+
+    }
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_darray* grib_darray_push(grib_context* c, grib_darray* v, double val)
+grib_darray* grib_darray_resize(grib_context* c, grib_darray* origin)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_darray_new(c, start_size, start_incsize);
+	int newsize;
 
-    if (v->n >= v->size)
-        v = grib_darray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	if (!origin)
+	{
+		return origin;
+	}
+
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA){
+
+		origin->dynA    = (double*)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) * sizeof(double));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_darray_resize unable to allocate %d bytes\n", sizeof(double) * (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (double*)grib_context_malloc(c, (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) * sizeof(double));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_darray_resize unable to allocate %d bytes\n", sizeof(double) * (newsize-DYN_DEFAULT_DARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-void grib_darray_delete(grib_context* c, grib_darray* v)
+void darrayPoolInit()
 {
-    if (!v)
+	int i;
+
+	for (i=0; i<DYN_DEFAULT_DARRAY_POOL_SIZE; i++) {
+		darrayPOOL.arrayPOOL[i].size=DYN_DEFAULT_DARRAY_SIZE_INIT;
+		darrayPOOL.arrayPOOL[i].n=0;
+		darrayPOOL.arrayPOOL[i].incsize=DYN_DEFAULT_DARRAY_SIZE_INCR;
+		darrayPOOL.arrayPOOL[i].dynA=0;
+		memset(darrayPOOL.arrayPOOL[i].stA,0,DYN_DEFAULT_DARRAY_SIZE_INIT);
+	}
+}
+
+grib_darray* grib_darray_push(grib_context* c, grib_darray* source, double val)
+{
+
+    size_t start_size    = DYN_DEFAULT_DARRAY_SIZE_INIT;
+    size_t start_incsize = DYN_DEFAULT_DARRAY_SIZE_INCR;
+
+    /*If the target is empty, initialize it*/
+    /*if (!source)
+        source = grib_darray_new(c, start_size, start_incsize);*/
+    if (!source) {
+    	if(darrayPOOL.poolCounter != (DYN_DEFAULT_DARRAY_POOL_SIZE - 1) ) {
+    		source = &(darrayPOOL.arrayPOOL[darrayPOOL.poolCounter]);
+    		darrayPOOL.poolCounter++;
+    	} else {
+    		source = grib_darray_new(0, start_size, start_incsize);
+    	}
+    }
+
+    /*If the actual used size of the target is equal to the allowed size, resize the array*/
+    if (source->n == source->size) {
+
+    	source = grib_darray_resize(c, source);
+
+    	/*Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!*/
+    	if (!source)
+    	{
+    		return source;
+    	}
+
+    	/*insertion in new allocated dynamic array*/
+    	source->dynA[ (source->n-(DYN_DEFAULT_DARRAY_SIZE_INIT)) ] = val;
+    	source->n++;
+    	return source;
+
+    }
+
+    /*insertion in static array*/
+    if (source->n <= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1) )
+    {
+    	source->stA[source->n] = val;
+    }
+    else {
+    	/*insertion in dynamic array*/
+    	source->dynA[ (source->n-(DYN_DEFAULT_DARRAY_SIZE_INIT)) ] = val;
+    }
+
+    source->n++;
+    return source;
+}
+
+/**
+ * Return the double value at index 'index' for grib_darray 'source'
+ */
+double grib_darray_get(const grib_darray* source, size_t index)
+{
+
+	if (!source)
+	    return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_DARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[(index-DYN_DEFAULT_DARRAY_SIZE_INIT)];
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * The method returns the array currently in use. If the given grib_darray structure pointer is null, it returns NULL.
+ */
+double* grib_darray_get_arrays_by_reference(grib_darray* source)
+{
+	if (!source)
+		return NULL;
+
+	/* return source->stA; */
+
+	/* PREVIOUS ATTEMPT */
+	if (source->n < DYN_DEFAULT_DARRAY_SIZE_INIT) {
+		return source->stA; /* stA is the static array */
+	} else {
+		if (source->dynA) {
+			return source->dynA; /* dynA is the dynamic array */
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * Sets the double value 'val' at index 'index' for grib_darray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_darray_put (grib_darray* source, size_t index, double val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_DARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA) {
+			source->dynA[(index-DYN_DEFAULT_DARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_darray_delete(grib_context* c, grib_darray* source)
+{
+    if (!source)
         return;
     if (!c)
         grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+
+    if (source->dynA)
+        grib_context_free(c, source->dynA);
+
+    grib_context_free(c, source);
 }
 
-double* grib_darray_get_array(grib_context* c, grib_darray* v)
+/**
+ * The method returns an array of double of size source->n containing all the values contained in the 'source' grib_darray, starting to copy from the static array 'sv' and then copying the dynamic array 'v'.
+ * Data in the result:
+ * 1. From index 0 until index (DYN_DEFAULT_DARRAY_SIZE_INIT -1), data located at the same index in source->sv;
+ * 2. From index DYN_DEFAULT_DARRAY_SIZE_INIT until ( source->n ), data located at index (index - DYN_DEFAULT_DARRAY_SIZE_INIT) in source->v;
+ */
+double* grib_darray_get_array(grib_context* c, const grib_darray* source)
 {
-    double* ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (double*)grib_context_malloc_clear(c, sizeof(double) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+	double* result;
+    size_t i;
+
+    result = (double*)grib_context_malloc_clear(c, sizeof(double) * source->n);
+
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1)) {
+    		result[i] = source->stA[i];
+    	} else {
+    		result[i] = source->dynA[(i-(DYN_DEFAULT_DARRAY_SIZE_INIT))];
+    	}
+    }
+
+    return result;
 }
 
-int grib_darray_is_constant(grib_darray* v, double eps)
+int grib_darray_is_constant(const grib_darray* source, double eps)
 {
     int i;
     double val;
-    if (v->n == 1)
+    if (source->n == 1)
         return 1;
 
-    val = v->v[0];
-    for (i = 1; i < v->n; i++) {
-        if (fabs(val - v->v[i]) > eps)
-            return 0;
+    val = source->stA[0];
+
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_DARRAY_SIZE_INIT - 1)) {
+    		if (fabs(val - source->stA[i]) > eps)
+    			return 0;
+    	} else {
+    		if (fabs(val - source->dynA[(i-(DYN_DEFAULT_DARRAY_SIZE_INIT))]) > eps)
+    		    return 0;
+    	}
     }
+
     return 1;
 }
 
-size_t grib_darray_used_size(grib_darray* v)
+size_t grib_darray_used_size(const grib_darray* source)
 {
-    return v->n;
+	return (!source) ? 0 : source->n;
 }

--- a/src/grib_handle.c
+++ b/src/grib_handle.c
@@ -16,34 +16,34 @@
 #include "grib_api_internal.h"
 
 #if 0
- /* #if GRIB_PTHREADS */
- static pthread_once_t once  = PTHREAD_ONCE_INIT;
- static pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
- static pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
- static void init() {
+/* #if GRIB_PTHREADS */
+static pthread_once_t once  = PTHREAD_ONCE_INIT;
+static pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+static void init() {
 	pthread_mutexattr_t attr;
 	pthread_mutexattr_init(&attr);
 	pthread_mutexattr_settype(&attr,PTHREAD_MUTEX_RECURSIVE);
 	pthread_mutex_init(&mutex1,&attr);
 	pthread_mutex_init(&mutex2,&attr);
 	pthread_mutexattr_destroy(&attr);
- }
- /* #elif GRIB_OMP_THREADS */
- static int once = 0;
- static omp_nest_lock_t mutex1;
- static omp_nest_lock_t mutex2;
- static void init()
- {
-    GRIB_OMP_CRITICAL(lock_grib_handle_c)
-    {
-        if (once == 0)
-        {
-            omp_init_nest_lock(&mutex1);
-            omp_init_nest_lock(&mutex2);
-            once = 1;
-        }
-    }
- }
+}
+/* #elif GRIB_OMP_THREADS */
+static int once = 0;
+static omp_nest_lock_t mutex1;
+static omp_nest_lock_t mutex2;
+static void init()
+{
+	GRIB_OMP_CRITICAL(lock_grib_handle_c)
+    		{
+		if (once == 0)
+		{
+			omp_init_nest_lock(&mutex1);
+			omp_init_nest_lock(&mutex2);
+			once = 1;
+		}
+    		}
+}
 #endif
 
 static grib_handle* grib_handle_new_from_file_no_multi(grib_context* c, FILE* f, int headers_only, int* error);
@@ -55,1591 +55,1638 @@ static grib_multi_support* grib_get_multi_support(grib_context* c, FILE* f);
 static grib_multi_support* grib_multi_support_new(grib_context* c);
 static grib_handle* grib_handle_new_multi(grib_context* c, unsigned char** idata, size_t* buflen, int* error);
 
+grib_vdarrayPOOL vdarrayPOOL;
+grib_vsarrayPOOL vsarrayPOOL;
+grib_viarrayPOOL viarrayPOOL;
+
 /* Note: A fast cut-down version of strcmp which does NOT return -1 */
 /* 0 means input strings are equal and 1 means not equal */
 static GRIB_INLINE int grib_inline_strcmp(const char* a, const char* b)
 {
-    if (*a != *b)
-        return 1;
-    while ((*a != 0 && *b != 0) && *(a) == *(b)) {
-        a++;
-        b++;
-    }
-    return (*a == 0 && *b == 0) ? 0 : 1;
+	if (*a != *b)
+		return 1;
+	while ((*a != 0 && *b != 0) && *(a) == *(b)) {
+		a++;
+		b++;
+	}
+	return (*a == 0 && *b == 0) ? 0 : 1;
 }
 
 grib_section* grib_section_create(grib_handle* h, grib_accessor* owner)
 {
-    grib_section* s = (grib_section*)grib_context_malloc_clear(h->context, sizeof(grib_section));
-    s->owner        = owner;
-    s->aclength     = NULL;
-    s->h            = h;
-    s->block        = (grib_block_of_accessors*)grib_context_malloc_clear(h->context, sizeof(grib_block_of_accessors));
-    return s;
+	grib_section* s = (grib_section*)grib_context_malloc_clear(h->context, sizeof(grib_section));
+	s->owner        = owner;
+	s->aclength     = NULL;
+	s->h            = h;
+	s->block        = (grib_block_of_accessors*)grib_context_malloc_clear(h->context, sizeof(grib_block_of_accessors));
+	return s;
 }
 
 static void update_sections(grib_section* s, grib_handle* h, long offset)
 {
-    grib_accessor* a = s ? s->block->first : NULL;
-    if (s)
-        s->h = h;
-    while (a) {
-        a->offset += offset;
-        /* update_sections ( grib_get_sub_section ( a ),h,offset ); */
-        update_sections(a->sub_section, h, offset);
-        a = a->next;
-    }
+	grib_accessor* a = s ? s->block->first : NULL;
+	if (s)
+		s->h = h;
+	while (a) {
+		a->offset += offset;
+		/* update_sections ( grib_get_sub_section ( a ),h,offset ); */
+		update_sections(a->sub_section, h, offset);
+		a = a->next;
+	}
 }
 
 void grib_swap_sections(grib_section* the_old, grib_section* the_new)
 {
-    grib_accessor* a;
-    grib_block_of_accessors* b = the_old->block;
+	grib_accessor* a;
+	grib_block_of_accessors* b = the_old->block;
 
-    /* printf("SWAPPING -----\n"); grib_dump_section_content(new,stdout); */
-    the_old->block = the_new->block;
-    the_new->block = b;
+	/* printf("SWAPPING -----\n"); grib_dump_section_content(new,stdout); */
+	the_old->block = the_new->block;
+	the_new->block = b;
 
-    a                 = the_old->aclength;
-    the_old->aclength = the_new->aclength;
-    the_new->aclength = a;
+	a                 = the_old->aclength;
+	the_old->aclength = the_new->aclength;
+	the_new->aclength = a;
 
-    a = the_old->block->first;
-    while (a) {
-        a->parent = the_old;
-        a         = a->next;
-    }
+	a = the_old->block->first;
+	while (a) {
+		a->parent = the_old;
+		a         = a->next;
+	}
 
-    update_sections(the_old, the_old->h, the_old->owner->offset);
-    /* update_sections(new,new->h,new->owner->offset); */
+	update_sections(the_old, the_old->h, the_old->owner->offset);
+	/* update_sections(new,new->h,new->owner->offset); */
 
-    /* printf("SWAPPING -----\n"); grib_dump_section_content(old,stdout); */
+	/* printf("SWAPPING -----\n"); grib_dump_section_content(old,stdout); */
 }
 
 void grib_empty_section(grib_context* c, grib_section* b)
 {
-    grib_accessor* current = NULL;
-    if (!b)
-        return;
+	grib_accessor* current = NULL;
+	if (!b)
+		return;
 
-    b->aclength = NULL;
+	b->aclength = NULL;
 
-    current = b->block->first;
+	current = b->block->first;
 
-    while (current) {
-        grib_accessor* next = current->next;
-        if (current->sub_section) {
-            grib_section_delete(c, current->sub_section);
-            current->sub_section = 0;
-        }
-        grib_accessor_delete(c, current);
-        current = next;
-    }
-    b->block->first = b->block->last = 0;
+	while (current) {
+		grib_accessor* next = current->next;
+		if (current->sub_section) {
+			grib_section_delete(c, current->sub_section);
+			current->sub_section = 0;
+		}
+		grib_accessor_delete(c, current);
+		current = next;
+	}
+	b->block->first = b->block->last = 0;
 }
 
 void grib_section_delete(grib_context* c, grib_section* b)
 {
-    if (!b)
-        return;
+	if (!b)
+		return;
 
-    grib_empty_section(c, b);
-    grib_context_free(c, b->block);
-    /* printf("++++ deleted %p\n",b); */
-    grib_context_free(c, b);
+	grib_empty_section(c, b);
+	grib_context_free(c, b->block);
+	/* printf("++++ deleted %p\n",b); */
+	grib_context_free(c, b);
 }
 
 int grib_handle_delete(grib_handle* h)
 {
-    if (h != NULL) {
-        grib_context* ct   = h->context;
-        grib_dependency* d = h->dependencies;
-        grib_dependency* n;
+	if (h != NULL) {
+		grib_context* ct   = h->context;
+		grib_dependency* d = h->dependencies;
+		grib_dependency* n;
 
-        if (h->kid != NULL)
-            return GRIB_INTERNAL_ERROR;
+		if (h->kid != NULL)
+			return GRIB_INTERNAL_ERROR;
 
-        while (d) {
-            n = d->next;
-            grib_context_free(ct, d);
-            d = n;
-        }
-        h->dependencies = 0;
+		while (d) {
+			n = d->next;
+			grib_context_free(ct, d);
+			d = n;
+		}
+		h->dependencies = 0;
 
-        grib_buffer_delete(ct, h->buffer);
-        grib_section_delete(ct, h->root);
+		grib_buffer_delete(ct, h->buffer);
+		grib_section_delete(ct, h->root);
 
-        grib_context_log(ct, GRIB_LOG_DEBUG, "grib_handle_delete: deleting handle %p", h);
-        grib_context_free(ct, h);
-        h = NULL;
-    }
-    return GRIB_SUCCESS;
+		grib_context_log(ct, GRIB_LOG_DEBUG, "grib_handle_delete: deleting handle %p", h);
+		grib_context_free(ct, h);
+		h = NULL;
+	}
+	return GRIB_SUCCESS;
 }
 
 grib_handle* grib_new_handle(grib_context* c)
 {
-    grib_handle* g = NULL;
-    if (c == NULL)
-        c = grib_context_get_default();
-    g = (grib_handle*)grib_context_malloc_clear(c, sizeof(grib_handle));
+	grib_handle* g = NULL;
+	if (c == NULL)
+		c = grib_context_get_default();
+	g = (grib_handle*)grib_context_malloc_clear(c, sizeof(grib_handle));
 
-    if (g == NULL) {
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_new_handle: cannot allocate handle");
-    }
-    else {
-        g->context      = c;
-        g->product_kind = PRODUCT_ANY; /* Default. Will later be set to a specific product */
-    }
+	if (g == NULL) {
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_new_handle: cannot allocate handle");
+	}
+	else {
+		g->context      = c;
+		g->product_kind = PRODUCT_ANY; /* Default. Will later be set to a specific product */
+	}
 
-    grib_context_log(c, GRIB_LOG_DEBUG, "grib_new_handle: allocated handle %p", g);
+	grib_context_log(c, GRIB_LOG_DEBUG, "grib_new_handle: allocated handle %p", g);
 
-    return g;
+	return g;
 }
 
 static grib_handle* grib_handle_create(grib_handle* gl, grib_context* c, const void* data, size_t buflen)
 {
-    grib_action* next = NULL;
-    int err           = 0;
+	grib_action* next = NULL;
+	int err           = 0;
 
-    if (gl == NULL)
-        return NULL;
+	if (gl == NULL)
+		return NULL;
 
-    gl->use_trie     = 1;
-    gl->trie_invalid = 0;
-    gl->buffer       = grib_new_buffer(gl->context, (const unsigned char*)data, buflen);
+	gl->use_trie     = 1;
+	gl->trie_invalid = 0;
+	gl->buffer       = grib_new_buffer(gl->context, (const unsigned char*)data, buflen);
 
-    if (gl->buffer == NULL) {
-        grib_handle_delete(gl);
-        return NULL;
-    }
+	if (gl->buffer == NULL) {
+		grib_handle_delete(gl);
+		return NULL;
+	}
 
-    gl->root = grib_create_root_section(gl->context, gl);
+	gl->root = grib_create_root_section(gl->context, gl);
 
-    if (!gl->root) {
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_create: cannot create root section");
-        grib_handle_delete(gl);
-        return NULL;
-    }
+	if (!gl->root) {
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_create: cannot create root section");
+		grib_handle_delete(gl);
+		return NULL;
+	}
 
-    if (!gl->context->grib_reader || !gl->context->grib_reader->first) {
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_create: cannot create handle, no definitions found");
-        grib_handle_delete(gl);
-        return NULL;
-    }
+	if (!gl->context->grib_reader || !gl->context->grib_reader->first) {
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_create: cannot create handle, no definitions found");
+		grib_handle_delete(gl);
+		return NULL;
+	}
 
-    gl->buffer->property = GRIB_USER_BUFFER;
+	gl->buffer->property = GRIB_USER_BUFFER;
 
-    next = gl->context->grib_reader->first->root;
-    while (next) {
-        if (grib_create_accessor(gl->root, next, NULL) != GRIB_SUCCESS)
-            break;
-        next = next->next;
-    }
+	next = gl->context->grib_reader->first->root;
+	while (next) {
+		if (grib_create_accessor(gl->root, next, NULL) != GRIB_SUCCESS)
+			break;
+		next = next->next;
+	}
 
-    err = grib_section_adjust_sizes(gl->root, 0, 0);
-    if (err) {
-        grib_handle_delete(gl);
-        return NULL;
-    }
+	err = grib_section_adjust_sizes(gl->root, 0, 0);
+	if (err) {
+		grib_handle_delete(gl);
+		return NULL;
+	}
 
-    grib_section_post_init(gl->root);
+	grib_section_post_init(gl->root);
 
-    return gl;
+	return gl;
 }
 
 grib_handle* grib_handle_new_from_samples(grib_context* c, const char* name)
 {
-    grib_handle* g = 0;
-    if (c == NULL)
-        c = grib_context_get_default();
-    grib_context_set_handle_file_count(c, 0);
-    grib_context_set_handle_total_count(c, 0);
+	grib_handle* g = 0;
+	if (c == NULL)
+		c = grib_context_get_default();
+	grib_context_set_handle_file_count(c, 0);
+	grib_context_set_handle_total_count(c, 0);
 
-    /*
-     * g = grib_internal_sample(c,name);
-     * if(g) return g;
-     */
-    if (c->debug) {
-        fprintf(stderr, "ECCODES DEBUG: grib_handle_new_from_samples '%s'\n", name);
-    }
+	/*
+	 * g = grib_internal_sample(c,name);
+	 * if(g) return g;
+	 */
+	if (c->debug) {
+		fprintf(stderr, "ECCODES DEBUG: grib_handle_new_from_samples '%s'\n", name);
+	}
 
-    g = grib_external_template(c, name);
-    if (!g)
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "Unable to load sample file '%s.tmpl'\n"
-                         "                   from %s\n"
-                         "                   (ecCodes Version=%s)",
-                         name, c->grib_samples_path, ECCODES_VERSION_STR);
+	g = grib_external_template(c, name);
+	if (!g)
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"Unable to load sample file '%s.tmpl'\n"
+				"                   from %s\n"
+				"                   (ecCodes Version=%s)",
+				name, c->grib_samples_path, ECCODES_VERSION_STR);
 
-    return g;
+	return g;
 }
 
 grib_handle* codes_bufr_handle_new_from_samples(grib_context* c, const char* name)
 {
-    grib_handle* g = 0;
-    if (c == NULL)
-        c = grib_context_get_default();
-    grib_context_set_handle_file_count(c, 0);
-    grib_context_set_handle_total_count(c, 0);
+	grib_handle* g = 0;
+	if (c == NULL)
+		c = grib_context_get_default();
+	grib_context_set_handle_file_count(c, 0);
+	grib_context_set_handle_total_count(c, 0);
 
-    /*
-     *  g = grib_internal_sample(c,name);
-     *  if(g) return g;
-     */
-    if (c->debug) {
-        fprintf(stderr, "ECCODES DEBUG: codes_bufr_handle_new_from_samples '%s'\n", name);
-    }
+	/*
+	 *  g = grib_internal_sample(c,name);
+	 *  if(g) return g;
+	 */
+	if (c->debug) {
+		fprintf(stderr, "ECCODES DEBUG: codes_bufr_handle_new_from_samples '%s'\n", name);
+	}
 
-    g = bufr_external_template(c, name);
-    if (!g)
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "Unable to load sample file '%s.tmpl'\n"
-                         "                   from %s\n"
-                         "                   (ecCodes Version=%s)",
-                         name, c->grib_samples_path, ECCODES_VERSION_STR);
+	g = bufr_external_template(c, name);
+	if (!g)
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"Unable to load sample file '%s.tmpl'\n"
+				"                   from %s\n"
+				"                   (ecCodes Version=%s)",
+				name, c->grib_samples_path, ECCODES_VERSION_STR);
 
-    return g;
+	return g;
 }
 
 int grib_write_message(const grib_handle* h, const char* file, const char* mode)
 {
-    FILE* fh = 0;
-    int err;
-    const void* buffer;
-    size_t size;
+	FILE* fh = 0;
+	int err;
+	const void* buffer;
+	size_t size;
 
-    fh = fopen(file, mode);
-    if (!fh) {
-        perror(file);
-        return GRIB_IO_PROBLEM;
-    }
-    err = grib_get_message(h, &buffer, &size);
-    if (err) {
-        fclose(fh);
-        return err;
-    }
+	fh = fopen(file, mode);
+	if (!fh) {
+		perror(file);
+		return GRIB_IO_PROBLEM;
+	}
+	err = grib_get_message(h, &buffer, &size);
+	if (err) {
+		fclose(fh);
+		return err;
+	}
 
-    if (fwrite(buffer, 1, size, fh) != size) {
-        perror(file);
-        fclose(fh);
-        return GRIB_IO_PROBLEM;
-    }
-    if (fclose(fh) != 0) {
-        perror(file);
-        return GRIB_IO_PROBLEM;
-    }
-    return 0;
+	if (fwrite(buffer, 1, size, fh) != size) {
+		perror(file);
+		fclose(fh);
+		return GRIB_IO_PROBLEM;
+	}
+	if (fclose(fh) != 0) {
+		perror(file);
+		return GRIB_IO_PROBLEM;
+	}
+	return 0;
 }
 
 grib_handle* grib_handle_clone(const grib_handle* h)
 {
-    grib_handle* result  = grib_handle_new_from_message_copy(h->context, h->buffer->data, h->buffer->ulength);
-    result->product_kind = h->product_kind;
-    return result;
+	grib_handle* result  = grib_handle_new_from_message_copy(h->context, h->buffer->data, h->buffer->ulength);
+	result->product_kind = h->product_kind;
+	return result;
 }
 
 grib_handle* codes_handle_new_from_file(grib_context* c, FILE* f, ProductKind product, int* error)
 {
-    if (product == PRODUCT_GRIB)
-        return grib_handle_new_from_file(c, f, error);
-    if (product == PRODUCT_BUFR)
-        return bufr_new_from_file(c, f, error);
-    if (product == PRODUCT_METAR)
-        return metar_new_from_file(c, f, error);
-    if (product == PRODUCT_GTS)
-        return gts_new_from_file(c, f, error);
-    if (product == PRODUCT_ANY)
-        return any_new_from_file(c, f, error);
+	if (product == PRODUCT_GRIB)
+		return grib_handle_new_from_file(c, f, error);
+	if (product == PRODUCT_BUFR)
+		return bufr_new_from_file(c, f, error);
+	if (product == PRODUCT_METAR)
+		return metar_new_from_file(c, f, error);
+	if (product == PRODUCT_GTS)
+		return gts_new_from_file(c, f, error);
+	if (product == PRODUCT_ANY)
+		return any_new_from_file(c, f, error);
 
-    Assert(!"codes_handle_new_from_file: Invalid product");
-    return NULL;
+	Assert(!"codes_handle_new_from_file: Invalid product");
+	return NULL;
 }
 
 grib_handle* codes_grib_handle_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    return grib_handle_new_from_file(c, f, error);
+	return grib_handle_new_from_file(c, f, error);
 }
 grib_handle* codes_bufr_handle_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    return bufr_new_from_file(c, f, error);
+	return bufr_new_from_file(c, f, error);
 }
 grib_handle* codes_metar_handle_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    return metar_new_from_file(c, f, error);
+	return metar_new_from_file(c, f, error);
 }
 grib_handle* codes_gts_handle_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    return gts_new_from_file(c, f, error);
+	return gts_new_from_file(c, f, error);
 }
 
 static int determine_product_kind(grib_handle* h, ProductKind* prod_kind)
 {
-    int err    = 0;
-    size_t len = 0;
-    err        = grib_get_length(h, "identifier", &len);
-    if (!err) {
-        char id_str[64] = {0,};
-        err = grib_get_string(h, "identifier", id_str, &len);
-        if (grib_inline_strcmp(id_str, "GRIB") == 0)
-            *prod_kind = PRODUCT_GRIB;
-        else if (grib_inline_strcmp(id_str, "BUFR") == 0)
-            *prod_kind = PRODUCT_BUFR;
-        else if (grib_inline_strcmp(id_str, "METAR") == 0)
-            *prod_kind = PRODUCT_METAR;
-        else if (grib_inline_strcmp(id_str, "GTS") == 0)
-            *prod_kind = PRODUCT_GTS;
-        else if (grib_inline_strcmp(id_str, "TAF") == 0)
-            *prod_kind = PRODUCT_TAF;
-        else
-            *prod_kind = PRODUCT_ANY;
-    }
-    return err;
+	int err    = 0;
+	size_t len = 0;
+	err        = grib_get_length(h, "identifier", &len);
+	if (!err) {
+		char id_str[64] = {0,};
+		err = grib_get_string(h, "identifier", id_str, &len);
+		if (grib_inline_strcmp(id_str, "GRIB") == 0)
+			*prod_kind = PRODUCT_GRIB;
+		else if (grib_inline_strcmp(id_str, "BUFR") == 0)
+			*prod_kind = PRODUCT_BUFR;
+		else if (grib_inline_strcmp(id_str, "METAR") == 0)
+			*prod_kind = PRODUCT_METAR;
+		else if (grib_inline_strcmp(id_str, "GTS") == 0)
+			*prod_kind = PRODUCT_GTS;
+		else if (grib_inline_strcmp(id_str, "TAF") == 0)
+			*prod_kind = PRODUCT_TAF;
+		else
+			*prod_kind = PRODUCT_ANY;
+	}
+	return err;
 }
 
 grib_handle* grib_handle_new_from_message_copy(grib_context* c, const void* data, size_t size)
 {
-    grib_handle* g = NULL;
-    void* copy     = NULL;
-    if (c == NULL)
-        c = grib_context_get_default();
+	grib_handle* g = NULL;
+	void* copy     = NULL;
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    grib_context_set_handle_file_count(c, 0);
-    grib_context_set_handle_total_count(c, 0);
-    copy = grib_context_malloc(c, size);
-    if (!copy) {
-        return NULL;
-    }
+	grib_context_set_handle_file_count(c, 0);
+	grib_context_set_handle_total_count(c, 0);
+	copy = grib_context_malloc(c, size);
+	if (!copy) {
+		return NULL;
+	}
 
-    memcpy(copy, data, size);
+	memcpy(copy, data, size);
 
-    g                   = grib_handle_new_from_message(c, copy, size);
-    g->buffer->property = GRIB_MY_BUFFER;
+	g                   = grib_handle_new_from_message(c, copy, size);
+	g->buffer->property = GRIB_MY_BUFFER;
 
-    return g;
+	return g;
 }
 
 grib_handle* grib_handle_new_from_partial_message_copy(grib_context* c, const void* data, size_t size)
 {
-    grib_handle* g = NULL;
-    void* copy     = NULL;
-    if (c == NULL)
-        c = grib_context_get_default();
-    grib_context_set_handle_file_count(c, 0);
-    grib_context_set_handle_total_count(c, 0);
-    copy = grib_context_malloc(c, size);
-    if (!copy)
-        return NULL;
+	grib_handle* g = NULL;
+	void* copy     = NULL;
+	if (c == NULL)
+		c = grib_context_get_default();
+	grib_context_set_handle_file_count(c, 0);
+	grib_context_set_handle_total_count(c, 0);
+	copy = grib_context_malloc(c, size);
+	if (!copy)
+		return NULL;
 
-    memcpy(copy, data, size);
+	memcpy(copy, data, size);
 
-    g                   = grib_handle_new_from_partial_message(c, copy, size);
-    g->buffer->property = GRIB_MY_BUFFER;
+	g                   = grib_handle_new_from_partial_message(c, copy, size);
+	g->buffer->property = GRIB_MY_BUFFER;
 
-    return g;
+	return g;
 }
 
 grib_handle* grib_handle_new_from_partial_message(grib_context* c, const void* data, size_t buflen)
 {
-    grib_handle* gl = NULL;
-    if (c == NULL)
-        c = grib_context_get_default();
-    grib_context_set_handle_file_count(c, 0);
-    grib_context_set_handle_total_count(c, 0);
-    gl          = grib_new_handle(c);
-    gl->partial = 1;
-    return grib_handle_create(gl, c, data, buflen);
+	grib_handle* gl = NULL;
+	if (c == NULL)
+		c = grib_context_get_default();
+	grib_context_set_handle_file_count(c, 0);
+	grib_context_set_handle_total_count(c, 0);
+	gl          = grib_new_handle(c);
+	gl->partial = 1;
+	return grib_handle_create(gl, c, data, buflen);
 }
 
 grib_handle* grib_handle_new_from_message(grib_context* c, const void* data, size_t buflen)
 {
-    grib_handle* gl          = NULL;
-    grib_handle* h           = NULL;
-    ProductKind product_kind = PRODUCT_ANY;
-    if (c == NULL)
-        c = grib_context_get_default();
-    gl               = grib_new_handle(c);
-    gl->product_kind = PRODUCT_GRIB; /* See ECC-480 */
-    h                = grib_handle_create(gl, c, data, buflen);
+	grib_handle* gl          = NULL;
+	grib_handle* h           = NULL;
+	ProductKind product_kind = PRODUCT_ANY;
+	if (c == NULL)
+		c = grib_context_get_default();
+	gl               = grib_new_handle(c);
+	gl->product_kind = PRODUCT_GRIB; /* See ECC-480 */
+	h                = grib_handle_create(gl, c, data, buflen);
 
-    /* See ECC-448 */
-    if (determine_product_kind(h, &product_kind) == GRIB_SUCCESS) {
-        h->product_kind = product_kind;
-    }
+	/* See ECC-448 */
+	if (determine_product_kind(h, &product_kind) == GRIB_SUCCESS) {
+		h->product_kind = product_kind;
+	}
 
-    if (h->product_kind == PRODUCT_GRIB) {
-        if (!grib_is_defined(h, "7777")) {
-            grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_message: No final 7777 in message!");
-            /* TODO: Return NULL. An incomplete message is no use to anyone.
-             * But first check the MARS Client and other applications
-             */
-        }
-    }
-    return h;
+	if (h->product_kind == PRODUCT_GRIB) {
+		if (!grib_is_defined(h, "7777")) {
+			grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_message: No final 7777 in message!");
+			/* TODO: Return NULL. An incomplete message is no use to anyone.
+			 * But first check the MARS Client and other applications
+			 */
+		}
+	}
+	return h;
 }
 
 grib_handle* grib_handle_new_from_multi_message(grib_context* c, void** data,
-                                                size_t* buflen, int* error)
+		size_t* buflen, int* error)
 {
-    grib_handle* h    = NULL;
-    unsigned char** d = (unsigned char**)data;
-    if (c == NULL)
-        c = grib_context_get_default();
+	grib_handle* h    = NULL;
+	unsigned char** d = (unsigned char**)data;
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (c->multi_support_on)
-        h = grib_handle_new_multi(c, d, buflen, error);
-    else {
-        size_t olen   = 0;
-        void* message = NULL;
-        *error        = grib_read_any_from_memory_alloc(c, d, buflen, &message, &olen);
-        if (message == NULL)
-            return NULL;
-        h = grib_new_handle(c);
-        grib_handle_create(h, c, message, olen);
-    }
+	if (c->multi_support_on)
+		h = grib_handle_new_multi(c, d, buflen, error);
+	else {
+		size_t olen   = 0;
+		void* message = NULL;
+		*error        = grib_read_any_from_memory_alloc(c, d, buflen, &message, &olen);
+		if (message == NULL)
+			return NULL;
+		h = grib_new_handle(c);
+		grib_handle_create(h, c, message, olen);
+	}
 
-    return h;
+	return h;
 }
 
 grib_handle* grib_handle_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    return grib_new_from_file(c, f, 0, error);
+	return grib_new_from_file(c, f, 0, error);
 }
 
 static grib_handle* grib_handle_new_multi(grib_context* c, unsigned char** data,
-                                          size_t* buflen, int* error)
+		size_t* buflen, int* error)
 {
-    void* message = NULL;
-    size_t olen = 0, len = 0;
-    grib_handle* gl         = NULL;
-    long edition            = 0;
-    size_t seclen           = 0;
-    unsigned char* secbegin = 0;
-    int secnum = 0, seccount = 0;
-    int err = 0, i = 0;
-    grib_multi_support* gm = NULL;
+	void* message = NULL;
+	size_t olen = 0, len = 0;
+	grib_handle* gl         = NULL;
+	long edition            = 0;
+	size_t seclen           = 0;
+	unsigned char* secbegin = 0;
+	int secnum = 0, seccount = 0;
+	int err = 0, i = 0;
+	grib_multi_support* gm = NULL;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    gm = grib_get_multi_support(c, 0);
+	gm = grib_get_multi_support(c, 0);
 
-    if (!gm->message) {
-        *error             = grib_read_any_from_memory_alloc(c, data, buflen, &message, &olen);
-        gm->message_length = olen;
-        gm->message        = (unsigned char*)message;
-        if (*error != GRIB_SUCCESS || !message) {
-            if (*error == GRIB_END_OF_FILE)
-                *error = GRIB_SUCCESS;
-            gm->message_length = 0;
-            return NULL;
-        }
-    }
-    else {
-        message = gm->message;
-    }
+	if (!gm->message) {
+		*error             = grib_read_any_from_memory_alloc(c, data, buflen, &message, &olen);
+		gm->message_length = olen;
+		gm->message        = (unsigned char*)message;
+		if (*error != GRIB_SUCCESS || !message) {
+			if (*error == GRIB_END_OF_FILE)
+				*error = GRIB_SUCCESS;
+			gm->message_length = 0;
+			return NULL;
+		}
+	}
+	else {
+		message = gm->message;
+	}
 
-    edition = grib_decode_unsigned_byte_long((const unsigned char*)message, 7, 1);
+	edition = grib_decode_unsigned_byte_long((const unsigned char*)message, 7, 1);
 
-    if (edition == 2) {
-        olen = gm->message_length;
-        if (gm->section_number == 0) {
-            gm->sections[0] = (unsigned char*)message;
-        }
-        secbegin = gm->sections[gm->section_number];
-        seclen   = gm->sections_length[gm->section_number];
-        secnum   = gm->section_number;
-        seccount = 0;
-        while (grib2_get_next_section((unsigned char*)message, olen, &secbegin, &seclen, &secnum, &err)) {
-            seccount++;
-            /*printf("   - %d - section %d length=%d\n",(int)seccount,(int)secnum,(int)seclen);*/
+	if (edition == 2) {
+		olen = gm->message_length;
+		if (gm->section_number == 0) {
+			gm->sections[0] = (unsigned char*)message;
+		}
+		secbegin = gm->sections[gm->section_number];
+		seclen   = gm->sections_length[gm->section_number];
+		secnum   = gm->section_number;
+		seccount = 0;
+		while (grib2_get_next_section((unsigned char*)message, olen, &secbegin, &seclen, &secnum, &err)) {
+			seccount++;
+			/*printf("   - %d - section %d length=%d\n",(int)seccount,(int)secnum,(int)seclen);*/
 
-            gm->sections[secnum]        = secbegin;
-            gm->sections_length[secnum] = seclen;
+			gm->sections[secnum]        = secbegin;
+			gm->sections_length[secnum] = seclen;
 
-            if (secnum == 6) {
-                /* Special case for inherited bitmaps */
-                if (grib_decode_unsigned_byte_long(secbegin, 5, 1) == 254) {
-                    if (!gm->bitmap_section) {
-                        grib_context_log(c, GRIB_LOG_ERROR,
-                                         "grib_handle_new_multi : cannot create handle, missing bitmap\n");
-                        return NULL;
-                    }
-                    gm->sections[secnum]        = gm->bitmap_section;
-                    gm->sections_length[secnum] = gm->bitmap_section_length;
-                }
-                else {
-                    if (gm->bitmap_section) {
-                        grib_context_free(c, gm->bitmap_section);
-                        gm->bitmap_section = NULL;
-                    }
-                    gm->bitmap_section        = (unsigned char*)grib_context_malloc(c, seclen);
-                    gm->bitmap_section        = (unsigned char*)memcpy(gm->bitmap_section, secbegin, seclen);
-                    gm->bitmap_section_length = seclen;
-                }
-            }
+			if (secnum == 6) {
+				/* Special case for inherited bitmaps */
+				if (grib_decode_unsigned_byte_long(secbegin, 5, 1) == 254) {
+					if (!gm->bitmap_section) {
+						grib_context_log(c, GRIB_LOG_ERROR,
+								"grib_handle_new_multi : cannot create handle, missing bitmap\n");
+						return NULL;
+					}
+					gm->sections[secnum]        = gm->bitmap_section;
+					gm->sections_length[secnum] = gm->bitmap_section_length;
+				}
+				else {
+					if (gm->bitmap_section) {
+						grib_context_free(c, gm->bitmap_section);
+						gm->bitmap_section = NULL;
+					}
+					gm->bitmap_section        = (unsigned char*)grib_context_malloc(c, seclen);
+					gm->bitmap_section        = (unsigned char*)memcpy(gm->bitmap_section, secbegin, seclen);
+					gm->bitmap_section_length = seclen;
+				}
+			}
 
-            if (secnum == 7) {
-                void* p = message;
-                len     = olen;
-                grib2_build_message(c, gm->sections, gm->sections_length, &message, &len);
+			if (secnum == 7) {
+				void* p = message;
+				len     = olen;
+				grib2_build_message(c, gm->sections, gm->sections_length, &message, &len);
 
-                if (grib2_has_next_section((unsigned char*)p, olen, secbegin, seclen, &err)) {
-                    gm->message        = (unsigned char*)p;
-                    gm->section_number = secnum;
-                    olen               = len;
-                }
-                else {
-                    grib_context_free(c, gm->message);
-                    gm->message = NULL;
-                    for (i = 0; i < 8; i++)
-                        gm->sections[i] = NULL;
-                    gm->section_number = 0;
-                    gm->message_length = 0;
-                    olen               = len;
-                }
+				if (grib2_has_next_section((unsigned char*)p, olen, secbegin, seclen, &err)) {
+					gm->message        = (unsigned char*)p;
+					gm->section_number = secnum;
+					olen               = len;
+				}
+				else {
+					grib_context_free(c, gm->message);
+					gm->message = NULL;
+					for (i = 0; i < 8; i++)
+						gm->sections[i] = NULL;
+					gm->section_number = 0;
+					gm->message_length = 0;
+					olen               = len;
+				}
 
-                break;
-            }
-        }
-    }
-    else if (edition == 3) {
-        *error = GRIB_UNSUPPORTED_EDITION;
-        return NULL;
-    }
-    else {
-        gm->message_length = 0;
-        gm->message        = NULL;
-    }
+				break;
+			}
+		}
+	}
+	else if (edition == 3) {
+		*error = GRIB_UNSUPPORTED_EDITION;
+		return NULL;
+	}
+	else {
+		gm->message_length = 0;
+		gm->message        = NULL;
+	}
 
-    gl = grib_handle_new_from_message(c, message, olen);
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_multi: cannot create handle \n");
-        return NULL;
-    }
+	gl = grib_handle_new_from_message(c, message, olen);
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_multi: cannot create handle \n");
+		return NULL;
+	}
 
-    gl->buffer->property = GRIB_MY_BUFFER;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
+	gl->buffer->property = GRIB_MY_BUFFER;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
 
-    return gl;
+	return gl;
 }
 
 static grib_handle* grib_handle_new_from_file_multi(grib_context* c, FILE* f, int* error)
 {
-    void *data = NULL, *old_data = NULL;
-    size_t olen = 0, len = 0;
-    grib_handle* gl         = NULL;
-    long edition            = 0;
-    size_t seclen           = 0;
-    unsigned char* secbegin = 0;
-    int secnum = 0, seccount = 0;
-    int err = 0, i = 0;
-    grib_multi_support* gm  = NULL;
-    off_t gts_header_offset = 0;
-    off_t end_msg_offset = 0, offset = 0;
-    char *gts_header = 0, *save_gts_header = 0;
-    int gtslen = 0;
+	void *data = NULL, *old_data = NULL;
+	size_t olen = 0, len = 0;
+	grib_handle* gl         = NULL;
+	long edition            = 0;
+	size_t seclen           = 0;
+	unsigned char* secbegin = 0;
+	int secnum = 0, seccount = 0;
+	int err = 0, i = 0;
+	grib_multi_support* gm  = NULL;
+	off_t gts_header_offset = 0;
+	off_t end_msg_offset = 0, offset = 0;
+	char *gts_header = 0, *save_gts_header = 0;
+	int gtslen = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    gm = grib_get_multi_support(c, f);
+	gm = grib_get_multi_support(c, f);
 
-    if (!gm->message) {
-        gts_header_offset = grib_context_tell(c, f);
-        data              = wmo_read_grib_from_file_malloc(f, 0, &olen, &offset, error);
-        end_msg_offset    = grib_context_tell(c, f);
+	if (!gm->message) {
+		gts_header_offset = grib_context_tell(c, f);
+		data              = wmo_read_grib_from_file_malloc(f, 0, &olen, &offset, error);
+		end_msg_offset    = grib_context_tell(c, f);
 
-        gm->message_length = olen;
-        gm->message        = (unsigned char*)data;
-        gm->offset         = offset;
-        if (*error != GRIB_SUCCESS || !data) {
-            if (data)
-                grib_context_free(c, data);
+		gm->message_length = olen;
+		gm->message        = (unsigned char*)data;
+		gm->offset         = offset;
+		if (*error != GRIB_SUCCESS || !data) {
+			if (data)
+				grib_context_free(c, data);
 
-            if (*error == GRIB_END_OF_FILE)
-                *error = GRIB_SUCCESS;
-            gm->message_length = 0;
-            gm->message        = NULL;
-            return NULL;
-        }
-        if (c->gts_header_on) {
-            int g = 0;
-            grib_context_seek(c, gts_header_offset, SEEK_SET, f);
-            gtslen          = offset - gts_header_offset;
-            gts_header      = (char*)grib_context_malloc_clear(c, sizeof(unsigned char) * gtslen);
-            save_gts_header = gts_header;
-            grib_context_read(c, gts_header, gtslen, f);
-            g = gtslen;
-            while (gts_header != NULL && g != 0 && *gts_header != '\03') {
-                /*printf("--------%d %X \n",gtslen,*gts_header);*/
-                gts_header++;
-                g--;
-            }
-            if (g > 8) {
-                gts_header++;
-                gtslen = g - 1;
-            }
-            else
-                gts_header = save_gts_header;
-            grib_context_seek(c, end_msg_offset, SEEK_SET, f);
-        }
-    }
-    else
-        data = gm->message;
+			if (*error == GRIB_END_OF_FILE)
+				*error = GRIB_SUCCESS;
+			gm->message_length = 0;
+			gm->message        = NULL;
+			return NULL;
+		}
+		if (c->gts_header_on) {
+			int g = 0;
+			grib_context_seek(c, gts_header_offset, SEEK_SET, f);
+			gtslen          = offset - gts_header_offset;
+			gts_header      = (char*)grib_context_malloc_clear(c, sizeof(unsigned char) * gtslen);
+			save_gts_header = gts_header;
+			grib_context_read(c, gts_header, gtslen, f);
+			g = gtslen;
+			while (gts_header != NULL && g != 0 && *gts_header != '\03') {
+				/*printf("--------%d %X \n",gtslen,*gts_header);*/
+				gts_header++;
+				g--;
+			}
+			if (g > 8) {
+				gts_header++;
+				gtslen = g - 1;
+			}
+			else
+				gts_header = save_gts_header;
+			grib_context_seek(c, end_msg_offset, SEEK_SET, f);
+		}
+	}
+	else
+		data = gm->message;
 
-    edition = grib_decode_unsigned_byte_long((const unsigned char*)data, 7, 1);
+	edition = grib_decode_unsigned_byte_long((const unsigned char*)data, 7, 1);
 
-    if (edition == 2) {
-        olen = gm->message_length;
-        if (gm->section_number == 0) {
-            gm->sections[0] = (unsigned char*)data;
-        }
-        secbegin = gm->sections[gm->section_number];
-        seclen   = gm->sections_length[gm->section_number];
-        secnum   = gm->section_number;
-        seccount = 0;
-        while (grib2_get_next_section((unsigned char*)data, olen, &secbegin, &seclen, &secnum, &err)) {
-            seccount++;
-            /*printf("   - %d - section %d length=%d\n",(int)seccount,(int)secnum,(int)seclen);*/
+	if (edition == 2) {
+		olen = gm->message_length;
+		if (gm->section_number == 0) {
+			gm->sections[0] = (unsigned char*)data;
+		}
+		secbegin = gm->sections[gm->section_number];
+		seclen   = gm->sections_length[gm->section_number];
+		secnum   = gm->section_number;
+		seccount = 0;
+		while (grib2_get_next_section((unsigned char*)data, olen, &secbegin, &seclen, &secnum, &err)) {
+			seccount++;
+			/*printf("   - %d - section %d length=%d\n",(int)seccount,(int)secnum,(int)seclen);*/
 
-            gm->sections[secnum]        = secbegin;
-            gm->sections_length[secnum] = seclen;
+			gm->sections[secnum]        = secbegin;
+			gm->sections_length[secnum] = seclen;
 
-            if (secnum == 6) {
-                /* Special case for inherited bitmaps */
-                if (grib_decode_unsigned_byte_long(secbegin, 5, 1) == 254) {
-                    if (!gm->bitmap_section) {
-                        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_file_multi: cannot create handle, missing bitmap\n");
-                        grib_context_free(c, data);
-                        return NULL;
-                    }
-                    gm->sections[secnum]        = gm->bitmap_section;
-                    gm->sections_length[secnum] = gm->bitmap_section_length;
-                }
-                else {
-                    if (gm->bitmap_section) {
-                        grib_context_free(c, gm->bitmap_section);
-                        gm->bitmap_section = NULL;
-                    }
-                    gm->bitmap_section        = (unsigned char*)grib_context_malloc(c, seclen);
-                    gm->bitmap_section        = (unsigned char*)memcpy(gm->bitmap_section, secbegin, seclen);
-                    gm->bitmap_section_length = seclen;
-                }
-            }
+			if (secnum == 6) {
+				/* Special case for inherited bitmaps */
+				if (grib_decode_unsigned_byte_long(secbegin, 5, 1) == 254) {
+					if (!gm->bitmap_section) {
+						grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_file_multi: cannot create handle, missing bitmap\n");
+						grib_context_free(c, data);
+						return NULL;
+					}
+					gm->sections[secnum]        = gm->bitmap_section;
+					gm->sections_length[secnum] = gm->bitmap_section_length;
+				}
+				else {
+					if (gm->bitmap_section) {
+						grib_context_free(c, gm->bitmap_section);
+						gm->bitmap_section = NULL;
+					}
+					gm->bitmap_section        = (unsigned char*)grib_context_malloc(c, seclen);
+					gm->bitmap_section        = (unsigned char*)memcpy(gm->bitmap_section, secbegin, seclen);
+					gm->bitmap_section_length = seclen;
+				}
+			}
 
-            if (secnum == 7) {
-                old_data = data;
-                len      = olen;
-                grib2_build_message(c, gm->sections, gm->sections_length, &data, &len);
+			if (secnum == 7) {
+				old_data = data;
+				len      = olen;
+				grib2_build_message(c, gm->sections, gm->sections_length, &data, &len);
 
-                if (grib2_has_next_section((unsigned char*)old_data, olen, secbegin, seclen, &err)) {
-                    gm->message        = (unsigned char*)old_data;
-                    gm->section_number = secnum;
-                    olen               = len;
-                }
-                else {
-                    if (gm->message)
-                        grib_context_free(c, gm->message);
-                    gm->message = NULL;
-                    for (i = 0; i < 8; i++)
-                        gm->sections[i] = NULL;
-                    gm->section_number = 0;
-                    gm->message_length = 0;
-                    olen               = len;
-                }
-                break;
-            }
-        }
-    }
-    else if (edition == 3) {
-        /* GRIB3: Multi-field mode not yet supported */
-        printf("WARNING: %s\n", "grib_handle_new_from_file_multi: GRIB3 multi-field mode not yet implemented! Reverting to single-field mode");
-        gm->message_length = 0;
-        gm->message        = NULL;
-    }
-    else {
-        gm->message_length = 0;
-        gm->message        = NULL;
-    }
+				if (grib2_has_next_section((unsigned char*)old_data, olen, secbegin, seclen, &err)) {
+					gm->message        = (unsigned char*)old_data;
+					gm->section_number = secnum;
+					olen               = len;
+				}
+				else {
+					if (gm->message)
+						grib_context_free(c, gm->message);
+					gm->message = NULL;
+					for (i = 0; i < 8; i++)
+						gm->sections[i] = NULL;
+					gm->section_number = 0;
+					gm->message_length = 0;
+					olen               = len;
+				}
+				break;
+			}
+		}
+	}
+	else if (edition == 3) {
+		/* GRIB3: Multi-field mode not yet supported */
+		printf("WARNING: %s\n", "grib_handle_new_from_file_multi: GRIB3 multi-field mode not yet implemented! Reverting to single-field mode");
+		gm->message_length = 0;
+		gm->message        = NULL;
+	}
+	else {
+		gm->message_length = 0;
+		gm->message        = NULL;
+	}
 
-    gl = grib_handle_new_from_message(c, data, olen);
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_file_multi: cannot create handle \n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	gl = grib_handle_new_from_message(c, data, olen);
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_file_multi: cannot create handle \n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    gl->offset           = gm->offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
+	gl->offset           = gm->offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
 
-    if (c->gts_header_on && gtslen >= 8) {
-        gl->gts_header = (char*)grib_context_malloc_clear(c, sizeof(unsigned char) * gtslen);
-        DebugAssert(gts_header);
-        if (gts_header) memcpy(gl->gts_header, gts_header, gtslen);
-        gl->gts_header_len = gtslen;
-        grib_context_free(c, save_gts_header);
-        gtslen = 0;
-    }
-    else {
-        gl->gts_header = NULL;
-    }
+	if (c->gts_header_on && gtslen >= 8) {
+		gl->gts_header = (char*)grib_context_malloc_clear(c, sizeof(unsigned char) * gtslen);
+		DebugAssert(gts_header);
+		if (gts_header) memcpy(gl->gts_header, gts_header, gtslen);
+		gl->gts_header_len = gtslen;
+		grib_context_free(c, save_gts_header);
+		gtslen = 0;
+	}
+	else {
+		gl->gts_header = NULL;
+	}
 
-    return gl;
+	return gl;
 }
 
 grib_handle* grib_new_from_file(grib_context* c, FILE* f, int headers_only, int* error)
 {
-    grib_handle* h = 0;
-    if (!f) {
-        *error = GRIB_IO_PROBLEM;
-        return NULL;
-    }
+	grib_handle* h = 0;
+	if (!f) {
+		*error = GRIB_IO_PROBLEM;
+		return NULL;
+	}
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    if (c->multi_support_on)
-        h = grib_handle_new_from_file_multi(c, f, error);
-    else
-        h = grib_handle_new_from_file_no_multi(c, f, headers_only, error);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (h && h->offset == 0)
-        grib_context_set_handle_file_count(c, 1);
+	if (c->multi_support_on)
+		h = grib_handle_new_from_file_multi(c, f, error);
+	else
+		h = grib_handle_new_from_file_no_multi(c, f, headers_only, error);
 
-    if (h) {
-        h->product_kind = PRODUCT_GRIB;
-    }
+	if (h && h->offset == 0)
+		grib_context_set_handle_file_count(c, 1);
 
-    if (!c->no_fail_on_wrong_length && *error == GRIB_WRONG_LENGTH) {
-        grib_handle_delete(h);
-        h = NULL;
-    }
+	if (h) {
+		h->product_kind = PRODUCT_GRIB;
+	}
 
-    return h;
+	if (!c->no_fail_on_wrong_length && *error == GRIB_WRONG_LENGTH) {
+		grib_handle_delete(h);
+		h = NULL;
+	}
+
+	return h;
 }
 
 grib_handle* gts_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    void* data      = NULL;
-    size_t olen     = 0;
-    grib_handle* gl = NULL;
-    off_t offset    = 0;
+	void* data      = NULL;
+	size_t olen     = 0;
+	grib_handle* gl = NULL;
+	off_t offset    = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    data = wmo_read_gts_from_file_malloc(f, 0, &olen, &offset, error);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (*error != GRIB_SUCCESS) {
-        if (data)
-            grib_context_free(c, data);
+	data = wmo_read_gts_from_file_malloc(f, 0, &olen, &offset, error);
 
-        if (*error == GRIB_END_OF_FILE)
-            *error = GRIB_SUCCESS;
-        return NULL;
-    }
+	if (*error != GRIB_SUCCESS) {
+		if (data)
+			grib_context_free(c, data);
 
-    gl = grib_handle_new_from_message(c, data, olen);
+		if (*error == GRIB_END_OF_FILE)
+			*error = GRIB_SUCCESS;
+		return NULL;
+	}
 
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "gts_new_from_file: cannot create handle \n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	gl = grib_handle_new_from_message(c, data, olen);
 
-    gl->offset           = offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
-    gl->product_kind     = PRODUCT_GTS;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
-    if (gl->offset == 0)
-        grib_context_set_handle_file_count(c, 1);
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "gts_new_from_file: cannot create handle \n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    return gl;
+	gl->offset           = offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
+	gl->product_kind     = PRODUCT_GTS;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
+	if (gl->offset == 0)
+		grib_context_set_handle_file_count(c, 1);
+
+	return gl;
 }
 
 grib_handle* taf_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    void* data      = NULL;
-    size_t olen     = 0;
-    grib_handle* gl = NULL;
-    off_t offset    = 0;
+	void* data      = NULL;
+	size_t olen     = 0;
+	grib_handle* gl = NULL;
+	off_t offset    = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    data = wmo_read_taf_from_file_malloc(f, 0, &olen, &offset, error);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (*error != GRIB_SUCCESS) {
-        if (data)
-            grib_context_free(c, data);
+	data = wmo_read_taf_from_file_malloc(f, 0, &olen, &offset, error);
 
-        if (*error == GRIB_END_OF_FILE)
-            *error = GRIB_SUCCESS;
-        return NULL;
-    }
+	if (*error != GRIB_SUCCESS) {
+		if (data)
+			grib_context_free(c, data);
 
-    gl = grib_handle_new_from_message(c, data, olen);
+		if (*error == GRIB_END_OF_FILE)
+			*error = GRIB_SUCCESS;
+		return NULL;
+	}
 
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "taf_new_from_file: cannot create handle \n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	gl = grib_handle_new_from_message(c, data, olen);
 
-    gl->offset           = offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
-    gl->product_kind     = PRODUCT_TAF;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
-    if (gl->offset == 0)
-        grib_context_set_handle_file_count(c, 1);
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "taf_new_from_file: cannot create handle \n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    return gl;
+	gl->offset           = offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
+	gl->product_kind     = PRODUCT_TAF;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
+	if (gl->offset == 0)
+		grib_context_set_handle_file_count(c, 1);
+
+	return gl;
 }
 
 grib_handle* metar_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    void* data      = NULL;
-    size_t olen     = 0;
-    grib_handle* gl = NULL;
-    off_t offset    = 0;
+	void* data      = NULL;
+	size_t olen     = 0;
+	grib_handle* gl = NULL;
+	off_t offset    = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    data = wmo_read_metar_from_file_malloc(f, 0, &olen, &offset, error);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (*error != GRIB_SUCCESS) {
-        if (data)
-            grib_context_free(c, data);
+	data = wmo_read_metar_from_file_malloc(f, 0, &olen, &offset, error);
 
-        if (*error == GRIB_END_OF_FILE)
-            *error = GRIB_SUCCESS;
-        return NULL;
-    }
+	if (*error != GRIB_SUCCESS) {
+		if (data)
+			grib_context_free(c, data);
 
-    gl = grib_handle_new_from_message(c, data, olen);
+		if (*error == GRIB_END_OF_FILE)
+			*error = GRIB_SUCCESS;
+		return NULL;
+	}
 
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "metar_new_from_file: cannot create handle \n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	gl = grib_handle_new_from_message(c, data, olen);
 
-    gl->offset           = offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
-    gl->product_kind     = PRODUCT_METAR;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
-    if (gl->offset == 0)
-        grib_context_set_handle_file_count(c, 1);
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "metar_new_from_file: cannot create handle \n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    return gl;
+	gl->offset           = offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
+	gl->product_kind     = PRODUCT_METAR;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
+	if (gl->offset == 0)
+		grib_context_set_handle_file_count(c, 1);
+
+	return gl;
 }
 
 grib_handle* bufr_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    void* data              = NULL;
-    size_t olen             = 0;
-    grib_handle* gl         = NULL;
-    off_t gts_header_offset = 0;
-    off_t offset = 0, end_msg_offset = 0;
-    char *gts_header = 0, *save_gts_header = 0;
-    int gtslen = 0;
+	void* data              = NULL;
+	size_t olen             = 0;
+	grib_handle* gl         = NULL;
+	off_t gts_header_offset = 0;
+	off_t offset = 0, end_msg_offset = 0;
+	char *gts_header = 0, *save_gts_header = 0;
+	int gtslen = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    gts_header_offset = grib_context_tell(c, f);
-    data              = wmo_read_bufr_from_file_malloc(f, 0, &olen, &offset, error);
-    end_msg_offset    = grib_context_tell(c, f);
 
-    if (*error != GRIB_SUCCESS) {
-        if (data)
-            grib_context_free(c, data);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-        if (*error == GRIB_END_OF_FILE)
-            *error = GRIB_SUCCESS;
-        return NULL;
-    }
+	gts_header_offset = grib_context_tell(c, f);
+	data              = wmo_read_bufr_from_file_malloc(f, 0, &olen, &offset, error);
+	end_msg_offset    = grib_context_tell(c, f);
 
-    if (c->gts_header_on) {
-        int g = 0;
-        grib_context_seek(c, gts_header_offset, SEEK_SET, f);
-        gtslen          = offset - gts_header_offset;
-        gts_header      = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
-        save_gts_header = gts_header;
-        grib_context_read(c, gts_header, gtslen, f);
-        g = gtslen;
-        while (gts_header != NULL && g != 0 && *gts_header != '\03') {
-            /*printf("--------%d %X \n",gtslen,*gts_header);*/
-            gts_header++;
-            g--;
-        }
-        if (g > 8) {
-            gts_header++;
-            gtslen = g - 1;
-        }
-        else
-            gts_header = save_gts_header;
-        grib_context_seek(c, end_msg_offset, SEEK_SET, f);
-    }
+	if (*error != GRIB_SUCCESS) {
+		if (data)
+			grib_context_free(c, data);
 
-    gl = grib_handle_new_from_message(c, data, olen);
+		if (*error == GRIB_END_OF_FILE)
+			*error = GRIB_SUCCESS;
+		return NULL;
+	}
 
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "bufr_new_from_file: cannot create handle \n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	if (c->gts_header_on) {
+		int g = 0;
+		grib_context_seek(c, gts_header_offset, SEEK_SET, f);
+		gtslen          = offset - gts_header_offset;
+		gts_header      = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
+		save_gts_header = gts_header;
+		grib_context_read(c, gts_header, gtslen, f);
+		g = gtslen;
+		while (gts_header != NULL && g != 0 && *gts_header != '\03') {
+			/*printf("--------%d %X \n",gtslen,*gts_header);*/
+			gts_header++;
+			g--;
+		}
+		if (g > 8) {
+			gts_header++;
+			gtslen = g - 1;
+		}
+		else
+			gts_header = save_gts_header;
+		grib_context_seek(c, end_msg_offset, SEEK_SET, f);
+	}
 
-    gl->offset           = offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
-    gl->product_kind     = PRODUCT_BUFR;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
-    if (gl->offset == 0)
-        grib_context_set_handle_file_count(c, 1);
+	gl = grib_handle_new_from_message(c, data, olen);
 
-    if (c->gts_header_on && gtslen >= 8) {
-        gl->gts_header = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
-        DebugAssert(gts_header);
-        if (gts_header) memcpy(gl->gts_header, gts_header, gtslen);
-        gl->gts_header_len = gtslen;
-        grib_context_free(c, save_gts_header);
-    }
-    else {
-        gl->gts_header = NULL;
-    }
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "bufr_new_from_file: cannot create handle \n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    return gl;
+	gl->offset           = offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
+	gl->product_kind     = PRODUCT_BUFR;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
+	if (gl->offset == 0)
+		grib_context_set_handle_file_count(c, 1);
+
+	if (c->gts_header_on && gtslen >= 8) {
+		gl->gts_header = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
+		DebugAssert(gts_header);
+		if (gts_header) memcpy(gl->gts_header, gts_header, gtslen);
+		gl->gts_header_len = gtslen;
+		grib_context_free(c, save_gts_header);
+	}
+	else {
+		gl->gts_header = NULL;
+	}
+
+	return gl;
 }
 
 grib_handle* any_new_from_file(grib_context* c, FILE* f, int* error)
 {
-    void* data      = NULL;
-    size_t olen     = 0;
-    grib_handle* gl = NULL;
-    off_t offset    = 0;
+	void* data      = NULL;
+	size_t olen     = 0;
+	grib_handle* gl = NULL;
+	off_t offset    = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    data = wmo_read_any_from_file_malloc(f, 0, &olen, &offset, error);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (*error != GRIB_SUCCESS) {
-        if (data)
-            grib_context_free(c, data);
+	data = wmo_read_any_from_file_malloc(f, 0, &olen, &offset, error);
 
-        if (*error == GRIB_END_OF_FILE)
-            *error = GRIB_SUCCESS;
-        return NULL;
-    }
+	if (*error != GRIB_SUCCESS) {
+		if (data)
+			grib_context_free(c, data);
 
-    gl = grib_handle_new_from_message(c, data, olen);
+		if (*error == GRIB_END_OF_FILE)
+			*error = GRIB_SUCCESS;
+		return NULL;
+	}
 
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "any_new_from_file : cannot create handle\n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	gl = grib_handle_new_from_message(c, data, olen);
 
-    gl->offset           = offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
-    gl->product_kind     = PRODUCT_ANY;
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
-    if (gl->offset == 0)
-        grib_context_set_handle_file_count(c, 1);
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "any_new_from_file : cannot create handle\n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    return gl;
+	gl->offset           = offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
+	gl->product_kind     = PRODUCT_ANY;
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
+	if (gl->offset == 0)
+		grib_context_set_handle_file_count(c, 1);
+
+	return gl;
 }
 
 static grib_handle* grib_handle_new_from_file_no_multi(grib_context* c, FILE* f, int headers_only, int* error)
 {
-    void* data              = NULL;
-    size_t olen             = 0;
-    grib_handle* gl         = NULL;
-    off_t gts_header_offset = 0;
-    off_t offset = 0, end_msg_offset = 0;
-    char *gts_header = 0, *save_gts_header = 0;
-    int gtslen = 0;
+	void* data              = NULL;
+	size_t olen             = 0;
+	grib_handle* gl         = NULL;
+	off_t gts_header_offset = 0;
+	off_t offset = 0, end_msg_offset = 0;
+	char *gts_header = 0, *save_gts_header = 0;
+	int gtslen = 0;
 
-    if (c == NULL)
-        c = grib_context_get_default();
+	iarrayPoolInit(c);
+	darrayPoolInit();
+	/* viarrayPoolInit(); */
+	/* vdarrayPoolInit(); */
+	/* vsarrayPoolInit(); */
 
-    gts_header_offset = grib_context_tell(c, f);
-    data              = wmo_read_grib_from_file_malloc(f, headers_only, &olen, &offset, error);
-    end_msg_offset    = grib_context_tell(c, f);
+	if (c == NULL)
+		c = grib_context_get_default();
 
-    if (*error != GRIB_SUCCESS) {
-        if (data)
-            grib_context_free(c, data);
+	gts_header_offset = grib_context_tell(c, f);
+	data              = wmo_read_grib_from_file_malloc(f, headers_only, &olen, &offset, error);
+	end_msg_offset    = grib_context_tell(c, f);
 
-        if (*error == GRIB_END_OF_FILE)
-            *error = GRIB_SUCCESS;
-        return NULL;
-    }
+	if (*error != GRIB_SUCCESS) {
+		if (data)
+			grib_context_free(c, data);
 
-    if (c->gts_header_on) {
-        int g = 0;
-        grib_context_seek(c, gts_header_offset, SEEK_SET, f);
-        gtslen          = offset - gts_header_offset;
-        gts_header      = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
-        save_gts_header = gts_header;
-        grib_context_read(c, gts_header, gtslen, f);
-        g = gtslen;
-        while (gts_header != NULL && g != 0 && *gts_header != '\03') {
-            /*printf("--------%d %X \n",gtslen,*gts_header);*/
-            gts_header++;
-            g--;
-        }
-        if (g > 8) {
-            gts_header++;
-            gtslen = g - 1;
-        }
-        else
-            gts_header = save_gts_header;
-        grib_context_seek(c, end_msg_offset, SEEK_SET, f);
-    }
+		if (*error == GRIB_END_OF_FILE)
+			*error = GRIB_SUCCESS;
+		return NULL;
+	}
 
-    if (headers_only) {
-        gl = grib_handle_new_from_partial_message(c, data, olen);
-    }
-    else {
-        gl = grib_handle_new_from_message(c, data, olen);
-    }
+	if (c->gts_header_on) {
+		int g = 0;
+		grib_context_seek(c, gts_header_offset, SEEK_SET, f);
+		gtslen          = offset - gts_header_offset;
+		gts_header      = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
+		save_gts_header = gts_header;
+		grib_context_read(c, gts_header, gtslen, f);
+		g = gtslen;
+		while (gts_header != NULL && g != 0 && *gts_header != '\03') {
+			/*printf("--------%d %X \n",gtslen,*gts_header);*/
+			gts_header++;
+			g--;
+		}
+		if (g > 8) {
+			gts_header++;
+			gtslen = g - 1;
+		}
+		else
+			gts_header = save_gts_header;
+		grib_context_seek(c, end_msg_offset, SEEK_SET, f);
+	}
 
-    if (!gl) {
-        *error = GRIB_DECODING_ERROR;
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_file_no_multi: cannot create handle\n");
-        grib_context_free(c, data);
-        return NULL;
-    }
+	if (headers_only) {
+		gl = grib_handle_new_from_partial_message(c, data, olen);
+	}
+	else {
+		gl = grib_handle_new_from_message(c, data, olen);
+	}
 
-    gl->offset           = offset;
-    gl->buffer->property = GRIB_MY_BUFFER;
+	if (!gl) {
+		*error = GRIB_DECODING_ERROR;
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new_from_file_no_multi: cannot create handle\n");
+		grib_context_free(c, data);
+		return NULL;
+	}
 
-    grib_context_increment_handle_file_count(c);
-    grib_context_increment_handle_total_count(c);
+	gl->offset           = offset;
+	gl->buffer->property = GRIB_MY_BUFFER;
 
-    if (c->gts_header_on && gtslen >= 8) {
-        gl->gts_header = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
-        DebugAssert(gts_header);
-        if (gts_header) memcpy(gl->gts_header, gts_header, gtslen);
-        gl->gts_header_len = gtslen;
-        grib_context_free(c, save_gts_header);
-    }
-    else {
-        gl->gts_header = NULL;
-    }
+	grib_context_increment_handle_file_count(c);
+	grib_context_increment_handle_total_count(c);
 
-    return gl;
+	if (c->gts_header_on && gtslen >= 8) {
+		gl->gts_header = (char*)grib_context_malloc(c, sizeof(unsigned char) * gtslen);
+		DebugAssert(gts_header);
+		if (gts_header) memcpy(gl->gts_header, gts_header, gtslen);
+		gl->gts_header_len = gtslen;
+		grib_context_free(c, save_gts_header);
+	}
+	else {
+		gl->gts_header = NULL;
+	}
+
+	return gl;
 }
 
 grib_multi_handle* grib_multi_handle_new(grib_context* c)
 {
-    grib_multi_handle* h;
-    if (c == NULL)
-        c = grib_context_get_default();
-    if (!c->multi_support_on)
-        c->multi_support_on = 1;
+	grib_multi_handle* h;
+	if (c == NULL)
+		c = grib_context_get_default();
+	if (!c->multi_support_on)
+		c->multi_support_on = 1;
 
-    h = (grib_multi_handle*)grib_context_malloc_clear(c, sizeof(grib_multi_handle));
-    if (h == NULL) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_multi_handle_new: unable to allocate memory. %s",
-                         grib_get_error_message(GRIB_OUT_OF_MEMORY));
-        return NULL;
-    }
-    h->buffer          = grib_create_growable_buffer(c);
-    h->buffer->ulength = 0;
-    h->context         = c;
+	h = (grib_multi_handle*)grib_context_malloc_clear(c, sizeof(grib_multi_handle));
+	if (h == NULL) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_multi_handle_new: unable to allocate memory. %s",
+				grib_get_error_message(GRIB_OUT_OF_MEMORY));
+		return NULL;
+	}
+	h->buffer          = grib_create_growable_buffer(c);
+	h->buffer->ulength = 0;
+	h->context         = c;
 
-    return h;
+	return h;
 }
 
 int grib_multi_handle_delete(grib_multi_handle* h)
 {
-    if (h == NULL)
-        return GRIB_SUCCESS;
+	if (h == NULL)
+		return GRIB_SUCCESS;
 
-    grib_buffer_delete(h->context, h->buffer);
-    grib_context_free(h->context, h);
-    return GRIB_SUCCESS;
+	grib_buffer_delete(h->context, h->buffer);
+	grib_context_free(h->context, h);
+	return GRIB_SUCCESS;
 }
 
 int grib_multi_handle_append(grib_handle* h, int start_section, grib_multi_handle* mh)
 {
-    const void* mess = NULL;
-    unsigned char* p = NULL;
-    int err          = 0;
-    size_t mess_len  = 0;
-    size_t total_len = 0;
+	const void* mess = NULL;
+	unsigned char* p = NULL;
+	int err          = 0;
+	size_t mess_len  = 0;
+	size_t total_len = 0;
 
-    if (!h)
-        return GRIB_NULL_HANDLE;
-    if (!mh)
-        return GRIB_NULL_HANDLE;
+	if (!h)
+		return GRIB_NULL_HANDLE;
+	if (!mh)
+		return GRIB_NULL_HANDLE;
 
-    if (start_section == 0 || mh->buffer->ulength == 0) {
-        err = grib_get_message(h, &mess, &mess_len);
-        if (err != 0)
-            return err;
-        total_len = mh->buffer->ulength + mess_len;
+	if (start_section == 0 || mh->buffer->ulength == 0) {
+		err = grib_get_message(h, &mess, &mess_len);
+		if (err != 0)
+			return err;
+		total_len = mh->buffer->ulength + mess_len;
 
-        if (total_len > mh->buffer->length)
-            grib_grow_buffer(h->context, mh->buffer, total_len);
+		if (total_len > mh->buffer->length)
+			grib_grow_buffer(h->context, mh->buffer, total_len);
 
-        p = mh->buffer->data + mh->buffer->ulength;
-        memcpy(p, mess, mess_len);
-        mh->offset          = mh->buffer->ulength;
-        mh->buffer->ulength = total_len;
-        mh->length          = mess_len;
-    }
-    else {
-        long off = 0;
-        err      = grib_get_partial_message(h, &mess, &mess_len, start_section);
-        if (err != 0)
-            return err;
-        total_len = mh->buffer->ulength + mess_len - 4;
+		p = mh->buffer->data + mh->buffer->ulength;
+		memcpy(p, mess, mess_len);
+		mh->offset          = mh->buffer->ulength;
+		mh->buffer->ulength = total_len;
+		mh->length          = mess_len;
+	}
+	else {
+		long off = 0;
+		err      = grib_get_partial_message(h, &mess, &mess_len, start_section);
+		if (err != 0)
+			return err;
+		total_len = mh->buffer->ulength + mess_len - 4;
 
-        while (total_len > mh->buffer->length)
-            grib_grow_buffer(h->context, mh->buffer, total_len);
+		while (total_len > mh->buffer->length)
+			grib_grow_buffer(h->context, mh->buffer, total_len);
 
-        p = mh->buffer->data + mh->buffer->ulength - 4;
-        memcpy(p, mess, mess_len);
-        mh->length += mess_len - 4;
+		p = mh->buffer->data + mh->buffer->ulength - 4;
+		memcpy(p, mess, mess_len);
+		mh->length += mess_len - 4;
 
-        off = mh->offset + 64;
+		off = mh->offset + 64;
 
-        grib_encode_unsigned_long(mh->buffer->data, mh->length, &off, 64);
-        mh->buffer->ulength = total_len;
-    }
-    return err;
+		grib_encode_unsigned_long(mh->buffer->data, mh->length, &off, 64);
+		mh->buffer->ulength = total_len;
+	}
+	return err;
 }
 
 int grib_multi_handle_write(grib_multi_handle* h, FILE* f)
 {
-    if (f == NULL)
-        return GRIB_INVALID_FILE;
-    if (h == NULL)
-        return GRIB_INVALID_GRIB;
+	if (f == NULL)
+		return GRIB_INVALID_FILE;
+	if (h == NULL)
+		return GRIB_INVALID_GRIB;
 
-    if (fwrite(h->buffer->data, 1, h->buffer->ulength, f) != h->buffer->ulength) {
-        grib_context_log(h->context, GRIB_LOG_PERROR, "grib_multi_handle_write writing on file");
-        return GRIB_IO_PROBLEM;
-    }
+	if (fwrite(h->buffer->data, 1, h->buffer->ulength, f) != h->buffer->ulength) {
+		grib_context_log(h->context, GRIB_LOG_PERROR, "grib_multi_handle_write writing on file");
+		return GRIB_IO_PROBLEM;
+	}
 
-    return 0;
+	return 0;
 }
 
 int grib_get_partial_message(grib_handle* h, const void** msg, size_t* len, int start_section)
 {
-    size_t partial_len  = 0;
-    long section_offset = 0;
-    if (!h)
-        return GRIB_NULL_HANDLE;
+	size_t partial_len  = 0;
+	long section_offset = 0;
+	if (!h)
+		return GRIB_NULL_HANDLE;
 
-    if (start_section > h->sections_count)
-        return GRIB_INVALID_SECTION_NUMBER;
+	if (start_section > h->sections_count)
+		return GRIB_INVALID_SECTION_NUMBER;
 
-    grib_get_long(h, h->section_offset[start_section], &section_offset);
-    partial_len = h->buffer->ulength - section_offset;
+	grib_get_long(h, h->section_offset[start_section], &section_offset);
+	partial_len = h->buffer->ulength - section_offset;
 
-    *len = partial_len;
-    *msg = h->buffer->data + section_offset;
+	*len = partial_len;
+	*msg = h->buffer->data + section_offset;
 
-    return GRIB_SUCCESS;
+	return GRIB_SUCCESS;
 }
 
 int grib_get_partial_message_copy(grib_handle* h, void* message, size_t* len,
-                                  int start_section)
+		int start_section)
 {
-    size_t partial_len  = 0;
-    long section_offset = 0;
-    if (!h)
-        return GRIB_NULL_HANDLE;
+	size_t partial_len  = 0;
+	long section_offset = 0;
+	if (!h)
+		return GRIB_NULL_HANDLE;
 
-    if (start_section > h->sections_count)
-        return GRIB_INVALID_SECTION_NUMBER;
+	if (start_section > h->sections_count)
+		return GRIB_INVALID_SECTION_NUMBER;
 
-    grib_get_long(h, h->section_offset[start_section], &section_offset);
-    partial_len = h->buffer->ulength - section_offset;
+	grib_get_long(h, h->section_offset[start_section], &section_offset);
+	partial_len = h->buffer->ulength - section_offset;
 
-    if (*len < partial_len)
-        return GRIB_BUFFER_TOO_SMALL;
+	if (*len < partial_len)
+		return GRIB_BUFFER_TOO_SMALL;
 
-    *len = partial_len;
+	*len = partial_len;
 
-    memcpy(message, h->buffer->data + section_offset, *len);
-    return GRIB_SUCCESS;
+	memcpy(message, h->buffer->data + section_offset, *len);
+	return GRIB_SUCCESS;
 }
 
 int grib_get_message_copy(const grib_handle* h, void* message, size_t* len)
 {
-    if (!h)
-        return GRIB_NOT_FOUND;
+	if (!h)
+		return GRIB_NOT_FOUND;
 
-    if (*len < h->buffer->ulength)
-        return GRIB_BUFFER_TOO_SMALL;
+	if (*len < h->buffer->ulength)
+		return GRIB_BUFFER_TOO_SMALL;
 
-    *len = h->buffer->ulength;
+	*len = h->buffer->ulength;
 
-    memcpy(message, h->buffer->data, *len);
-    return GRIB_SUCCESS;
+	memcpy(message, h->buffer->data, *len);
+	return GRIB_SUCCESS;
 }
 
 int grib_get_message_offset(const grib_handle* h, off_t* offset)
 {
-    if (h)
-        *offset = h->offset;
-    else
-        return GRIB_INTERNAL_ERROR;
+	if (h)
+		*offset = h->offset;
+	else
+		return GRIB_INTERNAL_ERROR;
 
-    return 0;
+	return 0;
 }
 
 int codes_get_product_kind(const grib_handle* h, ProductKind* product_kind)
 {
-    if (h) {
-        *product_kind = h->product_kind;
-        return GRIB_SUCCESS;
-    }
-    return GRIB_NULL_HANDLE;
+	if (h) {
+		*product_kind = h->product_kind;
+		return GRIB_SUCCESS;
+	}
+	return GRIB_NULL_HANDLE;
 }
 
 int codes_check_message_header(const void* bytes, size_t length, ProductKind product)
 {
-    const char* p = ((const char*)bytes);
-    Assert(p);
-    Assert(product == PRODUCT_GRIB || product == PRODUCT_BUFR); /* Others not yet implemented */
-    Assert(length > 4);
-    if (product == PRODUCT_GRIB) {
-        if (p[0] != 'G' || p[1] != 'R' || p[2] != 'I' || p[3] != 'B')
-            return GRIB_INVALID_MESSAGE;
-    }
-    else if (product == PRODUCT_BUFR) {
-        if (p[0] != 'B' || p[1] != 'U' || p[2] != 'F' || p[3] != 'R')
-            return GRIB_INVALID_MESSAGE;
-    }
-    else {
-        return GRIB_NOT_IMPLEMENTED;
-    }
+	const char* p = ((const char*)bytes);
+	Assert(p);
+	Assert(product == PRODUCT_GRIB || product == PRODUCT_BUFR); /* Others not yet implemented */
+	Assert(length > 4);
+	if (product == PRODUCT_GRIB) {
+		if (p[0] != 'G' || p[1] != 'R' || p[2] != 'I' || p[3] != 'B')
+			return GRIB_INVALID_MESSAGE;
+	}
+	else if (product == PRODUCT_BUFR) {
+		if (p[0] != 'B' || p[1] != 'U' || p[2] != 'F' || p[3] != 'R')
+			return GRIB_INVALID_MESSAGE;
+	}
+	else {
+		return GRIB_NOT_IMPLEMENTED;
+	}
 
-    return GRIB_SUCCESS;
+	return GRIB_SUCCESS;
 }
 int codes_check_message_footer(const void* bytes, size_t length, ProductKind product)
 {
-    const char* p = ((const char*)bytes);
-    Assert(p);
-    Assert(product == PRODUCT_GRIB || product == PRODUCT_BUFR); /* Others not yet implemented */
+	const char* p = ((const char*)bytes);
+	Assert(p);
+	Assert(product == PRODUCT_GRIB || product == PRODUCT_BUFR); /* Others not yet implemented */
 
-    if (p[length - 4] != '7' || p[length - 3] != '7' || p[length - 2] != '7' || p[length - 1] != '7') {
-        return GRIB_7777_NOT_FOUND;
-    }
-    return GRIB_SUCCESS;
+	if (p[length - 4] != '7' || p[length - 3] != '7' || p[length - 2] != '7' || p[length - 1] != '7') {
+		return GRIB_7777_NOT_FOUND;
+	}
+	return GRIB_SUCCESS;
 }
 
 int grib_get_message_size(const grib_handle* ch, size_t* size)
 {
-    long totalLength = 0;
-    int ret          = 0;
-    grib_handle* h   = (grib_handle*)ch;
-    *size            = h->buffer->ulength;
-    ret              = grib_get_long(h, "totalLength", &totalLength);
-    if (!ret)
-        *size = totalLength;
-    return ret;
+	long totalLength = 0;
+	int ret          = 0;
+	grib_handle* h   = (grib_handle*)ch;
+	*size            = h->buffer->ulength;
+	ret              = grib_get_long(h, "totalLength", &totalLength);
+	if (!ret)
+		*size = totalLength;
+	return ret;
 }
 
 int grib_get_message(const grib_handle* ch, const void** msg, size_t* size)
 {
-    long totalLength = 0;
-    int ret          = 0;
-    grib_handle* h   = (grib_handle*)ch;
-    *msg             = h->buffer->data;
-    *size            = h->buffer->ulength;
+	long totalLength = 0;
+	int ret          = 0;
+	grib_handle* h   = (grib_handle*)ch;
+	*msg             = h->buffer->data;
+	*size            = h->buffer->ulength;
 
-    ret = grib_get_long(h, "totalLength", &totalLength);
-    if (!ret)
-        *size = totalLength;
+	ret = grib_get_long(h, "totalLength", &totalLength);
+	if (!ret)
+		*size = totalLength;
 
-    if (h->context->gts_header_on && h->gts_header) {
-        char strbuf[10];
-        sprintf(strbuf, "%.8d", (int)(h->buffer->ulength + h->gts_header_len - 6));
-        memcpy(h->gts_header, strbuf, 8);
-    }
-    return 0;
+	if (h->context->gts_header_on && h->gts_header) {
+		char strbuf[10];
+		sprintf(strbuf, "%.8d", (int)(h->buffer->ulength + h->gts_header_len - 6));
+		memcpy(h->gts_header, strbuf, 8);
+	}
+	return 0;
 }
 
 int grib_get_message_headers(grib_handle* h, const void** msg, size_t* size)
 {
-    int ret = 0;
-    size_t endOfHeadersMarker;
-    *msg  = h->buffer->data;
-    *size = h->buffer->ulength;
+	int ret = 0;
+	size_t endOfHeadersMarker;
+	*msg  = h->buffer->data;
+	*size = h->buffer->ulength;
 
-    if ((ret = grib_get_offset(h, "endOfHeadersMarker", &endOfHeadersMarker)) != GRIB_SUCCESS) {
-        grib_context_log(h->context, GRIB_LOG_FATAL,
-                         "grib_get_message_headers unable to get offset of endOfHeadersMarker");
-        return ret;
-    }
+	if ((ret = grib_get_offset(h, "endOfHeadersMarker", &endOfHeadersMarker)) != GRIB_SUCCESS) {
+		grib_context_log(h->context, GRIB_LOG_FATAL,
+				"grib_get_message_headers unable to get offset of endOfHeadersMarker");
+		return ret;
+	}
 
-    *size = endOfHeadersMarker;
+	*size = endOfHeadersMarker;
 
-    return ret;
+	return ret;
 }
 
 grib_handle* grib_handle_new(grib_context* c)
 {
-    grib_handle* h;
+	grib_handle* h;
 
-    if (!c)
-        c = grib_context_get_default();
-    h         = grib_new_handle(c);
-    h->buffer = grib_create_growable_buffer(c);
-    if (h->buffer == NULL) {
-        grib_handle_delete(h);
-        return NULL;
-    }
-    h->root = grib_create_root_section(h->context, h);
+	if (!c)
+		c = grib_context_get_default();
+	h         = grib_new_handle(c);
+	h->buffer = grib_create_growable_buffer(c);
+	if (h->buffer == NULL) {
+		grib_handle_delete(h);
+		return NULL;
+	}
+	h->root = grib_create_root_section(h->context, h);
 
-    if (!h->root) {
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new: cannot create root section");
-        grib_handle_delete(h);
-        return NULL;
-    }
+	if (!h->root) {
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new: cannot create root section");
+		grib_handle_delete(h);
+		return NULL;
+	}
 
-    if (!h->context->grib_reader || !h->context->grib_reader->first) {
-        grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new: cannot create handle, no definitions found");
-        grib_handle_delete(h);
-        return NULL;
-    }
+	if (!h->context->grib_reader || !h->context->grib_reader->first) {
+		grib_context_log(c, GRIB_LOG_ERROR, "grib_handle_new: cannot create handle, no definitions found");
+		grib_handle_delete(h);
+		return NULL;
+	}
 
-    h->buffer->property = GRIB_USER_BUFFER;
+	h->buffer->property = GRIB_USER_BUFFER;
 
-    h->header_mode = 1;
+	h->header_mode = 1;
 
-    return h;
+	return h;
 }
 
 grib_action* grib_action_from_filter(const char* filter)
 {
-    grib_action* a        = NULL;
-    grib_context* context = grib_context_get_default();
-    a                     = grib_parse_file(context, filter);
-    context->grib_reader  = NULL;
-    return a;
+	grib_action* a        = NULL;
+	grib_context* context = grib_context_get_default();
+	a                     = grib_parse_file(context, filter);
+	context->grib_reader  = NULL;
+	return a;
 }
 
 int grib_handle_apply_action(grib_handle* h, grib_action* a)
 {
-    int err;
+	int err;
 
-    if (!a)
-        return GRIB_SUCCESS; /* TODO: return error */
+	if (!a)
+		return GRIB_SUCCESS; /* TODO: return error */
 
-    while (a) {
-        err = grib_action_execute(a, h);
-        if (err != GRIB_SUCCESS)
-            return err;
-        a = a->next;
-    }
+	while (a) {
+		err = grib_action_execute(a, h);
+		if (err != GRIB_SUCCESS)
+			return err;
+		a = a->next;
+	}
 
-    return GRIB_SUCCESS;
+	return GRIB_SUCCESS;
 }
 
 int grib_handle_prepare_action(grib_handle* h, grib_action* a)
 {
-    int err;
+	int err;
 
-    if (!a)
-        return GRIB_SUCCESS; /* TODO: return error */
+	if (!a)
+		return GRIB_SUCCESS; /* TODO: return error */
 
-    while (a) {
-        err = grib_action_execute(a, h);
-        if (err != GRIB_SUCCESS)
-            return err;
-        a = a->next;
-    }
+	while (a) {
+		err = grib_action_execute(a, h);
+		if (err != GRIB_SUCCESS)
+			return err;
+		a = a->next;
+	}
 
-    return GRIB_SUCCESS;
+	return GRIB_SUCCESS;
 }
 
 static int grib2_get_next_section(unsigned char* msgbegin, size_t msglen, unsigned char** secbegin, size_t* seclen, int* secnum, int* err)
 {
-    if (!grib2_has_next_section(msgbegin, msglen, *secbegin, *seclen, err))
-        return 0;
+	if (!grib2_has_next_section(msgbegin, msglen, *secbegin, *seclen, err))
+		return 0;
 
-    *secbegin += *seclen;
-    *seclen = grib_decode_unsigned_byte_long(*secbegin, 0, 4);
-    *secnum = grib_decode_unsigned_byte_long(*secbegin, 4, 1);
+	*secbegin += *seclen;
+	*seclen = grib_decode_unsigned_byte_long(*secbegin, 0, 4);
+	*secnum = grib_decode_unsigned_byte_long(*secbegin, 4, 1);
 
-    if (*secnum < 1 || *secnum > 7) {
-        *err = GRIB_INVALID_SECTION_NUMBER;
-        return 0;
-    }
-    return 1;
+	if (*secnum < 1 || *secnum > 7) {
+		*err = GRIB_INVALID_SECTION_NUMBER;
+		return 0;
+	}
+	return 1;
 }
 
 static int grib2_has_next_section(unsigned char* msgbegin, size_t msglen, unsigned char* secbegin, size_t seclen, int* err)
 {
-    long next_seclen;
-    *err = 0;
+	long next_seclen;
+	*err = 0;
 
-    next_seclen = (msgbegin + msglen) - (secbegin + seclen);
+	next_seclen = (msgbegin + msglen) - (secbegin + seclen);
 
-    if (next_seclen < 5) {
-        if ((next_seclen > 3) && !strncmp((char*)secbegin, "7777", 4))
-            *err = GRIB_SUCCESS;
-        else
-            *err = GRIB_7777_NOT_FOUND;
-        return 0;
-    }
+	if (next_seclen < 5) {
+		if ((next_seclen > 3) && !strncmp((char*)secbegin, "7777", 4))
+			*err = GRIB_SUCCESS;
+		else
+			*err = GRIB_7777_NOT_FOUND;
+		return 0;
+	}
 
-    /*secbegin += seclen;*/
+	/*secbegin += seclen;*/
 
-    return 1;
+	return 1;
 }
 
 static void grib2_build_message(grib_context* context, unsigned char* sections[], size_t sections_len[], void** data, size_t* len)
 {
-    int i            = 0;
-    char* theEnd     = "7777";
-    unsigned char* p = 0;
-    size_t msglen    = 0;
-    long bitp        = 64;
-    if (!sections[0]) {
-        *data = NULL;
-        return;
-    }
+	int i            = 0;
+	char* theEnd     = "7777";
+	unsigned char* p = 0;
+	size_t msglen    = 0;
+	long bitp        = 64;
+	if (!sections[0]) {
+		*data = NULL;
+		return;
+	}
 
-    for (i = 0; i < 8; i++)
-        msglen += sections_len[i];
-    msglen += 4;
-    if (*len < msglen)
-        msglen = *len;
+	for (i = 0; i < 8; i++)
+		msglen += sections_len[i];
+	msglen += 4;
+	if (*len < msglen)
+		msglen = *len;
 
-    *data = (unsigned char*)grib_context_malloc(context, msglen);
-    p     = (unsigned char*)*data;
+	*data = (unsigned char*)grib_context_malloc(context, msglen);
+	p     = (unsigned char*)*data;
 
-    for (i = 0; i < 8; i++) {
-        if (sections[i]) {
-            memcpy(p, sections[i], sections_len[i]);
-            p += sections_len[i];
-        }
-    }
+	for (i = 0; i < 8; i++) {
+		if (sections[i]) {
+			memcpy(p, sections[i], sections_len[i]);
+			p += sections_len[i];
+		}
+	}
 
-    memcpy(p, theEnd, 4);
+	memcpy(p, theEnd, 4);
 
-    grib_encode_unsigned_long((unsigned char*)*data, msglen, &bitp, 64);
+	grib_encode_unsigned_long((unsigned char*)*data, msglen, &bitp, 64);
 
-    *len = msglen;
+	*len = msglen;
 }
 
 /* For multi support mode: Reset all file handles equal to f. See GRIB-249 */
 void grib_multi_support_reset_file(grib_context* c, FILE* f)
 {
-    grib_multi_support* gm = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    gm = c->multi_support;
-    while (gm) {
-        if (gm->file == f) {
-            gm->file = NULL;
-        }
-        gm = gm->next;
-    }
+	grib_multi_support* gm = NULL;
+	if (!c)
+		c = grib_context_get_default();
+	gm = c->multi_support;
+	while (gm) {
+		if (gm->file == f) {
+			gm->file = NULL;
+		}
+		gm = gm->next;
+	}
 }
 
 static grib_multi_support* grib_get_multi_support(grib_context* c, FILE* f)
 {
-    int i                    = 0;
-    grib_multi_support* gm   = c->multi_support;
-    grib_multi_support* prev = NULL;
+	int i                    = 0;
+	grib_multi_support* gm   = c->multi_support;
+	grib_multi_support* prev = NULL;
 
-    while (gm) {
-        if (gm->file == f)
-            return gm;
-        prev = gm;
-        gm   = gm->next;
-    }
+	while (gm) {
+		if (gm->file == f)
+			return gm;
+		prev = gm;
+		gm   = gm->next;
+	}
 
-    if (!gm) {
-        gm = grib_multi_support_new(c);
-        if (!c->multi_support) {
-            c->multi_support = gm;
-        }
-        else {
-            if (prev)
-                prev->next = gm;
-        }
-    }
+	if (!gm) {
+		gm = grib_multi_support_new(c);
+		if (!c->multi_support) {
+			c->multi_support = gm;
+		}
+		else {
+			if (prev)
+				prev->next = gm;
+		}
+	}
 
-    gm->next = 0;
-    if (gm->message)
-        grib_context_free(c, gm->message);
-    gm->message            = NULL;
-    gm->section_number     = 0;
-    gm->sections_length[0] = 16;
-    for (i = 1; i < 8; i++)
-        gm->sections_length[i] = 0;
-    gm->sections_length[8] = 4;
-    gm->file               = f;
+	gm->next = 0;
+	if (gm->message)
+		grib_context_free(c, gm->message);
+	gm->message            = NULL;
+	gm->section_number     = 0;
+	gm->sections_length[0] = 16;
+	for (i = 1; i < 8; i++)
+		gm->sections_length[i] = 0;
+	gm->sections_length[8] = 4;
+	gm->file               = f;
 
-    return gm;
+	return gm;
 }
 
 void grib_multi_support_reset(grib_context* c)
 {
-    grib_multi_support* gm   = c->multi_support;
-    grib_multi_support* next = NULL;
-    int i                    = 0;
-    while (next) {
-        next = gm->next;
-        if (gm->file)
-            fclose(gm->file);
-        if (gm->message)
-            grib_context_free(c, gm->message);
-        gm->message = NULL;
-        for (i = 0; i < 8; i++)
-            gm->sections[i] = 0;
-        if (gm->bitmap_section)
-            grib_context_free(c, gm->bitmap_section);
-        gm->bitmap_section = NULL;
-        grib_context_free(c, gm);
-        gm = NULL;
-    }
+	grib_multi_support* gm   = c->multi_support;
+	grib_multi_support* next = NULL;
+	int i                    = 0;
+	while (next) {
+		next = gm->next;
+		if (gm->file)
+			fclose(gm->file);
+		if (gm->message)
+			grib_context_free(c, gm->message);
+		gm->message = NULL;
+		for (i = 0; i < 8; i++)
+			gm->sections[i] = 0;
+		if (gm->bitmap_section)
+			grib_context_free(c, gm->bitmap_section);
+		gm->bitmap_section = NULL;
+		grib_context_free(c, gm);
+		gm = NULL;
+	}
 }
 
 static grib_multi_support* grib_multi_support_new(grib_context* c)
 {
-    int i = 0;
-    grib_multi_support* gm =
-        (grib_multi_support*)grib_context_malloc_clear(c, sizeof(grib_multi_support));
-    gm->file                  = NULL;
-    gm->message               = NULL;
-    gm->message_length        = 0;
-    gm->bitmap_section        = NULL;
-    gm->bitmap_section_length = 0;
-    gm->section_number        = 0;
-    gm->next                  = 0;
-    gm->sections_length[0]    = 16;
-    for (i = 1; i < 8; i++)
-        gm->sections_length[i] = 0;
-    gm->sections_length[8] = 4;
+	int i = 0;
+	grib_multi_support* gm =
+			(grib_multi_support*)grib_context_malloc_clear(c, sizeof(grib_multi_support));
+	gm->file                  = NULL;
+	gm->message               = NULL;
+	gm->message_length        = 0;
+	gm->bitmap_section        = NULL;
+	gm->bitmap_section_length = 0;
+	gm->section_number        = 0;
+	gm->next                  = 0;
+	gm->sections_length[0]    = 16;
+	for (i = 1; i < 8; i++)
+		gm->sections_length[i] = 0;
+	gm->sections_length[8] = 4;
 
-    return gm;
+	return gm;
 }

--- a/src/grib_iarray.c
+++ b/src/grib_iarray.c
@@ -11,251 +11,259 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+extern grib_iarrayPOOL iarrayPOOL;
+
 /* For debugging purposes */
-void grib_iarray_print(const char* title, const grib_iarray* iarray)
+void grib_iarray_print(const char* title, const grib_iarray* source)
 {
-    size_t i;
-    Assert(iarray);
-    printf("%s: iarray.n=%lu  \t", title, (unsigned long)iarray->n);
-    for (i = 0; i < iarray->n; i++) {
-        printf("iarray[%lu]=%ld\t", (unsigned long)i, iarray->v[i]);
-    }
-    printf("\n");
-}
-
-grib_iarray* grib_iarray_new_from_array(grib_context* c, long* a, size_t size)
-{
-    size_t i;
-    grib_iarray* v;
-
-    if (!c)
-        c = grib_context_get_default();
-
-    v = grib_iarray_new(c, size, 100);
-    for (i = 0; i < size; i++)
-        v->v[i] = a[i];
-    v->n                   = size;
-    v->number_of_pop_front = 0;
-    v->context             = c;
-    return v;
+	size_t i;
+	Assert(source);
+	printf("%s: iarray.n=%lu  \t", title, (unsigned long)source->n);
+	for (i = 0; i < source->n; i++) {
+		if( i<= (DYN_DEFAULT_IARRAY_SIZE_INIT - 1)) {
+			printf("iarray[%lu]=%ld\t", (unsigned long)i, source->stA[i]);
+		} else {
+			printf("iarray[%lu]=%ld\t", (unsigned long)i, source->dynA[(i-(DYN_DEFAULT_IARRAY_SIZE_INIT))]);
+		}
+	}
+	printf("\n");
 }
 
 grib_iarray* grib_iarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_iarray* v = NULL;
+	grib_iarray* result = NULL;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (!c)
+		c = grib_context_get_default();
 
-    v = (grib_iarray*)grib_context_malloc(c, sizeof(grib_iarray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_iarray_new unable to allocate %d bytes\n", sizeof(grib_iarray));
-        return NULL;
-    }
-    v->context             = c;
-    v->size                = size;
-    v->n                   = 0;
-    v->incsize             = incsize;
-    v->v                   = (long*)grib_context_malloc(c, sizeof(long) * size);
-    v->number_of_pop_front = 0;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_iarray_new unable to allocate %d bytes\n", sizeof(long) * size);
-        return NULL;
-    }
-    return v;
+	result = (grib_iarray*)grib_context_malloc(c, sizeof(grib_iarray));
+	if (!result) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_iarray_new unable to allocate %d bytes\n", sizeof(grib_iarray));
+		return NULL;
+	}
+	result->context             = c;
+
+	if(size > DYN_DEFAULT_IARRAY_SIZE_INIT) {
+
+		result->dynA                   = (long*)grib_context_malloc(c, (sizeof(long) * (size-DYN_DEFAULT_IARRAY_SIZE_INIT)) );
+
+		if (!result->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_iarray_new unable to allocate %d bytes\n", (sizeof(long) * (size-DYN_DEFAULT_IARRAY_SIZE_INIT)) );
+			return NULL;
+		}
+
+		result->size                = size;
+		if (incsize > 0)
+			result->incsize             = incsize;
+		else
+			result->incsize             = DYN_DEFAULT_IARRAY_SIZE_INCR;
+
+	} else {
+
+		result->dynA					= NULL;
+		result->size                = DYN_DEFAULT_IARRAY_SIZE_INIT;
+		result->incsize             = DYN_DEFAULT_IARRAY_SIZE_INCR;
+
+	}
+
+	result->n                   = 0;
+
+	return result;
 }
 
-long grib_iarray_pop(grib_iarray* a)
+grib_iarray* grib_iarray_resize(grib_iarray* origin)
 {
-    a->n -= 1;
-    return a->v[a->n];
+	grib_context* c;
+	int newsize;
+
+	if (!origin)
+	{
+		return origin;
+	}
+
+	newsize = (origin->incsize + origin->size);
+	c = origin->context;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA){
+
+		origin->dynA      = (long*)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_IARRAY_SIZE_INIT) * sizeof(long));
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_iarray_resize unable to allocate %d bytes\n", sizeof(long) * newsize);
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA      = (long*)grib_context_malloc(c,  (newsize-DYN_DEFAULT_IARRAY_SIZE_INIT ) * sizeof(long) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_iarray_resize unable to allocate %d bytes\n", sizeof(long) * newsize);
+			return NULL;
+		}
+
+	}
+
+	origin->size                = newsize;
+
+	return origin;
 }
 
-long grib_iarray_pop_front(grib_iarray* a)
+void iarrayPoolInit(grib_context* c)
 {
-    long v = a->v[0];
-    /* size_t i=0; */
-    if (a->n == 0)
-        Assert(0);
-    a->n--;
-    a->v++;
-    a->number_of_pop_front++;
-    /* for (i=0;i<a->n;i++) a->v[i]=a->v[i+1]; */
+	int i;
+	grib_context* poolContext = c ? c : 0 ;
 
-    return v;
+	for (i=0; i<DYN_DEFAULT_IARRAY_POOL_SIZE; i++) {
+		iarrayPOOL.arrayPOOL[i].context=poolContext;
+		iarrayPOOL.arrayPOOL[i].size=DYN_DEFAULT_IARRAY_SIZE_INIT;
+		iarrayPOOL.arrayPOOL[i].n=0;
+		iarrayPOOL.arrayPOOL[i].incsize=DYN_DEFAULT_IARRAY_SIZE_INCR;
+		iarrayPOOL.arrayPOOL[i].dynA=0;
+		memset(iarrayPOOL.arrayPOOL[i].stA,0,DYN_DEFAULT_IARRAY_SIZE_INIT);
+	}
 }
 
-grib_iarray* grib_iarray_resize_to(grib_iarray* v, size_t newsize)
+grib_iarray* grib_iarray_push(grib_iarray* source, long val)
 {
-    long* newv;
-    size_t i;
-    grib_context* c = v->context;
+	size_t start_size    = DYN_DEFAULT_IARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_IARRAY_SIZE_INCR;
 
-    if (newsize < v->size)
-        return v;
+	/*If the target is empty, initialize it*/
+	/*if (!source)
+		source = grib_iarray_new(0, start_size, start_incsize);*/
+	if (!source) {
+		if(iarrayPOOL.poolCounter != (DYN_DEFAULT_IARRAY_POOL_SIZE - 1) ) {
+			grib_context* c = grib_context_get_default();
+			iarrayPOOL.arrayPOOL[iarrayPOOL.poolCounter].context=c;
+			source = &(iarrayPOOL.arrayPOOL[iarrayPOOL.poolCounter]);
+			iarrayPOOL.poolCounter++;
+		} else {
+			source = grib_iarray_new(0, start_size, start_incsize);
+		}
+	}
 
-    if (!c)
-        c = grib_context_get_default();
+	/*If the actual used size of the target is equal to the allowed size, resize the array*/
+	if (source->n == source->size) {
 
-    newv = (long*)grib_context_malloc_clear(c, newsize * sizeof(long));
-    if (!newv) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_iarray_resize unable to allocate %d bytes\n", sizeof(long) * newsize);
-        return NULL;
-    }
+		source = grib_iarray_resize(source);
 
-    for (i = 0; i < v->n; i++)
-        newv[i] = v->v[i];
+		/*Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!*/
+		if (!source)
+		{
+			return source;
+		}
 
-    v->v -= v->number_of_pop_front;
-    grib_context_free(c, v->v);
+		/*insertion in new allocated dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_IARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
 
-    v->v                   = newv;
-    v->size                = newsize;
-    v->number_of_pop_front = 0;
+	}
 
-    return v;
+	/*insertion in static array*/
+	if (source->n <= (DYN_DEFAULT_IARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		/*insertion in dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_IARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+	return source;
 }
 
-grib_iarray* grib_iarray_resize(grib_iarray* v)
+long grib_iarray_get(const grib_iarray* source, size_t index)
 {
-    int newsize = v->incsize + v->size;
 
-    return grib_iarray_resize_to(v, newsize);
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_IARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[index-DYN_DEFAULT_IARRAY_SIZE_INIT];
+		}
+	}
+
+	return 0;
 }
 
-grib_iarray* grib_iarray_push(grib_iarray* v, long val)
+/**
+ * The method returns the array currently in use. If the given grib_iarray structure pointer is null, it returns NULL.
+ */
+long* grib_iarray_get_arrays_by_reference(const grib_iarray* source)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
 
-    if (!v)
-        v = grib_iarray_new(0, start_size, start_incsize);
+	if(!source)
+		return NULL;
 
-    if (v->n >= v->size - v->number_of_pop_front)
-        v = grib_iarray_resize(v);
+	/*return source->stA;*/
 
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	/* PREVIOUS ATTEMPT */
+	if (source->n < DYN_DEFAULT_IARRAY_SIZE_INIT) {
+		return source->stA; /* stA is the static array */
+	} else {
+		if (source->dynA) {
+			return source->dynA;/* dynA is the dynamic array */
+		}
+	}
+
+	return NULL;
 }
 
-grib_iarray* grib_iarray_push_front(grib_iarray* v, long val)
+void grib_iarray_delete(grib_iarray* source)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    int i;
-    if (!v)
-        v = grib_iarray_new(0, start_size, start_incsize);
+	grib_context* c;
 
-    if (v->number_of_pop_front) {
-        v->v--;
-        v->number_of_pop_front--;
-    }
-    else {
-        if (v->n >= v->size)
-            v = grib_iarray_resize(v);
-        for (i = v->n; i > 0; i--)
-            v[i] = v[i - 1];
-    }
-    v->v[0] = val;
-    v->n++;
+	if (!source)
+		return;
+	c = source->context;
 
-    return v;
+	if (source->dynA) {
+		grib_context_free(c, source->dynA);
+	}
+
+	grib_context_free(c, source);
 }
 
-grib_iarray* grib_iarray_push_array(grib_iarray* v, long* val, size_t size)
+long* grib_iarray_get_array(grib_iarray* source)
 {
-    size_t start_size    = size;
-    size_t start_incsize = 100;
-    long* vp             = 0;
-    long* valp           = val;
-    if (!v)
-        v = grib_iarray_new(0, start_size, start_incsize);
+	long* vv;
+	size_t i;
+	grib_context* c = grib_context_get_default();
 
-    v  = grib_iarray_resize_to(v, size + v->n);
-    vp = v->v + v->n + v->number_of_pop_front;
-    v->n += size;
-    while (size) {
-        *(vp++) = *(valp++);
-        size--;
-    }
-    return v;
+	vv = (long*)grib_context_malloc_clear(c, sizeof(long) * source->n);
+	for (i = 0; i < source->n; i++) {
+		if( i<= (DYN_DEFAULT_IARRAY_SIZE_INIT - 1)) {
+			vv[i] = source->stA[i];
+		} else {
+			vv[i] = source->dynA[(i-(DYN_DEFAULT_IARRAY_SIZE_INIT))];
+		}
+	}
+
+	return vv;
 }
 
-long grib_iarray_get(grib_iarray* a, size_t i)
+size_t grib_iarray_used_size(grib_iarray* source)
 {
-    return a->v[i];
-}
-
-void grib_iarray_set(grib_iarray* a, size_t i, long v)
-{
-    a->v[i] = v;
-}
-
-void grib_iarray_delete(grib_iarray* v)
-{
-    grib_context* c;
-
-    if (!v)
-        return;
-    c = v->context;
-
-    grib_iarray_delete_array(v);
-
-    grib_context_free(c, v);
-}
-
-void grib_iarray_delete_array(grib_iarray* v)
-{
-    grib_context* c;
-
-    if (!v)
-        return;
-    c = v->context;
-
-    if (v->v) {
-        long* vv = v->v - v->number_of_pop_front;
-        grib_context_free(c, vv);
-    }
-}
-
-long* grib_iarray_get_array(grib_iarray* v)
-{
-    long* vv;
-    size_t i;
-    grib_context* c = grib_context_get_default();
-
-    vv = (long*)grib_context_malloc_clear(c, sizeof(long) * v->n);
-    for (i = 0; i < v->n; i++)
-        vv[i] = v->v[i];
-
-    return vv;
-}
-
-size_t grib_iarray_used_size(grib_iarray* v)
-{
-    return v == NULL ? 0 : v->n;
-}
-
-int grib_iarray_is_constant(grib_iarray* v)
-{
-    int i;
-    long val;
-    if (v->n == 1)
-        return 1;
-
-    val = v->v[0];
-    for (i = 1; i < v->n; i++) {
-        if (val != v->v[i])
-            return 0;
-    }
-    return 1;
+	return (!source) ? 0 : source->n;
 }

--- a/src/grib_oarray.c
+++ b/src/grib_oarray.c
@@ -11,111 +11,220 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+
 grib_oarray* grib_oarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_oarray* v = NULL;
+    grib_oarray* result = NULL;
+
     if (!c)
         c = grib_context_get_default();
-    v = (grib_oarray*)grib_context_malloc_clear(c, sizeof(grib_oarray));
-    if (!v) {
+
+    result = (grib_oarray*)grib_context_malloc_clear(c, sizeof(grib_oarray));
+    if (!result) {
         grib_context_log(c, GRIB_LOG_ERROR,
                          "grib_oarray_new unable to allocate %d bytes\n", sizeof(grib_oarray));
         return NULL;
     }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (void**)grib_context_malloc_clear(c, sizeof(char*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_oarray_new unable to allocate %d bytes\n", sizeof(char*) * size);
-        return NULL;
+
+    if(size > DYN_DEFAULT_OARRAY_SIZE_INIT) {
+
+    	result->dynA       = (void**)grib_context_malloc_clear(c, sizeof(char *) * (size-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_oarray_new unable to allocate %d bytes\n", sizeof(char *) * (size-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+    		return NULL;
+    	}
+
+    	result->size    = size;
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_OARRAY_SIZE_INIT;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_OARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_OARRAY_SIZE_INCR;
+
     }
-    return v;
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* v)
+grib_oarray* grib_oarray_resize(grib_context* c, grib_oarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (!origin)
+	{
+		return origin;
+	}
 
-    v->v    = (void**)grib_context_realloc(c, v->v, newsize * sizeof(char*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_oarray_resize unable to allocate %d bytes\n", sizeof(char*) * newsize);
-        return NULL;
-    }
-    return v;
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA){
+
+		origin->dynA    = (void**)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_OARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_oarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (void**)grib_context_malloc(c, (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_oarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_OARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* v, void* val)
+grib_oarray* grib_oarray_push(grib_context* c, grib_oarray* source, void* val)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_oarray_new(c, start_size, start_incsize);
+	size_t start_size    = DYN_DEFAULT_OARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_OARRAY_SIZE_INCR;
 
-    if (v->n >= v->size)
-        v = grib_oarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	/*If the target is empty, initialize it*/
+	if (!source)
+		source = grib_oarray_new(c, start_size, start_incsize);
+
+	/*If the actual used size of the target is equal to the allowed size, resize the array*/
+	if (source->n == source->size) {
+
+		source = grib_oarray_resize(c, source);
+
+		/*Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!*/
+		if (!source)
+		{
+			return source;
+		}
+
+		/*insertion in new allocated dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_OARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
+
+	}
+
+	/*insertion in static array*/
+	if (source->n <= (DYN_DEFAULT_OARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		/*insertion in dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_OARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+	return source;
 }
 
-void grib_oarray_delete(grib_context* c, grib_oarray* v)
+/**
+ * Return the void* value at index 'index' for grib_oarray 'source'
+ */
+void* grib_oarray_get(const grib_oarray* source, size_t index)
 {
-    if (!v)
+	if (!source)
+		return NULL;
+
+	if (index < 0)
+		return NULL;
+
+	if (index < DYN_DEFAULT_OARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[(index-DYN_DEFAULT_OARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * Sets the void* value 'val' at index 'index' for grib_oarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_oarray_put (grib_oarray* source, size_t index, void* val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_OARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA) {
+			source->dynA[(index-DYN_DEFAULT_OARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_oarray_delete(grib_context* c, grib_oarray* source)
+{
+    if (!source)
         return;
+
     if (!c)
         grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+
+    if (source->dynA)
+        grib_context_free(c, source->dynA);
+
+    grib_context_free(c, source);
 }
 
-void grib_oarray_delete_content(grib_context* c, grib_oarray* v)
+void grib_oarray_delete_content(grib_context* c, grib_oarray* source)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        if (v->v[i])
-            grib_context_free(c, v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+	int i;
+
+	if (!source)
+		return;
+
+	if (!c)
+		grib_context_get_default();
+
+	/*If the actual used size of the target is greater than the allowed size, it is a resized array*/
+	if (source->n > source->size && ( source->dynA) ) {
+		for (i = 0; i < (source->n - DYN_DEFAULT_OARRAY_SIZE_INIT); i++) {
+			source->dynA[i] = 0;
+		}
+	}
+
+	for (i = 0; i < (DYN_DEFAULT_OARRAY_SIZE_INIT); i++) {
+		source->stA[i] = 0;
+	}
+
+	source->n = 0;
 }
 
-void** grib_oarray_get_array(grib_context* c, grib_oarray* v)
+size_t grib_oarray_used_size(grib_oarray* source)
 {
-    void** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (void**)grib_context_malloc_clear(c, sizeof(char*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
-}
-
-void* grib_oarray_get(grib_oarray* v, int i)
-{
-    if (v == NULL || i > v->n - 1)
-        return NULL;
-    return v->v[i];
-}
-
-size_t grib_oarray_used_size(grib_oarray* v)
-{
-    return v->n;
+	return (!source) ? 0 : source->n;
 }

--- a/src/grib_parse_utils.c
+++ b/src/grib_parse_utils.c
@@ -21,6 +21,9 @@ grib_concept_value* grib_parser_concept       = 0;
 grib_hash_array_value* grib_parser_hash_array = 0;
 grib_rule* grib_parser_rules                  = 0;
 
+grib_iarrayPOOL iarrayPOOL;
+grib_darrayPOOL darrayPOOL;
+
 extern FILE* grib_yyin;
 extern int grib_yydebug;
 

--- a/src/grib_sarray.c
+++ b/src/grib_sarray.c
@@ -11,6 +11,7 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
@@ -18,97 +19,265 @@
 
 grib_sarray* grib_sarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_sarray* v = NULL;
+    grib_sarray* result = NULL;
+
     if (!c)
         c = grib_context_get_default();
-    v = (grib_sarray*)grib_context_malloc_clear(c, sizeof(grib_sarray));
-    if (!v) {
+
+    result = (grib_sarray*)grib_context_malloc_clear(c, sizeof(grib_sarray));
+    if (!result) {
         grib_context_log(c, GRIB_LOG_ERROR,
                          "grib_sarray_new unable to allocate %d bytes\n", sizeof(grib_sarray));
         return NULL;
     }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (char**)grib_context_malloc_clear(c, sizeof(char*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_sarray_new unable to allocate %d bytes\n", sizeof(char*) * size);
-        return NULL;
+
+    if(size > DYN_DEFAULT_SARRAY_SIZE_INIT) {
+
+    	result->dynA       = (char**)grib_context_malloc_clear(c, sizeof(char *) * (size-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+    	if (!result->dynA) {
+    		grib_context_log(c, GRIB_LOG_ERROR,
+    				"grib_sarray_new unable to allocate %d bytes\n", sizeof(char *) * (size-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+    		return NULL;
+    	}
+
+    	result->size    = size;
+    	if (incsize > 0)
+    		result->incsize             = incsize;
+    	else
+    		result->incsize             = DYN_DEFAULT_SARRAY_SIZE_INCR;
+
+    } else {
+
+    	result->dynA					= NULL;
+    	result->size                = DYN_DEFAULT_SARRAY_SIZE_INIT;
+    	result->incsize             = DYN_DEFAULT_SARRAY_SIZE_INCR;
+
     }
-    return v;
+
+    result->n       = 0;
+
+    return result;
 }
 
-grib_sarray* grib_sarray_resize(grib_context* c, grib_sarray* v)
+grib_sarray* grib_sarray_resize(grib_context* c, grib_sarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (!origin)
+	{
+		return origin;
+	}
 
-    v->v    = (char**)grib_context_realloc(c, v->v, newsize * sizeof(char*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_sarray_resize unable to allocate %d bytes\n", sizeof(char*) * newsize);
-        return NULL;
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA){
+
+		origin->dynA    = (char**)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_sarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (char**)grib_context_malloc(c, (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) * sizeof(char*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_sarray_resize unable to allocate %d bytes\n", sizeof(char*) * (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
+}
+
+grib_sarray* grib_sarray_push(grib_context* c, grib_sarray* source, char* val)
+{
+    size_t start_size    = DYN_DEFAULT_SARRAY_SIZE_INIT;
+    size_t start_incsize = DYN_DEFAULT_SARRAY_SIZE_INCR;
+
+    /*If the target is empty, initialize it*/
+    if (!source)
+    	source = grib_sarray_new(c, start_size, start_incsize);
+    /* TBD::: if (!source) {
+        	if(sarrayPOOL.poolCounter != (DYN_DEFAULT_SARRAY_POOL_SIZE - 1) ) {
+        		source = &(sarrayPOOL.arrayPOOL[sarrayPOOL.poolCounter]);
+        		sarrayPOOL.poolCounter++;
+        	} else {
+        		source = grib_sarray_new(0, start_size, start_incsize);
+        	}
+        }
+    */
+
+    /*If the actual used size of the target is equal to the allowed size, resize the array*/
+    if (source->n == source->size) {
+
+    	source = grib_sarray_resize(c, source);
+
+    	/*Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!*/
+    	if (!source)
+    	{
+    		return source;
+    	}
+
+    	/*insertion in new allocated dynamic array*/
+    	source->dynA[ (source->n-(DYN_DEFAULT_SARRAY_SIZE_INIT)) ] = val;
+    	source->n++;
+    	return source;
+
     }
-    return v;
+
+    /*insertion in static array*/
+    if (source->n <= (DYN_DEFAULT_SARRAY_SIZE_INIT - 1) )
+    {
+    	source->stA[source->n] = val;
+    }
+    else {
+    	/*insertion in dynamic array*/
+    	source->dynA[ (source->n-(DYN_DEFAULT_SARRAY_SIZE_INIT)) ] = val;
+    }
+
+    source->n++;
+    return source;
 }
 
-grib_sarray* grib_sarray_push(grib_context* c, grib_sarray* v, char* val)
+/**
+ * Return the char* value at index 'index' for grib_sarray 'source'
+ */
+char* grib_sarray_get(const grib_sarray* source, size_t index)
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_sarray_new(c, start_size, start_incsize);
 
-    if (v->n >= v->size)
-        v = grib_sarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	if (!source)
+	    return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_SARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[(index-DYN_DEFAULT_SARRAY_SIZE_INIT)];
+		}
+	}
+
+	return 0;
 }
 
-void grib_sarray_delete(grib_context* c, grib_sarray* v)
+/**
+ * The method returns the array currently in use. If the given grib_sarray structure pointer is null, it returns NULL.
+ */
+char** grib_sarray_get_arrays_by_reference(const grib_sarray* source)
 {
-    if (!v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+	if (!source)
+		return NULL;
+
+	/* return source->stA; */
+
+	/* PREVIOUS ATTEMPT */
+	if (source->n < DYN_DEFAULT_SARRAY_SIZE_INIT) {
+		return source->stA; /* stA is the static array */
+	} else {
+		if (source->dynA) {
+			return source->dynA; /* dynA is the dynamic array */
+		}
+	}
+
+	return NULL;
+
 }
 
-void grib_sarray_delete_content(grib_context* c, grib_sarray* v)
+/**
+ * Sets the char* value 'val' at index 'index' for grib_sarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_sarray_put (grib_sarray* source, size_t index, char* val)
+{
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_SARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA) {
+			source->dynA[(index-DYN_DEFAULT_SARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
+}
+
+void grib_sarray_delete(grib_context* c, grib_sarray* source)
+{
+	if (!source)
+		return;
+	if (!c)
+		grib_context_get_default();
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
+	grib_context_free(c, source);
+}
+
+void grib_sarray_delete_content(grib_context* c, grib_sarray* source)
 {
     int i;
-    if (!v || !v->v)
-        return;
+
+    if (!source)
+    	return;
+
     if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        if (v->v[i])
-            grib_context_free(c, v->v[i]);
-        v->v[i] = 0;
+    	grib_context_get_default();
+
+    /*If the actual used size of the target is greater than the allowed size, it is a resized array*/
+    if (source->n > source->size && ( source->dynA ) ) {
+    	for (i = 0; i < (source->n - DYN_DEFAULT_SARRAY_SIZE_INIT); i++) {
+    		grib_context_free(c, source->dynA[i]);
+    		source->dynA[i] = 0;
+    	}
     }
-    v->n = 0;
+
+    memset(source->stA,0,sizeof(char)*DYN_DEFAULT_SARRAY_SIZE_INIT);
+
+
+    source->n = 0;
 }
 
-char** grib_sarray_get_array(grib_context* c, grib_sarray* v)
+/**
+ * The method returns an array of char* of size source->n containing all the values contained in the 'source' grib_sarray, starting to copy from the static array 'sv' and then copying the dynamic array 'v'.
+ * Data in the result:
+ * 1. From index 0 until index (DYN_DEFAULT_SARRAY_SIZE_INIT -1), data located at the same index in source->sv;
+ * 2. From index DYN_DEFAULT_SARRAY_SIZE_INIT until ( source->n ), data located at index (index - DYN_DEFAULT_SARRAY_SIZE_INIT) in source->v;
+ */
+char** grib_sarray_get_array(grib_context* c, grib_sarray* source)
 {
-    char** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (char**)grib_context_malloc_clear(c, sizeof(char*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+    char** result;
+    size_t i;
+
+    result = (char**)grib_context_malloc_clear(c, sizeof(char*) * source->n);
+
+    for (i = 0; i < source->n; i++) {
+    	if( i<= (DYN_DEFAULT_SARRAY_SIZE_INIT - 1)) {
+    		result[i] = source->stA[i];
+    	} else {
+    		result[i] = source->dynA[(i-(DYN_DEFAULT_SARRAY_SIZE_INIT))];
+    	}
+    }
+
+    return result;
 }
 
-size_t grib_sarray_used_size(grib_sarray* v)
+size_t grib_sarray_used_size(grib_sarray* source)
 {
-    return v->n;
+	return (!source) ? 0 : source->n;
 }

--- a/src/grib_trie_with_rank.c
+++ b/src/grib_trie_with_rank.c
@@ -6,6 +6,8 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ * Modified for Performance Study by: CS GMBH
  */
 
 #include "grib_api_internal.h"
@@ -483,7 +485,8 @@ int grib_trie_with_rank_insert(grib_trie_with_rank* t, const char* key, void* da
         }
     }
     if (t->objs == NULL)
-        t->objs = grib_oarray_new(t->context, 100, 1000);
+        t->objs = grib_oarray_new(t->context, DYN_DEFAULT_OARRAY_SIZE_INIT, DYN_DEFAULT_OARRAY_SIZE_INCR);
+    	/* t->objs = grib_oarray_new(t->context, 100, 1000); */
     grib_oarray_push(t->context, t->objs, data);
     /* grib_trie_with_rank_insert_in_list(t,data); */
     GRIB_MUTEX_UNLOCK(&mutex);

--- a/src/grib_value.c
+++ b/src/grib_value.c
@@ -10,6 +10,7 @@
 /***************************************************************************
  * Jean Baptiste Filippi - 01.11.2005
  * Enrico Fucile                                                           *
+ * Modified for Performance Study by: CS GMBH
  ***************************************************************************/
 #include "grib_api_internal.h"
 #include <float.h>
@@ -799,18 +800,18 @@ int grib_set_double_array(grib_handle* h, const char* name, const double* val, s
     return __grib_set_double_array(h, name, val, length, /*check=*/1);
 }
 
-static int _grib_set_long_array_internal(grib_handle* h, grib_accessor* a, const long* val, size_t buffer_len, size_t* encoded_length, int check)
+static int _grib_set_long_array_internal(grib_handle* h, grib_accessor* a, const long* iarrayval, size_t iarraysize, size_t* encoded_length, int check)
 {
     if (a) {
-        int err = _grib_set_long_array_internal(h, a->same, val, buffer_len, encoded_length, check);
+        int err = _grib_set_long_array_internal(h, a->same, iarrayval, iarraysize, encoded_length, check);
 
         if (check && (a->flags & GRIB_ACCESSOR_FLAG_READ_ONLY))
             return GRIB_READ_ONLY;
 
         if (err == GRIB_SUCCESS) {
-            size_t len = buffer_len - *encoded_length;
+            size_t len = iarraysize - *encoded_length;
             if (len) {
-                err = grib_pack_long(a, val + *encoded_length, &len);
+                err = grib_pack_long(a, iarrayval + *encoded_length, &len);
                 *encoded_length += len;
             }
             else {
@@ -826,7 +827,7 @@ static int _grib_set_long_array_internal(grib_handle* h, grib_accessor* a, const
     }
 }
 
-static int _grib_set_long_array(grib_handle* h, const char* name, const long* val, size_t length, int check)
+static int _grib_set_long_array(grib_handle* h, const char* name, const long* iarrayval, size_t iarraysize, int check)
 {
     size_t encoded   = 0;
     grib_accessor* a = grib_find_accessor(h, name);
@@ -838,12 +839,12 @@ static int _grib_set_long_array(grib_handle* h, const char* name, const long* va
     if (h->context->debug) {
         size_t i = 0;
         size_t N = 5;
-        if (length <= N)
-            N = length;
-        fprintf(stderr, "ECCODES DEBUG _grib_set_long_array key=%s %ld values (", name, (long)length);
+        if (iarraysize <= N)
+            N = iarraysize;
+        fprintf(stderr, "ECCODES DEBUG _grib_set_long_array key=%s %ld values (", name, (long)iarraysize);
         for (i = 0; i < N; ++i)
-            fprintf(stderr, " %ld,", val[i]);
-        if (N >= length)
+            fprintf(stderr, " %ld,", iarrayval[i]);
+        if (N >= iarraysize)
             fprintf(stderr, " )\n");
         else
             fprintf(stderr, " ... )\n");
@@ -852,13 +853,13 @@ static int _grib_set_long_array(grib_handle* h, const char* name, const long* va
     if (name[0] == '/' || name[0] == '#') {
         if (check && (a->flags & GRIB_ACCESSOR_FLAG_READ_ONLY))
             return GRIB_READ_ONLY;
-        err     = grib_pack_long(a, val, &length);
-        encoded = length;
+        err     = grib_pack_long(a, iarrayval, &iarraysize);
+        encoded = iarraysize;
     }
     else
-        err = _grib_set_long_array_internal(h, a, val, length, &encoded, check);
+        err = _grib_set_long_array_internal(h, a, iarrayval, iarraysize, &encoded, check);
 
-    if (err == GRIB_SUCCESS && length > encoded)
+    if (err == GRIB_SUCCESS && iarraysize > encoded)
         err = GRIB_ARRAY_TOO_SMALL;
 
     if (err == GRIB_SUCCESS)
@@ -876,9 +877,9 @@ int grib_set_long_array_internal(grib_handle* h, const char* name, const long* v
     return ret;
 }
 
-int grib_set_long_array(grib_handle* h, const char* name, const long* val, size_t length)
+int grib_set_long_array(grib_handle* h, const char* name, const long* iarrayval, size_t iarraysize)
 {
-    return _grib_set_long_array(h, name, val, length, 1);
+    return _grib_set_long_array(h, name, iarrayval, iarraysize, 1);
 }
 
 int grib_get_long_internal(grib_handle* h, const char* name, long* val)

--- a/src/grib_vdarray.c
+++ b/src/grib_vdarray.c
@@ -11,117 +11,320 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+extern grib_vdarrayPOOL vdarrayPOOL;
+
 /* For debugging purposes */
-void grib_vdarray_print(const char* title, const grib_vdarray* vdarray)
+void grib_vdarray_print(const char* title, const grib_vdarray* source)
 {
-    size_t i;
-    char text[100] = {0,};
-    Assert(vdarray);
-    printf("%s: vdarray.n=%lu\n", title, (unsigned long)vdarray->n);
-    for (i = 0; i < vdarray->n; i++) {
-        sprintf(text, " vdarray->v[%lu]", (unsigned long)i);
-        grib_darray_print(text, vdarray->v[i]);
-    }
-    printf("\n");
+	if(source) {
+		size_t i;
+		char text[100] = {0,};
+		Assert(source);
+		printf("grib_vdarray_print %s: vdarray.n=%lu\n", title, (unsigned long)source->n);
+
+		for (i = 0; i < source->n; i++) {
+			sprintf(text, " vdarray->v[%lu]", (unsigned long)i);
+			if( i<= (DYN_DEFAULT_VDARRAY_SIZE_INIT - 1)) {
+				grib_darray_print(text, source->stA[i]);
+			} else {
+				grib_darray_print(text, source->dynA[(i-(DYN_DEFAULT_VDARRAY_SIZE_INIT))]);
+			}
+		}
+
+		printf("\n");
+	}
+}
+
+void grib_vdarray_completePrint (const grib_vdarray* source)
+{
+	if(source) {
+		size_t i;
+
+		printf("grib_vdarray_completePrint static-array size: %d darray.size=%lu, darray.incsize=%lu, darray.n=%lu \n",
+				(unsigned long)DYN_DEFAULT_DARRAY_SIZE_INIT, (unsigned long)source->size, (unsigned long)source->incsize, (unsigned long)source->n);
+
+		for (i = 0; i < source->n; i++) {
+			sprintf(" vdarray->v[%lu]", (unsigned long)i);
+			if( i<= (DYN_DEFAULT_VDARRAY_SIZE_INIT - 1)) {
+				grib_darray_print( "grib_vdarray_completePrint", source->stA[i]);
+			} else {
+				grib_darray_print( "grib_vdarray_completePrint", source->dynA[(i-(DYN_DEFAULT_VDARRAY_SIZE_INIT))]);
+			}
+		}
+
+		printf("static-array address: %p, dynamic array address: %p", source->stA, source->dynA);
+
+		printf("\n---\n");
+	}
+}
+
+int grib_vdarray_init(grib_vdarray* source)
+{
+
+	if (!source)
+		return 0;
+
+	memset(source->stA,0,sizeof(grib_darray*)*DYN_DEFAULT_VDARRAY_SIZE_INIT);
+	source->size 				= DYN_DEFAULT_VDARRAY_SIZE_INIT;
+	source->incsize             = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+	source->n					= 0;
+	source->dynA				= 0;
+
+	return 1;
+}
+
+void grib_vdarray_free_dynamic (grib_context* c, grib_vdarray* source)
+{
+	if (!source)
+		return;
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
 }
 
 grib_vdarray* grib_vdarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_vdarray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_vdarray*)grib_context_malloc_clear(c, sizeof(grib_vdarray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_vdarray));
-        return NULL;
-    }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (grib_darray**)grib_context_malloc_clear(c, sizeof(grib_darray*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_darray*) * size);
-        return NULL;
-    }
-    return v;
+	grib_vdarray* result = NULL;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	result = (grib_vdarray*)grib_context_malloc_clear(c, sizeof(grib_vdarray));
+	if (!result) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_vdarray));
+		return NULL;
+	}
+
+	if(size > DYN_DEFAULT_VDARRAY_SIZE_INIT) {
+
+		result->dynA       = (grib_darray**)grib_context_malloc_clear(c, sizeof(grib_darray*) *  (size-DYN_DEFAULT_VDARRAY_SIZE_INIT)  );
+
+		if (!result->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vdarray_new unable to allocate %d bytes\n", sizeof(grib_darray*) * (size-DYN_DEFAULT_VDARRAY_SIZE_INIT)  );
+			return NULL;
+		}
+		result->size    = size;
+
+		if (incsize > 0)
+			result->incsize             = incsize;
+		else
+			result->incsize             = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+
+	} else {
+
+		result->dynA					= NULL;
+		result->size                = DYN_DEFAULT_VDARRAY_SIZE_INIT;
+		result->incsize             = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+
+	}
+
+	result->n       = 0;
+
+	return result;
 }
 
-grib_vdarray* grib_vdarray_resize(grib_context* c, grib_vdarray* v)
+grib_vdarray* grib_vdarray_resize(grib_context* c, grib_vdarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (!origin)
+	{
+		return origin;
+	}
+	if (!c)
+		c = grib_context_get_default();
 
-    v->v    = (grib_darray**)grib_context_realloc(c, v->v, newsize * sizeof(grib_darray*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vdarray_resize unable to allocate %d bytes\n", sizeof(grib_darray*) * newsize);
-        return NULL;
-    }
-    return v;
+	newsize = origin->incsize + origin->size;
+
+	if (origin->dynA){
+
+		origin->dynA    = (grib_darray**)grib_context_realloc(c, origin->dynA,  sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vdarray_resize unable to allocate %d bytes\n", sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA      = (grib_darray**)grib_context_malloc(c, sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vdarray_resize unable to allocate %d bytes\n", sizeof(grib_darray*) * (newsize-DYN_DEFAULT_VDARRAY_SIZE_INIT ) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-grib_vdarray* grib_vdarray_push(grib_context* c, grib_vdarray* v, grib_darray* val)
+void vdarrayPoolInit()
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_vdarray_new(c, start_size, start_incsize);
+	int i;
 
-    if (v->n >= v->size)
-        v = grib_vdarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	for (i=0; i<DYN_DEFAULT_VDARRAY_POOL_SIZE; i++) {
+		vdarrayPOOL.arrayPOOL[i].size=DYN_DEFAULT_VDARRAY_SIZE_INIT;
+		vdarrayPOOL.arrayPOOL[i].n=0;
+		vdarrayPOOL.arrayPOOL[i].incsize=DYN_DEFAULT_VDARRAY_SIZE_INCR;
+		vdarrayPOOL.arrayPOOL[i].dynA=0;
+		memset(vdarrayPOOL.arrayPOOL[i].stA,0,DYN_DEFAULT_VDARRAY_SIZE_INIT);
+	}
 }
 
-void grib_vdarray_delete(grib_context* c, grib_vdarray* v)
+grib_vdarray* grib_vdarray_push(grib_context* c, grib_vdarray* source, grib_darray* val)
 {
-    if (!v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+
+	size_t start_size    = DYN_DEFAULT_VDARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_VDARRAY_SIZE_INCR;
+
+	if (!source)
+		source = grib_vdarray_new(c, start_size, start_incsize);
+
+	/*if (!source) {
+		if(vdarrayPOOL.poolCounter != (DYN_DEFAULT_VDARRAY_POOL_SIZE - 1) ) {
+			source = &(vdarrayPOOL.arrayPOOL[vdarrayPOOL.poolCounter]);
+			vdarrayPOOL.poolCounter++;
+		} else {
+			source = grib_vdarray_new(0, start_size, start_incsize);
+		}
+	}*/
+
+	/*If the actual used size of the target is equal to the allowed size, resize the array */
+	if (source->n == source->size) {
+
+		source = grib_vdarray_resize(c, source);
+
+		/* Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value! */
+		if (!source)
+		{
+			return source;
+		}
+
+		/* insertion in new allocated dynamic array */
+		source->dynA[ (source->n-(DYN_DEFAULT_VDARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
+
+	}
+
+	/* insertion in static array */
+	if (source->n <= (DYN_DEFAULT_VDARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		/* insertion in dynamic array */
+		source->dynA[ (source->n-(DYN_DEFAULT_VDARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+	return source;
 }
 
-void grib_vdarray_delete_content(grib_context* c, grib_vdarray* v)
+/**
+ * Return the grib_darray* value at index 'index' for grib_vdarray 'source'
+ */
+grib_darray* grib_vdarray_get(const grib_vdarray* source, size_t index)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        grib_darray_delete(c, v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+	if (!source)
+		return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_VDARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[(index-DYN_DEFAULT_VDARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
 }
 
-grib_darray** grib_vdarray_get_array(grib_context* c, grib_vdarray* v)
+/**
+ * Sets the grib_darray* value 'val' at index 'index' for grib_vdarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_vdarray_put (grib_vdarray* source, size_t index, grib_darray* val)
 {
-    grib_darray** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (grib_darray**)grib_context_malloc_clear(c, sizeof(grib_darray*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_VDARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA) {
+			source->dynA[(index-DYN_DEFAULT_VDARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
 }
 
-size_t grib_vdarray_used_size(grib_vdarray* v)
+void grib_vdarray_delete(grib_context* c, grib_vdarray* source)
 {
-    return v->n;
+	if (!source)
+		return;
+	if (!c)
+		grib_context_get_default();
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+	grib_context_free(c, source);
+}
+
+void grib_vdarray_delete_content(grib_context* c, grib_vdarray* source)
+{
+	int i, statSize;
+
+	if (!source)
+		return;
+
+	if(source->n){
+		/* If the actual used size of the target is greater than the allowed size, it is a resized array */
+		if ( (source->n > DYN_DEFAULT_VDARRAY_SIZE_INIT) && ( source->dynA ) ) {
+
+			for (i =0; i<source->n - DYN_DEFAULT_VDARRAY_SIZE_INIT;i++){
+				grib_darray_delete(c, source->dynA[i]);
+			}
+
+			statSize = DYN_DEFAULT_VDARRAY_SIZE_INIT;
+		} else {
+
+			if (source->n == DYN_DEFAULT_VDARRAY_SIZE_INIT){
+				statSize = DYN_DEFAULT_VDARRAY_SIZE_INIT;
+			}else {
+				statSize = source->n;
+			}
+
+		}
+
+		for (i =0; i<statSize; i++){
+			grib_darray_delete(c, source->stA[i]);
+		}
+
+		source->n = 0;
+	}
+}
+
+size_t grib_vdarray_used_size(grib_vdarray* source)
+{
+	return (!source) ? 0 : source->n;
 }

--- a/src/grib_viarray.c
+++ b/src/grib_viarray.c
@@ -11,103 +11,267 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+extern grib_viarrayPOOL viarrayPOOL;
+
+/* For debugging purposes */
+void grib_viarray_print(const char* title, const grib_viarray* source)
+{
+	if(source) {
+		size_t i;
+		char text[100] = {0,};
+		Assert(source);
+		printf("%s: viarray.n=%lu\n", title, (unsigned long)source->n);
+		for (i = 0; i < source->n; i++) {
+			sprintf(text, " viarray->v[%lu]", (unsigned long)i);
+			if( i<= (DYN_DEFAULT_VIARRAY_SIZE_INIT - 1)) {
+				grib_iarray_print(text, source->stA[i]);
+			} else {
+				grib_iarray_print(text, source->dynA[(i-(DYN_DEFAULT_VIARRAY_SIZE_INIT))]);
+			}
+		}
+		printf("\n");
+	}
+}
+
+int grib_viarray_init(grib_viarray* source)
+{
+
+	if (!source)
+		return 0;
+
+	memset(source->stA,0,sizeof(grib_iarray*)*DYN_DEFAULT_VIARRAY_SIZE_INIT);
+	source->size 				= DYN_DEFAULT_VIARRAY_SIZE_INIT;
+	source->incsize             = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+	source->n					= 0;
+	source->dynA				= 0;
+
+	return 1;
+}
+
+void grib_viarray_free_dynamic (grib_context* c,  grib_viarray* source)
+{
+	if (!source)
+		return;
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
+}
+
 grib_viarray* grib_viarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_viarray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_viarray*)grib_context_malloc_clear(c, sizeof(grib_viarray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_viarray));
-        return NULL;
-    }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (grib_iarray**)grib_context_malloc_clear(c, sizeof(grib_iarray*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_iarray*) * size);
-        return NULL;
-    }
-    return v;
+	grib_viarray* result = NULL;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	result = (grib_viarray*)grib_context_malloc_clear(c, sizeof(grib_viarray));
+	if (!result) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_viarray));
+		return NULL;
+	}
+
+	if(size > DYN_DEFAULT_VIARRAY_SIZE_INIT) {
+
+		result->dynA       = (grib_iarray**)grib_context_malloc_clear(c, sizeof(grib_iarray*) *  (size-DYN_DEFAULT_VIARRAY_SIZE_INIT)  );
+
+		if (!result->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_viarray_new unable to allocate %d bytes\n", sizeof(grib_iarray*) * (size-DYN_DEFAULT_VIARRAY_SIZE_INIT)  );
+			return NULL;
+		}
+		result->size    = size;
+
+		if (incsize > 0)
+			result->incsize             = incsize;
+		else
+			result->incsize             = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+
+	} else {
+
+		result->dynA					= NULL;
+		result->size                = DYN_DEFAULT_VIARRAY_SIZE_INIT;
+		result->incsize             = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+
+	}
+
+	result->n       = 0;
+
+	return result;
 }
 
-grib_viarray* grib_viarray_resize(grib_context* c, grib_viarray* v)
+grib_viarray* grib_viarray_resize(grib_context* c, grib_viarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (!origin)
+	{
+		return origin;
+	}
+	if (!c)
+		c = grib_context_get_default();
 
-    v->v    = (grib_iarray**)grib_context_realloc(c, v->v, newsize * sizeof(grib_iarray*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_viarray_resize unable to allocate %d bytes\n", sizeof(grib_iarray*) * newsize);
-        return NULL;
-    }
-    return v;
+	newsize = origin->incsize + origin->size;
+
+	if (origin->dynA){
+
+		origin->dynA    = (grib_iarray**)grib_context_realloc(c, origin->dynA,  sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_viarray_resize unable to allocate %d bytes\n", sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA      = (grib_iarray**)grib_context_malloc(c, sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT) );
+
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_viarray_resize unable to allocate %d bytes\n", sizeof(grib_iarray*) * (newsize-DYN_DEFAULT_VIARRAY_SIZE_INIT ) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-grib_viarray* grib_viarray_push(grib_context* c, grib_viarray* v, grib_iarray* val)
+void viarrayPoolInit()
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_viarray_new(c, start_size, start_incsize);
+	int i;
 
-    if (v->n >= v->size)
-        v = grib_viarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	for (i=0; i<DYN_DEFAULT_VIARRAY_POOL_SIZE; i++) {
+		viarrayPOOL.arrayPOOL[i].size=DYN_DEFAULT_VIARRAY_SIZE_INIT;
+		viarrayPOOL.arrayPOOL[i].n=0;
+		viarrayPOOL.arrayPOOL[i].incsize=DYN_DEFAULT_VIARRAY_SIZE_INCR;
+		viarrayPOOL.arrayPOOL[i].dynA=0;
+		memset(viarrayPOOL.arrayPOOL[i].stA,0,DYN_DEFAULT_VIARRAY_SIZE_INIT);
+	}
 }
 
-void grib_viarray_delete(grib_context* c, grib_viarray* v)
+grib_viarray* grib_viarray_push(grib_context* c, grib_viarray* source, grib_iarray* val)
 {
-    if (!v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+	size_t start_size    = DYN_DEFAULT_VIARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_VIARRAY_SIZE_INCR;
+
+	/*If the target is empty, initialize it*/
+	if (!source)
+		source = grib_viarray_new(c, start_size, start_incsize);
+	/*if (!source) {
+		if(viarrayPOOL.poolCounter != (DYN_DEFAULT_VIARRAY_POOL_SIZE - 1) ) {
+			source = &(viarrayPOOL.arrayPOOL[viarrayPOOL.poolCounter]);
+			viarrayPOOL.poolCounter++;
+		} else {
+			source = grib_viarray_new(0, start_size, start_incsize);
+		}
+	}*/
+
+	/*If the actual used size of the target is equal to the allowed size, resize the array*/
+	if (source->n == source->size) {
+
+		source = grib_viarray_resize(c, source);
+
+		/*Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!*/
+		if (!source)
+		{
+			return source;
+		}
+
+		/*insertion in new allocated dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_VIARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
+
+	}
+
+	/*insertion in static array*/
+	if (source->n <= (DYN_DEFAULT_VIARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		/*insertion in dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_VIARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+	return source;
 }
 
-void grib_viarray_delete_content(grib_context* c, grib_viarray* v)
+grib_iarray* grib_viarray_get(const grib_viarray* source, size_t index)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        grib_iarray_delete(v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+	if (!source)
+		return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_VIARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[(index-DYN_DEFAULT_VIARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
 }
 
-grib_iarray** grib_viarray_get_array(grib_context* c, grib_viarray* v)
+void grib_viarray_delete(grib_context* c, grib_viarray* source)
 {
-    grib_iarray** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (grib_iarray**)grib_context_malloc_clear(c, sizeof(grib_iarray*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+	if (!source)
+		return;
+	if (!c)
+		grib_context_get_default();
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+	grib_context_free(c, source);
 }
 
-size_t grib_viarray_used_size(grib_viarray* v)
+void grib_viarray_delete_content(grib_context* c, grib_viarray* source)
 {
-    return v->n;
+	int i, statSize;
+
+	if (!source)
+		return;
+
+	if(source->n){
+		/*If the actual used size of the target is greater than the allowed size, it is a resized array*/
+		if ( (source->n > DYN_DEFAULT_VIARRAY_SIZE_INIT) && ( source->dynA) ) {
+
+			for (i =0; i<source->n - DYN_DEFAULT_VIARRAY_SIZE_INIT;i++){
+				grib_iarray_delete(source->dynA[i]);
+			}
+			statSize = DYN_DEFAULT_VIARRAY_SIZE_INIT;
+		} else {
+
+			if (source->n == DYN_DEFAULT_VIARRAY_SIZE_INIT){
+				statSize = DYN_DEFAULT_VIARRAY_SIZE_INIT;
+			}else {
+				statSize = source->n;
+			}
+
+		}
+
+		for (i =0; i<statSize; i++){
+			grib_iarray_delete(source->stA[i]);
+		}
+
+		source->n = 0;
+	}
+}
+
+size_t grib_viarray_used_size(grib_viarray* source)
+{
+	return (!source) ? 0 : source->n;
 }

--- a/src/grib_vsarray.c
+++ b/src/grib_vsarray.c
@@ -11,104 +11,277 @@
 /***************************************************************************
  *
  *   Enrico Fucile
+ *   Modified for Performance Study by: CS GMBH
  *
  ***************************************************************************/
 
 #include "grib_api_internal.h"
 
+extern grib_vsarrayPOOL vsarrayPOOL;
+
+int grib_vsarray_init(grib_vsarray* source)
+{
+
+	if (!source)
+		return 0;
+
+	memset(source->stA,0,sizeof(grib_sarray*)*DYN_DEFAULT_VSARRAY_SIZE_INIT);
+	source->size 				= DYN_DEFAULT_VSARRAY_SIZE_INIT;
+	source->incsize             = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+	source->n					= 0;
+	source->dynA				= 0;
+
+	return 1;
+}
+
+void grib_vsarray_free_dynamic (grib_context* c, grib_vsarray* source)
+{
+	if (!source)
+		return;
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
+}
+
 grib_vsarray* grib_vsarray_new(grib_context* c, size_t size, size_t incsize)
 {
-    grib_vsarray* v = NULL;
-    if (!c)
-        c = grib_context_get_default();
-    v = (grib_vsarray*)grib_context_malloc_clear(c, sizeof(grib_vsarray));
-    if (!v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_vsarray));
-        return NULL;
-    }
-    v->size    = size;
-    v->n       = 0;
-    v->incsize = incsize;
-    v->v       = (grib_sarray**)grib_context_malloc_clear(c, sizeof(grib_sarray*) * size);
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_sarray*) * size);
-        return NULL;
-    }
-    return v;
+	grib_vsarray* result = NULL;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	result = (grib_vsarray*)grib_context_malloc_clear(c, sizeof(grib_vsarray));
+
+	if (!result) {
+		grib_context_log(c, GRIB_LOG_ERROR,
+				"grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_vsarray));
+		return NULL;
+	}
+
+	if(size > DYN_DEFAULT_VSARRAY_SIZE_INIT) {
+
+		result->dynA       = (grib_sarray**)grib_context_malloc_clear(c, sizeof(grib_sarray*) *  (size-DYN_DEFAULT_VSARRAY_SIZE_INIT)  );
+
+		if (!result->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vsarray_new unable to allocate %d bytes\n", sizeof(grib_sarray*) * (size-DYN_DEFAULT_VSARRAY_SIZE_INIT)  );
+			return NULL;
+		}
+		result->size    = size;
+
+		if (incsize > 0)
+			result->incsize             = incsize;
+		else
+			result->incsize             = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+
+	} else {
+
+		result->dynA					= NULL;
+		result->size                = DYN_DEFAULT_VSARRAY_SIZE_INIT;
+		result->incsize             = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+
+	}
+
+	result->n       = 0;
+
+	return result;
 }
 
-grib_vsarray* grib_vsarray_resize(grib_context* c, grib_vsarray* v)
+grib_vsarray* grib_vsarray_resize(grib_context* c, grib_vsarray* origin)
 {
-    int newsize = v->incsize + v->size;
+	int newsize;
 
-    if (!c)
-        c = grib_context_get_default();
+	if (!origin)
+	{
+		return origin;
+	}
 
-    v->v    = (grib_sarray**)grib_context_realloc(c, v->v, newsize * sizeof(grib_sarray*));
-    v->size = newsize;
-    if (!v->v) {
-        grib_context_log(c, GRIB_LOG_ERROR,
-                         "grib_vsarray_resize unable to allocate %d bytes\n", sizeof(grib_sarray*) * newsize);
-        return NULL;
-    }
-    return v;
+	newsize = origin->incsize + origin->size;
+
+	if (!c)
+		c = grib_context_get_default();
+
+	if (origin->dynA){
+
+		origin->dynA    = (grib_sarray**)grib_context_realloc(c, origin->dynA, (newsize-DYN_DEFAULT_VSARRAY_SIZE_INIT) * sizeof(grib_sarray*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_vsarray_resize unable to allocate %d bytes\n", sizeof(grib_sarray*) * (newsize-DYN_DEFAULT_VSARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+	else {
+
+		origin->dynA = (grib_sarray**)grib_context_malloc(c, (newsize-DYN_DEFAULT_VSARRAY_SIZE_INIT) * sizeof(grib_sarray*));
+		if (!origin->dynA) {
+			grib_context_log(c, GRIB_LOG_ERROR,
+					"grib_sarray_resize unable to allocate %d bytes\n", sizeof(grib_sarray*) * (newsize-DYN_DEFAULT_SARRAY_SIZE_INIT) );
+			return NULL;
+		}
+
+	}
+
+	origin->size = newsize;
+
+	return origin;
 }
 
-grib_vsarray* grib_vsarray_push(grib_context* c, grib_vsarray* v, grib_sarray* val)
+void vsarrayPoolInit()
 {
-    size_t start_size    = 100;
-    size_t start_incsize = 100;
-    if (!v)
-        v = grib_vsarray_new(c, start_size, start_incsize);
+	int i;
 
-    if (v->n >= v->size)
-        v = grib_vsarray_resize(c, v);
-    v->v[v->n] = val;
-    v->n++;
-    return v;
+	for (i=0; i<DYN_DEFAULT_VSARRAY_POOL_SIZE; i++) {
+		vsarrayPOOL.arrayPOOL[i].size=DYN_DEFAULT_VSARRAY_SIZE_INIT;
+		vsarrayPOOL.arrayPOOL[i].n=0;
+		vsarrayPOOL.arrayPOOL[i].incsize=DYN_DEFAULT_VSARRAY_SIZE_INCR;
+		vsarrayPOOL.arrayPOOL[i].dynA=0;
+	}
 }
 
-void grib_vsarray_delete(grib_context* c, grib_vsarray* v)
+grib_vsarray* grib_vsarray_push(grib_context* c, grib_vsarray* source, grib_sarray* val)
 {
-    if (!v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    if (v->v)
-        grib_context_free(c, v->v);
-    grib_context_free(c, v);
+	size_t start_size    = DYN_DEFAULT_VSARRAY_SIZE_INIT;
+	size_t start_incsize = DYN_DEFAULT_VSARRAY_SIZE_INCR;
+
+	/*If the target is empty, initialize it*/
+	if (!source)
+		source = grib_vsarray_new(c, start_size, start_incsize);
+
+	/*if (!source) {
+		if(vsarrayPOOL.poolCounter != (DYN_DEFAULT_VSARRAY_POOL_SIZE - 1) ) {
+			source = &(vsarrayPOOL.arrayPOOL[vsarrayPOOL.poolCounter]);
+			vsarrayPOOL.poolCounter++;
+		} else {
+			source = grib_vsarray_new(0, start_size, start_incsize);
+		}
+	}*/
+
+	/*If the actual used size of the target is equal to the allowed size, resize the array*/
+	if (source->n == source->size) {
+
+		source = grib_vsarray_resize(c, source);
+
+		/*Check if REALLOC WAS POSSIBLE, otherwise it is not possible to insert a new value!*/
+		if (!source)
+		{
+			return source;
+		}
+
+		/*insertion in new allocated dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_VSARRAY_SIZE_INIT)) ] = val;
+		source->n++;
+		return source;
+
+	}
+
+	/*insertion in static array*/
+	if (source->n <= (DYN_DEFAULT_VSARRAY_SIZE_INIT - 1) )
+	{
+		source->stA[source->n] = val;
+	}
+	else {
+		/*insertion in dynamic array*/
+		source->dynA[ (source->n-(DYN_DEFAULT_VSARRAY_SIZE_INIT)) ] = val;
+	}
+
+	source->n++;
+
+	return source;
 }
 
-void grib_vsarray_delete_content(grib_context* c, grib_vsarray* v)
+/**
+ * Return the grib_sarray* value at index 'index' for grib_vsarray 'source'
+ */
+grib_sarray* grib_vsarray_get(const grib_vsarray* source, size_t index)
 {
-    int i;
-    if (!v || !v->v)
-        return;
-    if (!c)
-        grib_context_get_default();
-    for (i = 0; i < v->n; i++) {
-        grib_sarray_delete_content(c, v->v[i]);
-        grib_sarray_delete(c, v->v[i]);
-        v->v[i] = 0;
-    }
-    v->n = 0;
+
+	if (!source)
+		return NULL;
+	if (index < 0)
+		return NULL;
+	if (index < DYN_DEFAULT_VSARRAY_SIZE_INIT) {
+		return source->stA[index];
+	} else {
+		if (source->dynA) {
+			return source->dynA[(index-DYN_DEFAULT_VSARRAY_SIZE_INIT)];
+		}
+	}
+
+	return NULL;
 }
 
-grib_sarray** grib_vsarray_get_array(grib_context* c, grib_vsarray* v)
+/**
+ * Sets the grib_sarray* value 'val' at index 'index' for grib_vsarray 'source'.
+ * The method overwrites the existing value, if any.
+ * The method returns 1 if the writing operation occurred, otherwise 0.
+ */
+int grib_vsarray_put (grib_vsarray* source, size_t index, grib_sarray* val)
 {
-    grib_sarray** ret;
-    int i;
-    if (!v)
-        return NULL;
-    ret = (grib_sarray**)grib_context_malloc_clear(c, sizeof(grib_sarray*) * v->n);
-    for (i = 0; i < v->n; i++)
-        ret[i] = v->v[i];
-    return ret;
+	if (!source)
+		return 0;
+	if (index < 0)
+		return 0;
+	if (index < DYN_DEFAULT_VSARRAY_SIZE_INIT) {
+		source->stA[index] = val;
+
+	} else {
+		if (source->dynA) {
+			source->dynA[(index-DYN_DEFAULT_VSARRAY_SIZE_INIT)] = val;
+		}
+	}
+
+	return 1;
 }
 
-size_t grib_vsarray_used_size(grib_vsarray* v)
+void grib_vsarray_delete(grib_context* c, grib_vsarray* source)
 {
-    return v->n;
+	if (!source)
+		return;
+	if (!c)
+		grib_context_get_default();
+
+	if (source->dynA)
+		grib_context_free(c, source->dynA);
+
+	grib_context_free(c, source);
+}
+
+void grib_vsarray_delete_content(grib_context* c, grib_vsarray* source)
+{
+	int i, statSize;
+
+	if (!source)
+		return;
+
+	if(source->n){
+		/*If the actual used size of the target is greater than the allowed size, it is a resized array*/
+		if (source->n > DYN_DEFAULT_VSARRAY_SIZE_INIT && ( source->dynA ) ) {
+
+			for (i =0; i<source->n - DYN_DEFAULT_VSARRAY_SIZE_INIT;i++){
+				grib_sarray_delete(c, source->dynA[i]);
+			}
+			statSize = DYN_DEFAULT_VSARRAY_SIZE_INIT;
+		} else {
+
+			if (source->n == DYN_DEFAULT_VSARRAY_SIZE_INIT){
+				statSize = DYN_DEFAULT_VSARRAY_SIZE_INIT;
+			}else {
+				statSize = source->n;
+			}
+
+		}
+
+		for (i =0; i<statSize; i++){
+			grib_sarray_delete(c, source->stA[i]);
+		}
+
+		source->n = 0;
+	}
+}
+
+size_t grib_vsarray_used_size(grib_vsarray* source)
+{
+	return (!source) ? 0 : source->n;
 }

--- a/src/makeyacc
+++ b/src/makeyacc
@@ -1,17 +1,40 @@
 set -xe
+yacc --version | head -1 | grep 'bison' >> /dev/null 2>&1
+
+rm -rf ../profiling_parser/ >> /dev/null 2>&1 ;
+#The original grib_lex.c contains adjustements made from eccodes developers: keep them!
+mv grib_lex.c grib_lex.c.orig
+
+mkdir ../profiling_parser/ >> /dev/null 2>&1 ;
 export LEX=flex
 export LEX_OUT=gribl.c
 $LEX -o gribl.c gribl.l
 sed 's/yy/grib_yy/g' < $LEX_OUT | sed 's/static void grib_yyunput/void grib_yyunput/' > grib_lex1.c
 sed 's/fgetc/getc/g' < grib_lex1.c > grib_lex.c
-rm -f grib_lex1.c
-rm -f $LEX_OUT
+
+#rm -f grib_lex1.c
+mv grib_lex1.c ../profiling_parser/
+#rm -f $LEX_OUT
+mv $LEX_OUT ../profiling_parser/
+cp -rp grib_lex.c ../profiling_parser/
+cp -rp grib_lex.c.orig ../profiling_parser/
+
+#Remember to re-establish the original grib_lex.c
+mv grib_lex.c.orig grib_lex.c
 
 yacc -v -d griby.y
 sed 's/yy/grib_yy/g' < y.tab.c > grib_yacc1.c
 sed 's/fgetc/getc/g' < grib_yacc1.c > grib_yacc.c
-rm -f grib_yacc1.c
+
+#rm -f grib_yacc1.c
+mv grib_yacc1.c ../profiling_parser/
+
 sed 's/yy/grib_yy/g' < y.tab.h > grib_yacc.h
-rm -f y.tab.c y.tab.h
+
+#rm -f y.tab.c y.tab.h
+mv y.tab.c ../profiling_parser/ ; mv y.tab.h ../profiling_parser/ ;
+
+mv y.output ../profiling_parser/ ;
+
 echo
 echo ALL OK

--- a/tests/bufr_ecc-517.c
+++ b/tests/bufr_ecc-517.c
@@ -10,6 +10,8 @@
 #include "eccodes.h"
 #include <assert.h>
 
+/*extern grib_darrayPOOL darrayPOOL;*/
+
 int main(int argc, char** argv)
 {
     size_t size            = 0;
@@ -22,6 +24,8 @@ int main(int argc, char** argv)
 
     assert(argc == 2);
     outfilename = argv[1];
+
+    /*darrayPoolInit();*/
 
     h = codes_bufr_handle_new_from_samples(NULL, sampleName);
     assert(h);

--- a/tests/bufr_ecc-517.sh
+++ b/tests/bufr_ecc-517.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 # (C) Copyright 2005- ECMWF.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0

--- a/tools/codes_parser.c
+++ b/tools/codes_parser.c
@@ -6,9 +6,14 @@
  *
  * In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
  * virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+ *
+ * Modified for Performance Study by: CS GMBH
  */
 
 #include "grib_api_internal.h"
+
+/* extern grib_iarrayPOOL iarrayPOOL; */
+/* extern grib_darrayPOOL darrayPOOL; */
 
 int main(int argc, char* argv[])
 {
@@ -17,6 +22,9 @@ int main(int argc, char* argv[])
 
     grib_context* c = grib_context_get_default();
     grib_action* a  = NULL;
+
+    iarrayPoolInit(c);
+    darrayPoolInit();
 
     for (i = 1; i < argc; i++) {
         printf("%s ... ", argv[i]);

--- a/tools/grib_tools.c
+++ b/tools/grib_tools.c
@@ -10,7 +10,7 @@
 
 /*
  * C Implementation: grib_tools
- *
+ * Modified for Performance Study by: CS GMBH
  */
 
 #include "grib_tools.h"
@@ -48,6 +48,8 @@ static int grib_tool_onlyfiles(grib_runtime_options* options);
 static int grib_tool_index(grib_runtime_options* options);
 static int process(grib_context* c, grib_runtime_options* options, const char* path);
 static int scan(grib_context* c, grib_runtime_options* options, const char* dir);
+
+/* extern grib_iarrayPOOL iarrayPOOL; extern grib_darrayPOOL darrayPOOL; */
 
 FILE* dump_file;
 
@@ -162,6 +164,8 @@ int grib_tool(int argc, char** argv)
     grib_tool_before_getopt(&global_options);
 
     grib_process_runtime_options(c, argc, argv, &global_options);
+
+    /*iarrayPoolInit(c); darrayPoolInit();*/
 
     grib_tool_init(&global_options);
     if (global_options.dump_filename) {


### PR DESCRIPTION
The motivation of the change and impact on code:
This is the ecCodesMIA B7 version, also referred to as 'Reducing the heap allocation space: introducing static array pools'.
This is a pull request for a branch derived from ecCodes official repository, tag "2.17.0": so please, when merging take into account to not do it against the current ecCodes "develop" HEAD.
The complete changes applied are described in the file "src/ChangesB7.txt".
This code is not operational. Impacts on the code: NOT all automated tests are passing, the complete output is in the file "ctest3.out". The list of not passing tests is also mentioned in the Confluence webpage 'https://confluence.ecmwf.int/x/5xg1Cw'.
A full report of the ecCodesMIA project is accessible at https://gitlab.eumetsat.int/additional-data-services/eccodes-impact-analysis/-/blob/master/docs/officialdocs/ecCodesMIA_FinalReport_files/ecCodesMIA_FinalReport.md.

The author of changes accepts the "ECMWF Contributors License Agreement".
In particular:
2.1. This code can be redistributed under Apache License 2.0;
2.2. This code doesn't violate anyone IPR' rights;

3.Exception to PR requirements as described in "https://confluence.ecmwf.int/display/SUP/ECMWF+software+on+GitHub":
3.1. Although this code passes some of the automated and regression tests, it is not intended as an operational version, as stated earlier.