### PR TITLE
grib_io.c: restore signedness for arguments for seek

### DIFF
--- a/src/grib_io.c
+++ b/src/grib_io.c
@@ -261,7 +261,7 @@ static int read_GRIB(reader* r)
                 total_length = length;
                 /* length=8+sec1len + sec2len+sec3len+11; */
                 length = i;
-                err    = r->seek(r->read_data, total_length - length - 1);
+                err    = r->seek(r->read_data, (off_t)total_length - (off_t)length - 1);
             }
             else if (length & 0x800000) {
                 /* Large GRIBs */
@@ -972,7 +972,7 @@ static int read_any_gts(reader* r)
                 magic |= c;
                 magic &= 0xffffffff;
                 if (magic == theEnd) {
-                    r->seek(r->read_data, already_read - message_size);
+                    r->seek(r->read_data, (off_t)already_read - (off_t)message_size);
                     buffer = (unsigned char*)r->alloc(r->alloc_data, &message_size, &err);
                     if (!buffer)
                         return GRIB_OUT_OF_MEMORY;
@@ -1020,7 +1020,7 @@ static int read_any_taf(reader* r)
             while (r->read(r->read_data, &c, 1, &err) == 1 && err == 0) {
                 message_size++;
                 if (c == '=') {
-                    r->seek(r->read_data, already_read - message_size);
+                    r->seek(r->read_data, (off_t)already_read - (off_t)message_size);
                     buffer = (unsigned char*)r->alloc(r->alloc_data, &message_size, &err);
                     if (!buffer)
                         return GRIB_OUT_OF_MEMORY;
@@ -1072,7 +1072,7 @@ static int read_any_metar(reader* r)
                 while (r->read(r->read_data, &c, 1, &err) == 1 && err == 0) {
                     message_size++;
                     if (c == '=') {
-                        r->seek(r->read_data, already_read - message_size);
+                        r->seek(r->read_data, (off_t)already_read - (off_t)message_size);
                         buffer = (unsigned char*)r->alloc(r->alloc_data, &message_size, &err);
                         if (!buffer)
                             return GRIB_OUT_OF_MEMORY;


### PR DESCRIPTION
stdio.seek, which calls fseeko, uses "off_t" for argument, and
when seeking toward head of the file, passing negative off_t value
must be passed.

Currently when callling stdio.seek, "size_t" variable is passed
to the argument. On 64 bit system, the problem is hidden because
both size_t (unsigned) and off_t (signed) are 64 bit.
But on 32 bit system, as size_t is unsigned 32 bit and off_t is
signed 64 bit, when passing size_t "message_size - already_read"
(which is intended to be negative to seek toward head) is converted
to large unsigned 32 bit value, which is not intended.

The fix is to correctly cast to off_t.

The attached patch fixes the following tests failure on 2.4.1:
```
# 100 - eccodes_t_bufr_ecc-875
# 118 - eccodes_t_gts_get
# 119 - eccodes_t_gts_ls
# 120 - eccodes_t_gts_count
# 121 - eccodes_t_gts_compare
# 122 - eccodes_t_metar_ls
# 123 - eccodes_t_metar_get
# 124 - eccodes_t_metar_dump
# 125 - eccodes_t_metar_compare
# 162 - eccodes_t_grib_copy
```

Forwarded from: https://jira.ecmwf.int/browse/SUP-3558