### PR TITLE
Support to display the shortname of variable of CRA40 datasets.

### DIFF
--- a/definitions/grib2/localConcepts/babj/name.def
+++ b/definitions/grib2/localConcepts/babj/name.def
@@ -1,0 +1,737 @@
+# Manually generated according to CRA40 reanalyses datasets.
+# Created by Jianglizhi, Fujian Institue of Meteorology Sciences, Feb 8 2022.
+#Best (4 layer) lifted index (K)
+'Best (4 layer) lifted index' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 193 ;
+}
+
+#5-wave geopotential height (gpm)
+'5-wave geopotential height' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 193 ;
+}
+
+#Absolute vorticity (s-1)
+'Absolute vorticity' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 10 ;
+}
+
+#Aerodynamic conductance (m s-1)
+'Aerodynamic conductance' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 228 ;
+}
+
+#Convective precipitation (kg m-2)
+'Convective precipitation' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 10 ;
+}
+
+#Albedo (%)
+'Albedo' = {
+   discipline = 0 ;
+   parameterCategory = 19 ;
+   parameterNumber = 1 ;
+}
+
+#Total precipitation (kg m-2)
+'Total precipitation' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 8 ;
+}
+
+#Apparent temperature (K)
+'Apparent temperature' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 21 ;
+}
+
+#Brightness temperature (K)
+'Brightness temperature' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 4 ;
+}
+
+#Convective available potential energy (J kg-1)
+'Convective available potential energy' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 6 ;
+}
+
+#Clear sky UV-B downward solar flux (W m-2)
+'Clear sky UV-B downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 195 ;
+}
+
+#Categorical freezing rain (yes=1; no=0) (non-dim)
+'Categorical freezing rain (yes=1; no=0)' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 193 ;
+}
+
+#Categorical ice pellets (yes=1; no=0) (non-dim)
+'Categorical ice pellets (yes=1; no=0)' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 194 ;
+}
+
+#Convective inhibition (J kg-1)
+'Convective inhibition' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 7 ;
+}
+
+#Plant canopy surface water (kg m-2)
+'Plant canopy surface water' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 196 ;
+}
+
+#Percent frozen precipitation (%)
+'Percent frozen precipitation' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 39 ;
+}
+
+#Convective precipitation rate (kg m-2 s-1)
+'Convective precipitation rate' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 196 ;
+}
+
+#Categorical rain (yes=1; no=0) (non-dim)
+'Categorical rain (yes=1; no=0)' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 192 ;
+}
+
+#Clear sky downward long wave flux (W m-2)
+'Clear sky downward long wave flux' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 196 ;
+}
+
+#Clear sky downward solar flux (W m-2)
+'Clear sky downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 196 ;
+}
+
+#Categorical snow (yes=1; no=0) (non-dim)
+'Categorical snow (yes=1; no=0)' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 195 ;
+}
+
+#Clear sky upward long wave flux (W m-2)
+'Clear sky upward long wave flux' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 195 ;
+}
+
+#Clear sky upward solar flux (W m-2)
+'Clear sky upward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 198 ;
+}
+
+#Cloud water (kg m-2)
+'Cloud water' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 6 ;
+}
+
+#Cloud work function (J kg-1)
+'Cloud work function' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 193 ;
+}
+
+#Downward long-wave radiation flux (W m-2)
+'Downward long-wave radiation flux' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 192 ;
+}
+
+#Dew point temperature (K)
+'Dew point temperature' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 6 ;
+}
+
+#Downward short-wave radiation flux (W m-2)
+'Downward short-wave radiation flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 192 ;
+}
+
+#UV-B downward solar flux (W m-2)
+'UV-B downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 194 ;
+}
+
+#Direct evaporation from bare soil (W m-2)
+'Direct evaporation from bare soil' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 198 ;
+}
+
+#Canopy water evaporation (W m-2)
+'Canopy water evaporation' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 229 ;
+}
+
+#Field capacity (fraction)
+'Field capacity' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 203 ;
+}
+
+#Frictional velocity (m s-1)
+'Frictional velocity' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 197 ;
+}
+
+#Ground heat flux (W m-2)
+'Ground heat flux' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 193 ;
+}
+
+#Wind speed (gust) (m s-1)
+'Wind speed (gust)' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 22 ;
+}
+
+#Geopotential height (gpm)
+'Geopotential height' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 5 ;
+}
+
+#Haines index (Numeric)
+'Haines index' = {
+   discipline = 2 ;
+   parameterCategory = 4 ;
+   parameterNumber = 2 ;
+}
+
+#Storm relative helicity (m2 s-2)
+'Storm relative helicity' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 8 ;
+}
+
+#Planetary boundary layer height (m)
+'Planetary boundary layer height' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 196 ;
+}
+
+#ICAO standard atmosphere reference height (m)
+'ICAO standard atmosphere reference height' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 3 ;
+}
+
+#Ice cover (Proportion)
+'Ice cover' = {
+   discipline = 10 ;
+   parameterCategory = 2 ;
+   parameterNumber = 0 ;
+}
+
+#Ice thickness (m)
+'Ice thickness' = {
+   discipline = 10 ;
+   parameterCategory = 2 ;
+   parameterNumber = 1 ;
+}
+
+#Land cover (1=land, 0=sea) (Proportion)
+'Land cover (1=land, 0=sea)' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 0 ;
+}
+
+#Surface lifted index (K)
+'Surface lifted index' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 192 ;
+}
+
+#Latent heat net flux (W m-2)
+'Latent heat net flux' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 10 ;
+}
+
+#Montgomery stream function (m2 s-2)
+'Montgomery stream function' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 6 ;
+}
+
+#MSLP (ETA model reduction) (Pa)
+'MSLP (ETA model reduction)' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 192 ;
+}
+
+#Near IR beam downward solar flux (W m-2)
+'Near IR beam downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 202 ;
+}
+
+#Large-scale precipitation (non-convective) (kg m-2)
+'Large-scale precipitation (non-convective)' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 9 ;
+}
+
+#Near IR diffuse downward solar flux (W m-2)
+'Near IR diffuse downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 203 ;
+}
+
+#Potential evaporation rate (W m-2)
+'Potential evaporation rate' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 200 ;
+}
+
+#Parcel lifted index (to 500 hpa) (K)
+'Parcel lifted index (to 500 hpa)' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 0 ;
+}
+
+#Pressure of level from which parcel was lifted (Pa)
+'Pressure of level from which parcel was lifted' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 200 ;
+}
+
+#Potential temperature (K)
+'Potential temperature' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 2 ;
+}
+
+#Precipitation rate (kg m-2 s-1)
+'Precipitation rate' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 7 ;
+}
+
+#Pressure (Pa)
+'Pressure' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 0 ;
+}
+
+#Pressure reduced to MSL (Pa)
+'Pressure reduced to MSL' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 1 ;
+}
+
+#Potential vorticity (K m2 kg-1 s-1)
+'Potential vorticity' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 14 ;
+}
+
+#Precipitable water (kg m-2)
+'Precipitable water' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 3 ;
+}
+
+#Maximum specific humidity at 2m (kg kg-1)
+'Maximum specific humidity at 2m' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 219 ;
+}
+
+#Minimum specific humidity at 2m (kg kg-1)
+'Minimum specific humidity at 2m' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 220 ;
+}
+
+#Relative humidity (%)
+'Relative humidity' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 1 ;
+}
+
+#Sublimation (evaporation from snow) (W m-2)
+'Sublimation (evaporation from snow)' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 212 ;
+}
+
+#Surface roughness (m)
+'Surface roughness' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 1 ;
+}
+
+#Exchange coefficient ((kg m-3) (m s-1))
+'Exchange coefficient' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 195 ;
+}
+
+#Sensible heat net flux (W m-2)
+'Sensible heat net flux' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 11 ;
+}
+
+#Surface slope type (Index)
+'Surface slope type' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 194 ;
+}
+
+#Snow depth (m)
+'Snow depth' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 11 ;
+}
+
+#Snow phase change heat flux (W m-2)
+'Snow phase change heat flux' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 16 ;
+}
+
+#Snow cover (%)
+'Snow cover' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 42 ;
+}
+
+#Liquid volumetric soil moisture (non frozen) (Proportion)
+'Liquid volumetric soil moisture (non frozen)' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 192 ;
+}
+
+#Soil moisture content (kg m-2)
+'Soil moisture content' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 3 ;
+}
+
+#Volumetric soil moisture content (Fraction)
+'Volumetric soil moisture content' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 192 ;
+}
+
+#Soil type (Code Table 4.213)
+'Soil type' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 0 ;
+}
+
+#Specific humidity (kg kg-1)
+'Specific humidity' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 0 ;
+}
+
+#Storm surface runoff (kg m-2)
+'Storm surface runoff' = {
+   discipline = 1 ;
+   parameterCategory = 0 ;
+   parameterNumber = 193 ;
+}
+
+#Sunshine duration (s)
+'Sunshine duration' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 201 ;
+}
+
+#Total cloud cover (%)
+'Total cloud cover' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 1 ;
+}
+
+#Maximum temperature (K)
+'Maximum temperature' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 4 ;
+}
+
+#Minimum temperature (K)
+'Minimum temperature' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 5 ;
+}
+
+#Temperature (K)
+'Temperature' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 0 ;
+}
+
+#Total ozone (Dobson)
+'Total ozone' = {
+   discipline = 0 ;
+   parameterCategory = 14 ;
+   parameterNumber = 0 ;
+}
+
+#Transpiration (W m-2)
+'Transpiration' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 230 ;
+}
+
+#Soil temperature (K)
+'Soil temperature' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 2 ;
+}
+
+#Momentum flux, u-component (N m-2)
+'Momentum flux, u-component' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 17 ;
+}
+
+#U-component of wind (m s-1)
+'U-component of wind' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 2 ;
+}
+
+#Zonal flux of gravity wave stress (N m-2)
+'Zonal flux of gravity wave stress' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 194 ;
+}
+
+#Upward long-wave radiation flux (W m-2)
+'Upward long-wave radiation flux' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 193 ;
+}
+
+#U-component storm motion (m s-1)
+'U-component storm motion' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 194 ;
+}
+
+#Upward short-wave radiation flux (W m-2)
+'Upward short-wave radiation flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 193 ;
+}
+
+#Visible beam downward solar flux (W m-2)
+'Visible beam downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 200 ;
+}
+
+#Visible diffuse downward solar flux (W m-2)
+'Visible diffuse downward solar flux' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 201 ;
+}
+
+#Vegetation (%)
+'Vegetation' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 4 ;
+}
+
+#Momentum flux, v-component (N m-2)
+'Momentum flux, v-component' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 18 ;
+}
+
+#V-component of wind (m s-1)
+'V-component of wind' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 3 ;
+}
+
+#Vegetation type (Integer (0-13))
+'Vegetation type' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 198 ;
+}
+
+#Meridional flux of gravity wave stress (N m-2)
+'Meridional flux of gravity wave stress' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 195 ;
+}
+
+#Visibility (m)
+'Visibility' = {
+   discipline = 0 ;
+   parameterCategory = 19 ;
+   parameterNumber = 0 ;
+}
+
+#Ventilation rate (m2 s-1)
+'Ventilation rate' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 224 ;
+}
+
+#V-component storm motion (m s-1)
+'V-component storm motion' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 195 ;
+}
+
+#Vertical velocity (pressure) (Pa s-1)
+'Vertical velocity (pressure)' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 8 ;
+}
+
+#Vertical speed shear (s-1)
+'Vertical speed shear' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 192 ;
+}
+
+#Water runoff (kg m-2)
+'Water runoff' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 5 ;
+}
+
+#Water equivalent of accumulated snow depth (kg m-2)
+'Water equivalent of accumulated snow depth' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 13 ;
+}
+
+#Wilting point (Fraction)
+'Wilting point' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 201 ;
+}
+

