### PR TITLE
Avoid freeing base class members in a derived class.

### DIFF
--- a/src/action_class_transient_darray.c
+++ b/src/action_class_transient_darray.c
@@ -140,8 +140,6 @@ static void destroy(grib_context* context, grib_action* act)
 
     grib_context_free_persistent(context, a->name);
     grib_darray_delete(context, a->darray);
-    grib_context_free_persistent(context, act->name);
-    grib_context_free_persistent(context, act->op);
 }
 
 static void xref(grib_action* d, FILE* f, const char* path)


### PR DESCRIPTION
Freeing of these memory blocks are taken care of in destroy()@action_class_gen.c, aren't they?
Running "codes_parser /home/suzuki/src/eccodes-orig/build/share/eccodes/definitions/bufr/boot.def" complains about 'double free' and dumps core when I call grib_context_reset() on the default context via shared object detachment hook.