### PR TITLE
Fix multiple free in destroy@action_class_concept.c

### DIFF
--- a/src/action_class_concept.c
+++ b/src/action_class_concept.c
@@ -208,8 +208,9 @@ static void destroy(grib_context* context, grib_action* act)
     grib_action_concept* self = (grib_action_concept*)act;
 
     grib_concept_value* v = self->concept;
-    if (v)
+    if (v) {
         grib_trie_delete_container(v->index);
+    }
     while (v) {
         grib_concept_value* n = v->next;
         grib_concept_value_delete(context, v);

--- a/src/action_class_concept.c
+++ b/src/action_class_concept.c
@@ -209,7 +209,7 @@ static void destroy(grib_context* context, grib_action* act)
 
     grib_concept_value* v = self->concept;
     if (v)
-        grib_trie_delete(v->index);
+        grib_trie_delete_container(v->index);
     while (v) {
         grib_concept_value* n = v->next;
         grib_concept_value_delete(context, v);


### PR DESCRIPTION
Pointers to concept_value in the trie are borrowed pointers, which should not be free'd.)