### PR TITLE
Add packingType for template 5.200 (Run length packing with level values)

### DIFF
--- a/definitions/grib2/section.5.def
+++ b/definitions/grib2/section.5.def
@@ -48,6 +48,7 @@ concept packingType (unknown) {
   "spectral_ieee"                        = { dataRepresentationTemplateNumber = 50000; }
   "grid_simple_log_preprocessing"        = { dataRepresentationTemplateNumber = 61; }
   "bifourier_complex"                    = { dataRepresentationTemplateNumber = 53; spectralType=2; }
+  "grid_run_length"                      = { dataRepresentationTemplateNumber = 200; }
 }  : dump;
 
 template dataRepresentation "grib2/template.5.[dataRepresentationTemplateNumber:l].def";


### PR DESCRIPTION
Hello,

Thank you for adding support for template 5.200.  I used HEAD in the repository and noticed that `packingType` was left as `unknown` in `grib_ls`, so I added it.

I named RLE's `packingType` after simple packing and complex packing, but if there is a naming convention and my naming is inappropriate, I would appreciate it if you could let me know.

```shellsession
% ./install/bin/grib_ls Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin
Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin
edition      centre       date         dataType     gridType     stepRange    typeOfLevel  level        shortName    packingType
2            rjtd         20160822     af           regular_ll   0            surface      0            unknown      unknown
2            rjtd         20160822     af           regular_ll   10           surface      0            unknown      unknown
2            rjtd         20160822     af           regular_ll   20           surface      0            unknown      unknown
2            rjtd         20160822     af           regular_ll   30           surface      0            unknown      unknown
2            rjtd         20160822     af           regular_ll   40           surface      0            unknown      unknown
2            rjtd         20160822     af           regular_ll   50           surface      0            unknown      unknown
2            rjtd         20160822     af           regular_ll   1            surface      0            unknown      unknown
7 of 7 messages in Z__C_RJTD_20160822020000_NOWC_GPV_Ggis10km_Pphw10_FH0000-0100_grib2.bin

7 of 7 total messages in 1 files
```

Note: templates used in the data above is 3.0, 4.0, and 5.200 (so local section 4 templates are not used).
You can download it from [JMA's GPV sample data page](https://www.data.jma.go.jp/developer/gpv_sample.html); the link text is "竜巻発生確度ナウキャスト" and the file name is `tornado.zip`.
(I have read [a comment](https://github.com/ecmwf/eccodes/pull/72#issuecomment-1397651242) in #72 and think you are looking for such a data.)

Many thanks!