### PR TITLE
define uint64_t type grib_en/decode and use them

### DIFF
--- a/src/grib_accessor_class_bufr_data_array.c
+++ b/src/grib_accessor_class_bufr_data_array.c
@@ -628,7 +628,7 @@ static grib_darray* decode_double_array(grib_context* c, unsigned char* data, lo
 {
     grib_darray* ret = NULL;
     int j;
-    size_t lval;
+    uint64_t lval;
     int localReference, localWidth, modifiedWidth, modifiedReference;
     double modifiedFactor, dval;
     int bufr_multi_element_constant_arrays = c->bufr_multi_element_constant_arrays;
@@ -649,7 +649,7 @@ static grib_darray* decode_double_array(grib_context* c, unsigned char* data, lo
         *err = 0;
         return ret;
     }
-    lval           = grib_decode_size_t(data, pos, modifiedWidth);
+    lval           = grib_decode_uint64_t(data, pos, modifiedWidth);
     localReference = (long)lval + modifiedReference;
     localWidth     = grib_decode_unsigned_long(data, pos, 6);
     grib_context_log(c, GRIB_LOG_DEBUG, "BUFR data decoding: \tlocalWidth=%d", localWidth);
@@ -666,7 +666,7 @@ static grib_darray* decode_double_array(grib_context* c, unsigned char* data, lo
             return ret;
         }
         for (j = 0; j < self->numberOfSubsets; j++) {
-            lval = grib_decode_size_t(data, pos, localWidth);
+            lval = grib_decode_uint64_t(data, pos, localWidth);
             if (canBeMissing && grib_is_all_bits_one(lval, localWidth)) {
                 dval = GRIB_MISSING_DOUBLE;
             }
@@ -779,7 +779,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
 {
     int err = 0;
     int j, i;
-    size_t lval;
+    uint64_t lval;
     long localReference = 0, localWidth = 0, modifiedWidth, modifiedReference;
     long reference, allone;
     double localRange, modifiedFactor, inverseFactor;
@@ -841,7 +841,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
             }
             else {
                 lval = round(*v * inverseFactor) - modifiedReference;
-                grib_encode_size_tb(buff->data, lval, pos, modifiedWidth);
+                grib_encode_uint64_tb(buff->data, lval, pos, modifiedWidth);
             }
         }
         grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + 6);
@@ -870,7 +870,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
         }
         else {
             lval = round(*v * inverseFactor) - modifiedReference;
-            grib_encode_size_tb(buff->data, lval, pos, modifiedWidth);
+            grib_encode_uint64_tb(buff->data, lval, pos, modifiedWidth);
         }
         grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + 6);
         grib_encode_unsigned_longb(buff->data, localWidth, pos, 6);
@@ -967,7 +967,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
         }
         else {
             lval = localReference - modifiedReference;
-            grib_encode_size_tb(buff->data, lval, pos, modifiedWidth);
+            grib_encode_uint64_tb(buff->data, lval, pos, modifiedWidth);
         }
     }
     grib_buffer_set_ulength_bits(c, buff, buff->ulength_bits + 6);
@@ -981,7 +981,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
             }
             else {
                 lval = round(values[j] * inverseFactor) - reference;
-                grib_encode_size_tb(buff->data, lval, pos, localWidth);
+                grib_encode_uint64_tb(buff->data, lval, pos, localWidth);
             }
         }
     }