--- a/definitions/grib2/localConcepts/babj/shortName.def
+++ b/definitions/grib2/localConcepts/babj/shortName.def
@@ -1,0 +1,737 @@
+# Manually generated according to CRA40 reanalyses datasets.
+# Created by Jianglizhi, Fujian Institue of Meteorology Sciences, Feb 8 2022.
+#Best (4 layer) lifted index (K)
+'4lftx' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 193 ;
+}
+
+#5-wave geopotential height (gpm)
+'5wavh' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 193 ;
+}
+
+#Absolute vorticity (s-1)
+'absv' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 10 ;
+}
+
+#Aerodynamic conductance (m s-1)
+'acond' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 228 ;
+}
+
+#Convective precipitation (kg m-2)
+'acpcp' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 10 ;
+}
+
+#Albedo (%)
+'albdo' = {
+   discipline = 0 ;
+   parameterCategory = 19 ;
+   parameterNumber = 1 ;
+}
+
+#Total precipitation (kg m-2)
+'apcp' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 8 ;
+}
+
+#Apparent temperature (K)
+'aptmp' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 21 ;
+}
+
+#Brightness temperature (K)
+'brtmp' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 4 ;
+}
+
+#Convective available potential energy (J kg-1)
+'cape' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 6 ;
+}
+
+#Clear sky UV-B downward solar flux (W m-2)
+'cduvb' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 195 ;
+}
+
+#Categorical freezing rain (yes=1; no=0) (non-dim)
+'cfrzr' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 193 ;
+}
+
+#Categorical ice pellets (yes=1; no=0) (non-dim)
+'cicep' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 194 ;
+}
+
+#Convective inhibition (J kg-1)
+'cin' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 7 ;
+}
+
+#Plant canopy surface water (kg m-2)
+'cnwat' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 196 ;
+}
+
+#Percent frozen precipitation (%)
+'cpofp' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 39 ;
+}
+
+#Convective precipitation rate (kg m-2 s-1)
+'cprat' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 196 ;
+}
+
+#Categorical rain (yes=1; no=0) (non-dim)
+'crain' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 192 ;
+}
+
+#Clear sky downward long wave flux (W m-2)
+'csdlf' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 196 ;
+}
+
+#Clear sky downward solar flux (W m-2)
+'csdsf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 196 ;
+}
+
+#Categorical snow (yes=1; no=0) (non-dim)
+'csnow' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 195 ;
+}
+
+#Clear sky upward long wave flux (W m-2)
+'csulf' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 195 ;
+}
+
+#Clear sky upward solar flux (W m-2)
+'csusf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 198 ;
+}
+
+#Cloud water (kg m-2)
+'cwat' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 6 ;
+}
+
+#Cloud work function (J kg-1)
+'cwork' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 193 ;
+}
+
+#Downward long-wave radiation flux (W m-2)
+'dlwrf' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 192 ;
+}
+
+#Dew point temperature (K)
+'dpt' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 6 ;
+}
+
+#Downward short-wave radiation flux (W m-2)
+'dswrf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 192 ;
+}
+
+#UV-B downward solar flux (W m-2)
+'duvb' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 194 ;
+}
+
+#Direct evaporation from bare soil (W m-2)
+'evbs' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 198 ;
+}
+
+#Canopy water evaporation (W m-2)
+'evcw' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 229 ;
+}
+
+#Field capacity (fraction)
+'fldcp' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 203 ;
+}
+
+#Frictional velocity (m s-1)
+'fricv' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 197 ;
+}
+
+#Ground heat flux (W m-2)
+'gflux' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 193 ;
+}
+
+#Wind speed (gust) (m s-1)
+'gust' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 22 ;
+}
+
+#Geopotential height (gpm)
+'hgt' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 5 ;
+}
+
+#Haines index (Numeric)
+'hindex' = {
+   discipline = 2 ;
+   parameterCategory = 4 ;
+   parameterNumber = 2 ;
+}
+
+#Storm relative helicity (m2 s-2)
+'hlcy' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 8 ;
+}
+
+#Planetary boundary layer height (m)
+'hpbl' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 196 ;
+}
+
+#ICAO standard atmosphere reference height (m)
+'icaht' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 3 ;
+}
+
+#Ice cover (Proportion)
+'icec' = {
+   discipline = 10 ;
+   parameterCategory = 2 ;
+   parameterNumber = 0 ;
+}
+
+#Ice thickness (m)
+'icetk' = {
+   discipline = 10 ;
+   parameterCategory = 2 ;
+   parameterNumber = 1 ;
+}
+
+#Land cover (1=land, 0=sea) (Proportion)
+'land' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 0 ;
+}
+
+#Surface lifted index (K)
+'lftx' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 192 ;
+}
+
+#Latent heat net flux (W m-2)
+'lhtfl' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 10 ;
+}
+
+#Montgomery stream function (m2 s-2)
+'mntsf' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 6 ;
+}
+
+#MSLP (ETA model reduction) (Pa)
+'mslet' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 192 ;
+}
+
+#Near IR beam downward solar flux (W m-2)
+'nbdsf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 202 ;
+}
+
+#Large-scale precipitation (non-convective) (kg m-2)
+'ncpcp' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 9 ;
+}
+
+#Near IR diffuse downward solar flux (W m-2)
+'nddsf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 203 ;
+}
+
+#Potential evaporation rate (W m-2)
+'pevpr' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 200 ;
+}
+
+#Parcel lifted index (to 500 hpa) (K)
+'pli' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 0 ;
+}
+
+#Pressure of level from which parcel was lifted (Pa)
+'plpl' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 200 ;
+}
+
+#Potential temperature (K)
+'pot' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 2 ;
+}
+
+#Precipitation rate (kg m-2 s-1)
+'prate' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 7 ;
+}
+
+#Pressure (Pa)
+'pres' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 0 ;
+}
+
+#Pressure reduced to MSL (Pa)
+'prmsl' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 1 ;
+}
+
+#Potential vorticity (K m2 kg-1 s-1)
+'pvort' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 14 ;
+}
+
+#Precipitable water (kg m-2)
+'pwat' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 3 ;
+}
+
+#Maximum specific humidity at 2m (kg kg-1)
+'qmax' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 219 ;
+}
+
+#Minimum specific humidity at 2m (kg kg-1)
+'qmin' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 220 ;
+}
+
+#Relative humidity (%)
+'rh' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 1 ;
+}
+
+#Sublimation (evaporation from snow) (W m-2)
+'sbsno' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 212 ;
+}
+
+#Surface roughness (m)
+'sfcr' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 1 ;
+}
+
+#Exchange coefficient ((kg m-3) (m s-1))
+'sfexc' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 195 ;
+}
+
+#Sensible heat net flux (W m-2)
+'shtfl' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 11 ;
+}
+
+#Surface slope type (Index)
+'sltyp' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 194 ;
+}
+
+#Snow depth (m)
+'snod' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 11 ;
+}
+
+#Snow phase change heat flux (W m-2)
+'snohf' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 16 ;
+}
+
+#Snow cover (%)
+'snowc' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 42 ;
+}
+
+#Liquid volumetric soil moisture (non frozen) (Proportion)
+'soill' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 192 ;
+}
+
+#Soil moisture content (kg m-2)
+'soilm' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 3 ;
+}
+
+#Volumetric soil moisture content (Fraction)
+'soilw' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 192 ;
+}
+
+#Soil type (Code Table 4.213)
+'sotyp' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 0 ;
+}
+
+#Specific humidity (kg kg-1)
+'spfh' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 0 ;
+}
+
+#Storm surface runoff (kg m-2)
+'ssrun' = {
+   discipline = 1 ;
+   parameterCategory = 0 ;
+   parameterNumber = 193 ;
+}
+
+#Sunshine duration (s)
+'sunsd' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 201 ;
+}
+
+#Total cloud cover (%)
+'tcdc' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 1 ;
+}
+
+#Maximum temperature (K)
+'tmax' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 4 ;
+}
+
+#Minimum temperature (K)
+'tmin' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 5 ;
+}
+
+#Temperature (K)
+'tmp' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 0 ;
+}
+
+#Total ozone (Dobson)
+'tozne' = {
+   discipline = 0 ;
+   parameterCategory = 14 ;
+   parameterNumber = 0 ;
+}
+
+#Transpiration (W m-2)
+'trans' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 230 ;
+}
+
+#Soil temperature (K)
+'tsoil' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 2 ;
+}
+
+#Momentum flux, u-component (N m-2)
+'uflx' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 17 ;
+}
+
+#U-component of wind (m s-1)
+'ugrd' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 2 ;
+}
+
+#Zonal flux of gravity wave stress (N m-2)
+'ugwd' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 194 ;
+}
+
+#Upward long-wave radiation flux (W m-2)
+'ulwrf' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 193 ;
+}
+
+#U-component storm motion (m s-1)
+'ustm' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 194 ;
+}
+
+#Upward short-wave radiation flux (W m-2)
+'uswrf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 193 ;
+}
+
+#Visible beam downward solar flux (W m-2)
+'vbdsf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 200 ;
+}
+
+#Visible diffuse downward solar flux (W m-2)
+'vddsf' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 201 ;
+}
+
+#Vegetation (%)
+'veg' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 4 ;
+}
+
+#Momentum flux, v-component (N m-2)
+'vflx' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 18 ;
+}
+
+#V-component of wind (m s-1)
+'vgrd' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 3 ;
+}
+
+#Vegetation type (Integer (0-13))
+'vgtyp' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 198 ;
+}
+
+#Meridional flux of gravity wave stress (N m-2)
+'vgwd' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 195 ;
+}
+
+#Visibility (m)
+'vis' = {
+   discipline = 0 ;
+   parameterCategory = 19 ;
+   parameterNumber = 0 ;
+}
+
+#Ventilation rate (m2 s-1)
+'vrate' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 224 ;
+}
+
+#V-component storm motion (m s-1)
+'vstm' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 195 ;
+}
+
+#Vertical velocity (pressure) (Pa s-1)
+'vvel' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 8 ;
+}
+
+#Vertical speed shear (s-1)
+'vwsh' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 192 ;
+}
+
+#Water runoff (kg m-2)
+'watr' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 5 ;
+}
+
+#Water equivalent of accumulated snow depth (kg m-2)
+'weasd' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 13 ;
+}
+
+#Wilting point (Fraction)
+'wilt' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 201 ;
+}
+

