### PR TITLE
grib_util_set_spec: gridType=lambert_azimuthal_equal_area keys (MIR-5…

### DIFF
--- a/src/grib_util.cc
+++ b/src/grib_util.cc
@@ -1159,16 +1159,16 @@ grib_handle* grib_util_set_spec2(grib_handle* h,
             COPY_SPEC_DOUBLE(latitudeOfFirstGridPointInDegrees);
             COPY_SPEC_LONG(Ni); /* same as Nx */
             COPY_SPEC_LONG(Nj); /* same as Ny */
-            /* TODO: pass in extra keys e.g. Dx, Dy, standardParallel and centralLongitude */
+            COPY_SPEC_LONG(iScansNegatively);
+            COPY_SPEC_LONG(jScansPositively);
 
-            /*
-            COPY_SPEC_LONG(DxInMetres);
-            COPY_SPEC_LONG(DyInMetres);
-            COPY_SPEC_LONG(xDirectionGridLengthInMillimetres);
-            COPY_SPEC_LONG(yDirectionGridLengthInMillimetres);
-            COPY_SPEC_LONG(standardParallelInMicrodegrees);
-            COPY_SPEC_LONG(centralLongitudeInMicrodegrees);
-            */
+            // TODO: pass in extra keys e.g. Dx, Dy, standardParallel and centralLongitude
+            // COPY_SPEC_LONG(DxInMetres);
+            // COPY_SPEC_LONG(DyInMetres);
+            // COPY_SPEC_LONG(xDirectionGridLengthInMillimetres);
+            // COPY_SPEC_LONG(yDirectionGridLengthInMillimetres);
+            // COPY_SPEC_LONG(standardParallelInMicrodegrees);
+            // COPY_SPEC_LONG(centralLongitudeInMicrodegrees);
 
             break;
         case GRIB_UTIL_GRID_SPEC_UNSTRUCTURED:


### PR DESCRIPTION
Thie pertains to respecting, and preserving the input GRIB metadata (in this case, the scannningMode) withihn ecCodes codes_util_set_spec interface, specifically for gridType=lambert_azimuthal_equal_area (so, internal use only).

JIRA issues MIR-553, MIR-606