@@ -994,7 +994,7 @@ static int encode_double_array(grib_context* c, grib_buffer* buff, long* pos, bu
 static int encode_double_value(grib_context* c, grib_buffer* buff, long* pos, bufr_descriptor* bd,
                                grib_accessor_bufr_data_array* self, double value)
 {
-    size_t lval;
+    uint64_t lval;
     double maxAllowed, minAllowed;
     int err = 0;
     int modifiedWidth, modifiedReference;
@@ -1031,7 +1031,7 @@ static int encode_double_value(grib_context* c, grib_buffer* buff, long* pos, bu
         lval = round(value / modifiedFactor) - modifiedReference;
         if (c->debug)
             grib_context_log(c, GRIB_LOG_DEBUG, "encode_double_value %s: value=%.15f lval=%lu\n", bd->shortName, value, lval);
-        grib_encode_size_tb(buff->data, lval, pos, modifiedWidth);
+        grib_encode_uint64_tb(buff->data, lval, pos, modifiedWidth);
     }
 
     return err;
@@ -1078,7 +1078,7 @@ static double decode_double_value(grib_context* c, unsigned char* data, long* po
                                   bufr_descriptor* bd, int canBeMissing,
                                   grib_accessor_bufr_data_array* self, int* err)
 {
-    size_t lval;
+    uint64_t lval;
     int modifiedWidth, modifiedReference;
     double modifiedFactor;
     double dval = 0;
@@ -1095,7 +1095,7 @@ static double decode_double_value(grib_context* c, unsigned char* data, long* po
         return GRIB_MISSING_DOUBLE;
     }
 
-    lval = grib_decode_size_t(data, pos, modifiedWidth);
+    lval = grib_decode_uint64_t(data, pos, modifiedWidth);
     if (canBeMissing && grib_is_all_bits_one(lval, modifiedWidth)) {
         dval = GRIB_MISSING_DOUBLE;
     }

--- a/src/grib_api_prototypes.h
+++ b/src/grib_api_prototypes.h
@@ -1536,8 +1536,10 @@ char* grib_decode_string(const unsigned char* bitStream, long* bitOffset, size_t
 unsigned long grib_decode_unsigned_long(const unsigned char* p, long* bitp, long nbits);
 int grib_encode_unsigned_long(unsigned char* p, unsigned long val, long* bitp, long nbits);
 size_t grib_decode_size_t(const unsigned char* p, long* bitp, long nbits);
+uint64_t grib_decode_uint64_t(const unsigned char* p, long* bitp, long nbits);
 int grib_encode_unsigned_longb(unsigned char* p, unsigned long val, long* bitp, long nb);
 int grib_encode_size_tb(unsigned char* p, size_t val, long* bitp, long nb);
+int grib_encode_uint64_tb(unsigned char* p, uint64_t val, long* bitp, long nb);
 
 
 /* grib_bits_any_endian_simple.c */

--- a/src/grib_bits.c
+++ b/src/grib_bits.c
@@ -18,23 +18,29 @@
 #include "omp.h"
 #endif
 
-#define mask1(i) (1UL << i)
+#define mask1(i) ((uint64_t)1 << i)
 #define test(n, i) !!((n)&mask1(i))
 
-long GRIB_MASK = -1; /* Mask of sword bits */
+uint64_t GRIB_MASK = -1; /* Mask of sword bits */
 
 #define VALUE(p, q, b) \
-    (((b) == max_nbits ? GRIB_MASK : ~(GRIB_MASK << (b))) & ((p) >> (max_nbits - ((q) + (b)))))
+    (((b) == max_nbits ? (unsigned long)GRIB_MASK : ~((unsigned long)GRIB_MASK << (b))) & ((p) >> (max_nbits - ((q) + (b)))))
 
 #define MASKVALUE(q, b) \
-    ((b) == max_nbits ? GRIB_MASK : (~(GRIB_MASK << (b)) << (max_nbits - ((q) + (b)))))
+    ((b) == max_nbits ? (unsigned long)GRIB_MASK : (~((unsigned long)GRIB_MASK << (b)) << (max_nbits - ((q) + (b)))))
 
 
 #define VALUE_SIZE_T(p, q, b) \
-    (((b) == max_nbits_size_t ? GRIB_MASK : ~(GRIB_MASK << (b))) & ((p) >> (max_nbits_size_t - ((q) + (b)))))
+    (((b) == max_nbits_size_t ? (size_t)GRIB_MASK : ~((size_t)GRIB_MASK << (b))) & ((p) >> (max_nbits_size_t - ((q) + (b)))))
 
 #define MASKVALUE_SIZE_T(q, b) \
-    ((b) == max_nbits_size_t ? GRIB_MASK : (~(GRIB_MASK << (b)) << (max_nbits_size_t - ((q) + (b)))))
+    ((b) == max_nbits_size_t ? (size_t)GRIB_MASK : (~((size_t)GRIB_MASK << (b)) << (max_nbits_size_t - ((q) + (b)))))
+
+#define VALUE_UINT64_T(p, q, b) \
+    (((b) == 64 ? GRIB_MASK : ~(GRIB_MASK << (b))) & ((p) >> (64 - ((q) + (b)))))
+
+#define MASKVALUE_UINT64_T(q, b) \
+    ((b) == 64 ? GRIB_MASK : (~(GRIB_MASK << (b)) << (64 - ((q) + (b)))))
 
 static const unsigned long dmasks[] = {
     0xFF,

--- a/src/grib_bits_fast_big_endian.c
+++ b/src/grib_bits_fast_big_endian.c
@@ -176,6 +176,37 @@ size_t grib_decode_size_t(const unsigned char* p, long* bitp, long nbits)
     return val;
 }
 
+uint64_t grib_decode_uint64_t(const unsigned char* p, long* bitp, long nbits)
+{
+    long countOfLeftmostBits = 0, leftmostBits = 0;
+    long startBit      = *bitp;
+    long remainingBits = nbits;
+    long* pp           = (long*)p;
+    uint64_t val  = 0;
+
+    if (startBit >= 64) {
+        pp += startBit / 64;
+        startBit %= 64;
+    }
+
+    countOfLeftmostBits = startBit + remainingBits;
+    if (countOfLeftmostBits > 64) {
+        countOfLeftmostBits = 64 - startBit;
+        remainingBits -= countOfLeftmostBits;
+        leftmostBits = (VALUE_UINT64_T(*pp, startBit, countOfLeftmostBits)) << remainingBits;
+        startBit     = 0;
+        pp++;
+    }
+    else
+        leftmostBits = 0;
+
+    val = leftmostBits + (VALUE_UINT64_T(*pp, startBit, remainingBits));
+
+    *bitp += nbits;
+
+    return val;
+}
+
 int grib_encode_unsigned_long(unsigned char* p, unsigned long val, long* bitp, long nbits)
 {
     long* destination        = (long*)p;
@@ -249,9 +280,48 @@ int grib_encode_size_t(unsigned char* p, size_t val, long* bitp, long nbits)
     return GRIB_SUCCESS;
 }
 
+int grib_encode_uint64_t(unsigned char* p, uint64_t val, long* bitp, long nbits)
+{
+    long* destination        = (long*)p;
+    long countOfLeftmostBits = 0, nextWord = 0, startBit = 0, remainingBits = 0, rightmostBits = 0;
+
+    startBit      = *bitp;
+    remainingBits = nbits;
+
+    if (startBit >= 64) {
+        nextWord = startBit / 64;
+        startBit %= 64;
+    }
+    else
+        nextWord = 0;
+
+    countOfLeftmostBits = startBit + remainingBits;
+    if (countOfLeftmostBits > 64) {
+        countOfLeftmostBits = 64 - startBit;
+        startBit            = 64 - remainingBits;
+        remainingBits -= countOfLeftmostBits;
+        destination[nextWord] =
+            ((destination[nextWord] >> countOfLeftmostBits) << countOfLeftmostBits) + (VALUE_UINT64_T(val, startBit, countOfLeftmostBits));
+        startBit = 0;
+        nextWord++;
+    }
+
+    rightmostBits = VALUE_UINT64_T(val, 64 - remainingBits, remainingBits);
+    destination[nextWord] =
+        (destination[nextWord] & ~MASKVALUE_UINT64_T(startBit, remainingBits)) + (rightmostBits << 64 - (remainingBits + startBit));
+
+    *bitp += nbits;
+    return GRIB_SUCCESS;
+}
+
 int grib_encode_size_tb(unsigned char* p, size_t val, long* bitp, long nbits)
 {
     return grib_encode_size_t(p, val, bitp, nbits);
+}
+
+int grib_encode_uint64_tb(unsigned char* p, uint64_t val, long* bitp, long nbits)
+{
+    return grib_encode_uint64_t(p, val, bitp, nbits);
 }
 
 


### PR DESCRIPTION
Currently grib_encode_size_t / grib_decode_size_t are defined and
especially on windows where size_t is 64 bit,
encode_double_array and decode_double_array use them.

So especially for 32 bit linux system, define uint64_t type grib_encode /
grib_decode and use them instead of size_t type ones. This method is
more portable.

The proposal patch fixes the following test failure on Linux 32 bit:
```
#  35 - eccodes_t_bufr_ecc-1290
```

Forwarded from: https://jira.ecmwf.int/browse/SUP-3561
