### PR TITLE
fix constantly growing file pool

### DIFF
--- a/src/grib_api_internal.h
+++ b/src/grib_api_internal.h
@@ -1190,6 +1190,7 @@ struct grib_file
     char* buffer;
     long refcount;
     grib_file* next;
+    grib_file* pool_file;
     short id;
 };
 

--- a/src/grib_filepool.c
+++ b/src/grib_filepool.c
@@ -287,6 +287,7 @@ void grib_file_pool_delete_file(grib_file* file)
     if (file == file_pool.first) {
         file_pool.first   = file->next;
         file_pool.current = file->next;
+        file_pool.size--;
     }
     else {
         prev              = file_pool.first;
@@ -299,10 +300,13 @@ void grib_file_pool_delete_file(grib_file* file)
         DebugAssert(prev);
         if (prev) {
             prev->next = file->next;
+            file_pool.size--;
         }
     }
 
     if (file->handle) {
+        fclose(file->handle);
+        file->handle = NULL;
         file_pool.number_of_opened_files--;
     }
     grib_file_delete(file);
@@ -425,12 +429,13 @@ grib_file* grib_file_new(grib_context* c, const char* name, int* err)
     next_id++;
     GRIB_MUTEX_UNLOCK(&mutex1);
 
-    file->mode     = 0;
-    file->handle   = 0;
-    file->refcount = 0;
-    file->context  = c;
-    file->next     = 0;
-    file->buffer   = 0;
+    file->mode      = 0;
+    file->handle    = 0;
+    file->refcount  = 0;
+    file->context   = c;
+    file->next      = 0;
+    file->pool_file = 0;
+    file->buffer    = 0;
     return file;
 }
 

--- a/src/grib_index.c
+++ b/src/grib_index.c
@@ -767,6 +767,7 @@ void grib_index_delete(grib_index* index)
     while (file) {
         grib_file* f = file;
         file         = file->next;
+        grib_file_pool_delete_file(f->pool_file);
         grib_file_delete(f);
     }
     grib_context_free(index->context, index);
@@ -1094,11 +1095,12 @@ int _codes_index_add_file(grib_index* index, const char* filename, int message_t
 
     if (!index->files) {
         grib_filesid++;
-        newfile         = (grib_file*)grib_context_malloc_clear(c, sizeof(grib_file));
-        newfile->id     = grib_filesid;
-        newfile->name   = strdup(file->name);
-        newfile->handle = file->handle;
-        index->files    = newfile;
+        newfile            = (grib_file*)grib_context_malloc_clear(c, sizeof(grib_file));
+        newfile->id        = grib_filesid;
+        newfile->name      = strdup(file->name);
+        newfile->handle    = file->handle;
+        newfile->pool_file = file;
+        index->files       = newfile;
     }
     else {
         indfile = index->files;
@@ -1111,11 +1113,12 @@ int _codes_index_add_file(grib_index* index, const char* filename, int message_t
         while (indfile->next)
             indfile = indfile->next;
         grib_filesid++;
-        newfile         = (grib_file*)grib_context_malloc_clear(c, sizeof(grib_file));
-        newfile->id     = grib_filesid;
-        newfile->name   = strdup(file->name);
-        newfile->handle = file->handle;
-        indfile->next   = newfile;
+        newfile            = (grib_file*)grib_context_malloc_clear(c, sizeof(grib_file));
+        newfile->id        = grib_filesid;
+        newfile->name      = strdup(file->name);
+        newfile->handle    = file->handle;
+        newfile->pool_file = file;
+        indfile->next      = newfile;
     }
 
     fseeko(file->handle, 0, SEEK_SET);


### PR DESCRIPTION
We experienced a heavily decreased loading performance when reading thousands of grib files. The reason is the internal file pool, where files created from indexes are never deleted. 

Honestly, I didn't understand the motivation for the file_pool at all. So I strived for a minimal change to remove the files in the pool once the according index was deleted. 