--- a/definitions/grib2/localConcepts/babj/units.def
+++ b/definitions/grib2/localConcepts/babj/units.def
@@ -1,0 +1,737 @@
+# Manually generated according to CRA40 reanalyses datasets.
+# Created by Jianglizhi, Fujian Institue of Meteorology Sciences, Feb 8 2022.
+#Best (4 layer) lifted index
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 193 ;
+}
+
+#5-wave geopotential height
+'gpm' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 193 ;
+}
+
+#Absolute vorticity
+'s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 10 ;
+}
+
+#Aerodynamic conductance
+'m s-1' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 228 ;
+}
+
+#Convective precipitation
+'kg m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 10 ;
+}
+
+#Albedo
+'%' = {
+   discipline = 0 ;
+   parameterCategory = 19 ;
+   parameterNumber = 1 ;
+}
+
+#Total precipitation
+'kg m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 8 ;
+}
+
+#Apparent temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 21 ;
+}
+
+#Brightness temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 4 ;
+}
+
+#Convective available potential energy
+'J kg-1' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 6 ;
+}
+
+#Clear sky UV-B downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 195 ;
+}
+
+#Categorical freezing rain (yes=1; no=0)
+'non-dim' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 193 ;
+}
+
+#Categorical ice pellets (yes=1; no=0)
+'non-dim' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 194 ;
+}
+
+#Convective inhibition
+'J kg-1' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 7 ;
+}
+
+#Plant canopy surface water
+'kg m-2' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 196 ;
+}
+
+#Percent frozen precipitation
+'%' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 39 ;
+}
+
+#Convective precipitation rate
+'kg m-2 s-1' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 196 ;
+}
+
+#Categorical rain (yes=1; no=0)
+'non-dim' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 192 ;
+}
+
+#Clear sky downward long wave flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 196 ;
+}
+
+#Clear sky downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 196 ;
+}
+
+#Categorical snow (yes=1; no=0)
+'non-dim' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 195 ;
+}
+
+#Clear sky upward long wave flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 195 ;
+}
+
+#Clear sky upward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 198 ;
+}
+
+#Cloud water
+'kg m-2' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 6 ;
+}
+
+#Cloud work function
+'J kg-1' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 193 ;
+}
+
+#Downward long-wave radiation flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 192 ;
+}
+
+#Dew point temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 6 ;
+}
+
+#Downward short-wave radiation flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 192 ;
+}
+
+#UV-B downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 194 ;
+}
+
+#Direct evaporation from bare soil
+'W m-2' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 198 ;
+}
+
+#Canopy water evaporation
+'W m-2' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 229 ;
+}
+
+#Field capacity
+'fraction' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 203 ;
+}
+
+#Frictional velocity
+'m s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 197 ;
+}
+
+#Ground heat flux
+'W m-2' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 193 ;
+}
+
+#Wind speed (gust)
+'m s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 22 ;
+}
+
+#Geopotential height
+'gpm' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 5 ;
+}
+
+#Haines index
+'Numeric' = {
+   discipline = 2 ;
+   parameterCategory = 4 ;
+   parameterNumber = 2 ;
+}
+
+#Storm relative helicity
+'m2 s-2' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 8 ;
+}
+
+#Planetary boundary layer height
+'m' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 196 ;
+}
+
+#ICAO standard atmosphere reference height
+'m' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 3 ;
+}
+
+#Ice cover
+'Proportion' = {
+   discipline = 10 ;
+   parameterCategory = 2 ;
+   parameterNumber = 0 ;
+}
+
+#Ice thickness
+'m' = {
+   discipline = 10 ;
+   parameterCategory = 2 ;
+   parameterNumber = 1 ;
+}
+
+#Land cover (1=land, 0=sea)
+'Proportion' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 0 ;
+}
+
+#Surface lifted index
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 192 ;
+}
+
+#Latent heat net flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 10 ;
+}
+
+#Montgomery stream function
+'m2 s-2' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 6 ;
+}
+
+#MSLP (ETA model reduction)
+'Pa' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 192 ;
+}
+
+#Near IR beam downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 202 ;
+}
+
+#Large-scale precipitation (non-convective)
+'kg m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 9 ;
+}
+
+#Near IR diffuse downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 203 ;
+}
+
+#Potential evaporation rate
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 200 ;
+}
+
+#Parcel lifted index (to 500 hpa)
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 7 ;
+   parameterNumber = 0 ;
+}
+
+#Pressure of level from which parcel was lifted
+'Pa' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 200 ;
+}
+
+#Potential temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 2 ;
+}
+
+#Precipitation rate
+'kg m-2 s-1' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 7 ;
+}
+
+#Pressure
+'Pa' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 0 ;
+}
+
+#Pressure reduced to MSL
+'Pa' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 1 ;
+}
+
+#Potential vorticity
+'K m2 kg-1 s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 14 ;
+}
+
+#Precipitable water
+'kg m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 3 ;
+}
+
+#Maximum specific humidity at 2m
+'kg kg-1' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 219 ;
+}
+
+#Minimum specific humidity at 2m
+'kg kg-1' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 220 ;
+}
+
+#Relative humidity
+'%' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 1 ;
+}
+
+#Sublimation (evaporation from snow)
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 212 ;
+}
+
+#Surface roughness
+'m' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 1 ;
+}
+
+#Exchange coefficient
+'(kg m-3) (m s-1)' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 195 ;
+}
+
+#Sensible heat net flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 11 ;
+}
+
+#Surface slope type
+'Index' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 194 ;
+}
+
+#Snow depth
+'m' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 11 ;
+}
+
+#Snow phase change heat flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 16 ;
+}
+
+#Snow cover
+'%' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 42 ;
+}
+
+#Liquid volumetric soil moisture (non frozen)
+'Proportion' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 192 ;
+}
+
+#Soil moisture content
+'kg m-2' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 3 ;
+}
+
+#Volumetric soil moisture content
+'Fraction' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 192 ;
+}
+
+#Soil type
+'Code Table 4.213' = {
+   discipline = 2 ;
+   parameterCategory = 3 ;
+   parameterNumber = 0 ;
+}
+
+#Specific humidity
+'kg kg-1' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 0 ;
+}
+
+#Storm surface runoff
+'kg m-2' = {
+   discipline = 1 ;
+   parameterCategory = 0 ;
+   parameterNumber = 193 ;
+}
+
+#Sunshine duration
+'s' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 201 ;
+}
+
+#Total cloud cover
+'%' = {
+   discipline = 0 ;
+   parameterCategory = 6 ;
+   parameterNumber = 1 ;
+}
+
+#Maximum temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 4 ;
+}
+
+#Minimum temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 5 ;
+}
+
+#Temperature
+'K' = {
+   discipline = 0 ;
+   parameterCategory = 0 ;
+   parameterNumber = 0 ;
+}
+
+#Total ozone
+'Dobson' = {
+   discipline = 0 ;
+   parameterCategory = 14 ;
+   parameterNumber = 0 ;
+}
+
+#Transpiration
+'W m-2' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 230 ;
+}
+
+#Soil temperature
+'K' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 2 ;
+}
+
+#Momentum flux, u-component
+'N m-2' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 17 ;
+}
+
+#U-component of wind
+'m s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 2 ;
+}
+
+#Zonal flux of gravity wave stress
+'N m-2' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 194 ;
+}
+
+#Upward long-wave radiation flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 5 ;
+   parameterNumber = 193 ;
+}
+
+#U-component storm motion
+'m s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 194 ;
+}
+
+#Upward short-wave radiation flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 193 ;
+}
+
+#Visible beam downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 200 ;
+}
+
+#Visible diffuse downward solar flux
+'W m-2' = {
+   discipline = 0 ;
+   parameterCategory = 4 ;
+   parameterNumber = 201 ;
+}
+
+#Vegetation
+'%' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 4 ;
+}
+
+#Momentum flux, v-component
+'N m-2' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 18 ;
+}
+
+#V-component of wind
+'m s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 3 ;
+}
+
+#Vegetation type
+'Integer (0-13)' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 198 ;
+}
+
+#Meridional flux of gravity wave stress
+'N m-2' = {
+   discipline = 0 ;
+   parameterCategory = 3 ;
+   parameterNumber = 195 ;
+}
+
+#Visibility
+'m' = {
+   discipline = 0 ;
+   parameterCategory = 19 ;
+   parameterNumber = 0 ;
+}
+
+#Ventilation rate
+'m2 s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 224 ;
+}
+
+#V-component storm motion
+'m s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 195 ;
+}
+
+#Vertical velocity (pressure)
+'Pa s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 8 ;
+}
+
+#Vertical speed shear
+'s-1' = {
+   discipline = 0 ;
+   parameterCategory = 2 ;
+   parameterNumber = 192 ;
+}
+
+#Water runoff
+'kg m-2' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 5 ;
+}
+
+#Water equivalent of accumulated snow depth
+'kg m-2' = {
+   discipline = 0 ;
+   parameterCategory = 1 ;
+   parameterNumber = 13 ;
+}
+
+#Wilting point
+'Fraction' = {
+   discipline = 2 ;
+   parameterCategory = 0 ;
+   parameterNumber = 201 ;
+}
+


