### PR TITLE
grib_lex: use atoll for unsigned 32bit value

### DIFF
--- a/src/grib_lex.c
+++ b/src/grib_lex.c
@@ -2163,7 +2163,7 @@ YY_RULE_SETUP
 case 129:
 YY_RULE_SETUP
 #line 264 "gribl.l"
-{ grib_yylval.lval = atol((const char *)grib_yytext); return INTEGER; }
+{ grib_yylval.lval = (long)atoll((const char *)grib_yytext); return INTEGER; }
 	YY_BREAK
 case 130:
 YY_RULE_SETUP

--- a/src/gribl.l
+++ b/src/gribl.l
@@ -261,7 +261,7 @@ IDENT     {IDENT1}|{IDENT2}|{IDENT3}|{IDENT4}|{IDENT5}
 
 
 {IDENT}       { yylval.str = strdup(yytext); return IDENT; }
-{NUMB}        { yylval.lval = atol((const char *)yytext); return INTEGER; }
+{NUMB}        { yylval.lval = (long)atoll((const char *)yytext); return INTEGER; }
 {NSIGNED}     { yylval.lval = atol((const char *)yytext); return INTEGER; }
 {FLOAT1}      { yylval.dval = atof((const char *)yytext); return FLOAT; }
 {FLOAT2}      { yylval.dval = atof((const char *)yytext); return FLOAT; }


### PR DESCRIPTION
On 32 bit system, unsigned 32 bit value cannot be read with atol.
Use atoll and cast the result to long.

The proposal patch fixes the following test failure on linux 32 bit:
```
# 193 - eccodes_t_grib_to_netcdf
```

Forwarded from: https://jira.ecmwf.int/browse/SUP-3560
