### PR TITLE
introduce ECCODES_ON_LINUX_32BIT variable for test

### DIFF
--- a/tests/include.sh
+++ b/tests/include.sh
@@ -75,3 +75,15 @@ else
   # set -u
 fi
 
+ECCODES_ON_LINUX_32BIT=0
+if ( uname -s | grep -qi "linux")
+then
+  if which getconf
+  then
+     if test x`getconf LONG_BIT` == x32
+     then
+        ECCODES_ON_LINUX_32BIT=1
+     fi
+  fi
+fi
+


### PR DESCRIPTION
Windows uses ECCODES_ON_WINDOWS variable for test.
Similarly, introduce ECCODES_ON_LINUX_32BIT macro.

Exported from https://jira.ecmwf.int/browse/SUP-3562
This patch itself does not fix any test failure on linux 32 bit, but this patch is needed for
other 2 patches I am going to propose later.