### PR TITLE
add patch to src/grib_api_internal.h

### DIFF
--- a/src/grib_api_internal.h
+++ b/src/grib_api_internal.h
@@ -40,9 +40,9 @@ extern "C" {
 
 #if IS_BIG_ENDIAN
 #if GRIB_MEM_ALIGN
-#define FAST_BIG_ENDIAN 0
-#else
 #define FAST_BIG_ENDIAN 1
+#else
+#define FAST_BIG_ENDIAN 0
 #endif
 #endif
 


### PR DESCRIPTION
This problem was found and a fix was proposed by Mamoru TASAKA <mtasaka@fedoraproject.org> who deserves full credit for this, to fix test problems on the big endian s390x platform.
