### PR TITLE
Avoid accessing a trie node outside of the critical region.

### DIFF
--- a/src/grib_itrie.c
+++ b/src/grib_itrie.c
@@ -350,8 +350,9 @@ int grib_itrie_get_id(grib_itrie* t, const char* key)
         t = t->next[mapping[(int)*k++]];
 
     if (t != NULL && t->id != -1) {
+        int id = t->id;
         GRIB_MUTEX_UNLOCK(&mutex);
-        return t->id;
+        return id;
     }
     else {
         int ret = grib_itrie_insert(last, key);
@@ -401,11 +402,12 @@ int grib_itrie_insert(grib_itrie* t, const char* key)
         Assert(*(t->count) < MAX_NUM_CONCEPTS);
     }
 
+    int id = t->id;
     GRIB_MUTEX_UNLOCK(&mutex);
 
     /*printf("grib_itrie_get_id: %s -> %d\n",key,t->id);*/
 
-    return t->id;
+    return id;
 }
 
 int grib_itrie_get_size(grib_itrie* t)

--- a/src/grib_itrie_keys.c
+++ b/src/grib_itrie_keys.c
@@ -375,11 +375,12 @@ static int grib_hash_keys_insert(grib_itrie* t, const char* key)
         Assert(*(t->count) + TOTAL_KEYWORDS < ACCESSORS_ARRAY_SIZE);
     }
 
+    int id = t->id;
     GRIB_MUTEX_UNLOCK(&mutex);
 
     /*printf("grib_hash_keys_get_id: %s -> %d\n",key,t->id);*/
 
-    return t->id;
+    return id;
 }
 
 int grib_hash_keys_get_id(grib_itrie* t, const char* key)
@@ -403,8 +404,9 @@ int grib_hash_keys_get_id(grib_itrie* t, const char* key)
             t = t->next[mapping[(int)*k++]];
 
         if (t != NULL && t->id != -1) {
+            int id = t->id;
             GRIB_MUTEX_UNLOCK(&mutex);
-            return t->id + TOTAL_KEYWORDS + 1;
+            return id + TOTAL_KEYWORDS + 1;
         }
         else {
             int ret = grib_hash_keys_insert(last, key);

--- a/src/grib_trie.c
+++ b/src/grib_trie.c
@@ -482,9 +482,11 @@ void* grib_trie_get(grib_trie* t, const char* key)
         t = t->next[mapping[(int)*k++]];
     }
 
-    if (*k == 0 && t != NULL && t->data != NULL) {
+    if( t ) {
+        /* t!=NULL implies *k==0 */
+        void * saved = t->data;
         GRIB_MUTEX_UNLOCK(&mutex);
-        return t->data;
+        return saved;
     }
     GRIB_MUTEX_UNLOCK(&mutex);
     return NULL;

--- a/src/grib_trie_with_rank.c
+++ b/src/grib_trie_with_rank.c
@@ -485,8 +485,9 @@ int grib_trie_with_rank_insert(grib_trie_with_rank* t, const char* key, void* da
         t->objs = grib_oarray_new(t->context, 100, 1000);
     grib_oarray_push(t->context, t->objs, data);
     /* grib_trie_with_rank_insert_in_list(t,data); */
+    size_t n = t->objs->n;
     GRIB_MUTEX_UNLOCK(&mutex);
-    return t->objs->n; /* grib_oarray_used_size(t->objs) */
+    return n; /* grib_oarray_used_size(t->objs) */
 }
 
 /*


### PR DESCRIPTION
It is thread-unsafe to dereference a pointer to a trie node outside of the critical region protected by the mutex because another thread may delete the node before the dereference, isn't it? (This PR supercedes https://github.com/ecmwf/eccodes/pull/38.)