### PR TITLE
bitsPerValue test: restrict max value to 31 on linux 32 bit

### DIFF
--- a/tests/grib_bitsPerValue.sh
+++ b/tests/grib_bitsPerValue.sh
@@ -120,9 +120,12 @@ res=`${tools_dir}/grib_get -p decimalScaleFactor,bitsPerValue ${data_dir}/gfs.c2
 # Test increasing bits per value
 input=${data_dir}/sample.grib2
 temp=temp.grib_bitsPerValue.grib
-MAX_BPV=58
+MAX_BPV=63
 if [ $ECCODES_ON_WINDOWS -eq 1 ]; then
-    MAX_BPV=26
+    MAX_BPV=31
+fi
+if [ $ECCODES_ON_LINUX_32BIT -eq 1 ] ; then
+    MAX_BPV=31
 fi
 stats1=`${tools_dir}/grib_get -M -F%.3f -p min,max,avg,sd $input`
 grib_check_key_equals $input 'bitsPerValue,packingType' '16 grid_simple'


### PR DESCRIPTION
NOTE:
Mark this as "Draft" because this depends on #63 and #60

On grib_bitsPerValue.sh, restrict maximum bitsPerValue value
(MAX_BPV) to 31 on linux 32 bit, higher value is not supported.

Note that currently on Windows system, MAX_BPV is set to 26 instead
of 31, but this should be able to be changed to 31 as well on
Windows as this should be fixed with
"decode_long_array: avoid overflow on 32 bit when overread" change.

Also, on linux 64 bit system, change MAX_BPV to 63. This should also
be fixed with the above change.

The proposal patch fixes the following test failure on Linux 32  #bit:
```
# 153 - eccodes_t_grib_bitsPerValue
```
Exported from https://jira.ecmwf.int/browse/SUP-3563