### PR TITLE
Avoid null pointer dereference in grib_expression_free().

### DIFF
--- a/src/grib_expression.c
+++ b/src/grib_expression.c
@@ -89,13 +89,15 @@ void grib_expression_print(grib_context* ctx, grib_expression* g, grib_handle* f
 
 void grib_expression_free(grib_context* ctx, grib_expression* g)
 {
-    grib_expression_class* c = g->cclass;
-    while (c) {
-        if (c->destroy)
-            c->destroy(ctx, g);
-        c = c->super ? *(c->super) : NULL;
+    if (g) {
+        grib_expression_class* c = g->cclass;
+        while (c) {
+            if (c->destroy)
+                c->destroy(ctx, g);
+            c = c->super ? *(c->super) : NULL;
+        }
+        grib_context_free_persistent(ctx, g);
     }
-    grib_context_free_persistent(ctx, g);
 }
 
 void grib_expression_add_dependency(grib_expression* e, grib_accessor* observer)


### PR DESCRIPTION
It seems grib_arguments::expression can be null.

Call stack leading to the crash is as follow. (grib_context.c is modified outside of this pull request. So line numbers may not match there.)
grib_dump -O /home/suzuki/src/eccodes-orig/build/share/eccodes/samples/reduced_gg_pl_48_grib2.tmpl
==673984== Process terminating with default action of signal 11 (SIGSEGV)
==673984==  Access not within mapped region at address 0x0
==673984==    at 0x4A6B42E: grib_expression_free (grib_expression.c:92)
==673984==    by 0x4A6B7AB: grib_arguments_free (grib_expression.c:162)
==673984==    by 0x4A6B794: grib_arguments_free (grib_expression.c:161)
==673984==    by 0x4A6B794: grib_arguments_free (grib_expression.c:161)
==673984==    by 0x4A6B794: grib_arguments_free (grib_expression.c:161)
==673984==    by 0x4A6B794: grib_arguments_free (grib_expression.c:161)
==673984==    by 0x4A6B794: grib_arguments_free (grib_expression.c:161)
==673984==    by 0x494C3AE: destroy (action_class_gen.c:212)
==673984==    by 0x494AC7B: grib_action_delete (action.c:127)
==673984==    by 0x4A20384: grib_context_reset (grib_context.c:798)
==673984==    by 0x4A20602: grib_context_delete (grib_context.c:866)
==673984==    by 0x4A1F175: eccodes_module_destructor (grib_context.c:375)
