### PR TITLE
Run nightly tests

### DIFF
--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -10,4 +10,5 @@ module load  gnuparallel/new
 module load  python3
 
 cd ~masn/REGRESSION_TESTING/ecCodes
-./par-suite.sh -w $TMPDIR/install/eccodes
+# ./par-suite.sh -w $TMPDIR/install/eccodes
+./seq-suite.sh -w $TMPDIR/install/eccodes -d -t ecc-1314-grib.sh

--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -13,6 +13,7 @@ module load gnuparallel/new
 module load python3
 
 cd ~masn/REGRESSION_TESTING/ecCodes
-./par-suite.sh -w $TMPDIR/install/eccodes -t py_
+./par-suite.sh -w $TMPDIR/install/eccodes
 
+# For debugging specific test(s)
 # ./seq-suite.sh -w $TMPDIR/install/eccodes -d -t py_

--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -13,5 +13,6 @@ module load gnuparallel/new
 module load python3
 
 cd ~masn/REGRESSION_TESTING/ecCodes
-# ./par-suite.sh -w $TMPDIR/install/eccodes
-./seq-suite.sh -w $TMPDIR/install/eccodes -d -t py_binary_message
+./par-suite.sh -w $TMPDIR/install/eccodes -t py_
+
+# ./seq-suite.sh -w $TMPDIR/install/eccodes -d -t py_

--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -11,4 +11,4 @@ module load  python3
 
 cd ~masn/REGRESSION_TESTING/ecCodes
 # ./par-suite.sh -w $TMPDIR/install/eccodes
-./seq-suite.sh -w $TMPDIR/install/eccodes -d -t ecc-1314-grib.sh
+./seq-suite.sh -w $TMPDIR/install/eccodes -d -t grib_png

--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+module unload ecmwf-toolbox # Very important if you are testing your own build/install
+module load  cdo/new
+module load  numdiff
+module load  nccmp netcdf4/new
+module load  gnuparallel/new
+module load  python3
+
+cd ~masn/REGRESSION_TESTING/ecCodes
+./par-suite.sh -w $TMPDIR/install/eccodes

--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -2,13 +2,16 @@
 
 set -e
 
-module unload ecmwf-toolbox # Very important if you are testing your own build/install
-module load  cdo/new
-module load  numdiff
-module load  nccmp netcdf4/new
-module load  gnuparallel/new
-module load  python3
+# We do not want to come across the ecCodes tools in the toolbox
+module unload ecmwf-toolbox
+
+module load cdo/new
+module load numdiff
+module load nccmp
+module load netcdf4/new
+module load gnuparallel/new
+module load python3
 
 cd ~masn/REGRESSION_TESTING/ecCodes
 # ./par-suite.sh -w $TMPDIR/install/eccodes
-./seq-suite.sh -w $TMPDIR/install/eccodes -d -t grib_png
+./seq-suite.sh -w $TMPDIR/install/eccodes -d -t py_binary_message

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,16 @@
+name: nightly
+
+on:
+  workflow_dispatch: ~
+
+  # Run at 20:00 UTC every day (on default branch)
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-ci-hpc.yml
+    with:
+      eccodes: ecmwf/eccodes@${{ github.event.pull_request.head.sha || github.sha }}
+      nightly_test: true
+    secrets: inherit

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -25,4 +25,5 @@ jobs:
           aec
         --parallel: 64
         ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' }}
+        ${{ inputs.nightly_test && '--force-build: true' }}
     secrets: inherit

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -23,6 +23,7 @@ jobs:
           ecbuild
           ninja
           aec
+          netcdf4/new
         --parallel: 64
         ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' }}
         ${{ inputs.nightly_test && '--force-build: true' }}

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -26,4 +26,5 @@ jobs:
         --parallel: 64
         ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' }}
         ${{ inputs.nightly_test && '--force-build: true' }}
+        ${{ inputs.nightly_test && '--cmake-options: -DENABLE_PNG=1,-DENABLE_NETCDF=1' }}
     secrets: inherit

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -6,6 +6,10 @@ on:
       eccodes:
         required: false
         type: string
+      nightly_test:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   ci-hpc:
@@ -20,4 +24,5 @@ jobs:
           ninja
           aec
         --parallel: 64
+        ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' }}
     secrets: inherit


### PR DESCRIPTION
Adds a github actions workflow and a script to trigger nightly long running tests.
Tests run at 20:00 UTC every day on the develop branch or can be manually dispatched.