### PR DESCRIPTION
Hello,
I woud like to use eccodes to display the shortname of variables of CRA40 dataset. However, it display some unknown value for some variable . 
```
[root@SR868 CRA]# grib_ls  /data-bak/CRA/2022/20220101/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2 
/data-bak/CRA/2022/20220101/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2
edition      centre       date         dataType     gridType     typeOfLevel  level        stepRange    shortName    packingType  
2            babj         20220101     fc           regular_ll   surface      0            0-6          unknown      grid_jpeg   
2            babj         20220101     fc           regular_ll   surface      0            0-6          unknown      grid_jpeg   
2            babj         20220101     fc           regular_ll   surface      0            0-6          unknown      grid_jpeg   
...
2            babj         20220101     fc           regular_ll   heightAboveGround  2            0-6          unknown      grid_jpeg   
66 of 66 messages in /data-bak/CRA/2022/20220101/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2

66 of 66 total messages in 1 files
```
I used the ncl to open these gribfiles and display the information including discipline, category, and numbers of each variable of CRA40 datasets. After that, definition files (*.def) has been creaded according to the examples in ecmf directory.
Then, these created files has been added in "definitions/grib2/localConcepts/babj" folders. I tried grib_ls again, the shortName displayed normally.
```
[root@SR868 CRA]# grib_ls  /data-bak/CRA/2022/20220101/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2 
/data-bak/CRA/2022/20220101/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2
edition      centre       date         dataType     gridType     typeOfLevel  level        stepRange    shortName    packingType  
2            babj         20220101     fc           regular_ll   surface      0            0-6          csnow        grid_jpeg   
2            babj         20220101     fc           regular_ll   surface      0            0-6          cicep        grid_jpeg   
2            babj         20220101     fc           regular_ll   surface      0            0-6          cfrzr        grid_jpeg   
...
   
2            babj         20220101     fc           regular_ll   heightAboveGround  2            0-6          qmin         grid_jpeg   
66 of 66 messages in /data-bak/CRA/2022/20220101/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2

66 of 66 total messages in 1 files
```

Actually, these file was been created MANUALLY, since I am not sure the eccodes software's hierarchy and not known the prel language. It's beyond my knowledge. That would be great if someone created thes files automatically. 
Regards.

Jiang

[remove the suffix ".txt "]
[CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.z01.txt](https://github.com/ecmwf/eccodes/files/8022102/CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.z01.txt)
[CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.z02.txt](https://github.com/ecmwf/eccodes/files/8022107/CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.z02.txt)
[CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.z03.txt](https://github.com/ecmwf/eccodes/files/8022110/CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.z03.txt)
[CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.zip.txt](https://github.com/ecmwf/eccodes/files/8022111/CRA40_SINGLE_2022010100_GLB_0P25_HOUR_V1_0_0.zip.txt)

[CRA40_SINGLEA_2022010100_GLB_0P25_HOUR_V1_1_2.z01.txt](https://github.com/ecmwf/eccodes/files/8022115/CRA40_SINGLEA_2022010100_GLB_0P25_HOUR_V1_1_2.z01.txt)
[CRA40_SINGLEA_2022010100_GLB_0P25_HOUR_V1_1_2.zip.txt](https://github.com/ecmwf/eccodes/files/8022116/CRA40_SINGLEA_2022010100_GLB_0P25_HOUR_V1_1_2.zip.txt)

[CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2.txt](https://github.com/ecmwf/eccodes/files/8022117/CRA40_SINGLEF_2022010100_GLB_0P25_HOUR_V1_1_2.grib2.txt)
