### PR TITLE
Add abbreviation birk for Reykjavik

### DIFF
--- a/definitions/common/c-1.table
+++ b/definitions/common/c-1.table
@@ -74,7 +74,7 @@
 210 210  Frascati (ESA/ESRIN)
 211 211  Lannion
 212 212  Lisboa
-213 213  Reykjavik
+213 birk Reykjavik
 214 lemm INM Madrid
 215 lssw Zurich
 216 216  Service ARGOS Toulouse

--- a/definitions/common/c-11.table
+++ b/definitions/common/c-11.table
@@ -73,7 +73,7 @@
 210 210  Frascati (ESA/ESRIN)
 211 211  Lannion
 212 212  Lisboa
-213 213  Reykjavik
+213 birk Reykjavik
 214 lemm INM Madrid
 215 lssw Zurich
 216 216  Service ARGOS Toulouse

--- a/definitions/grib2/local/2.0.table
+++ b/definitions/grib2/local/2.0.table
@@ -78,7 +78,7 @@
 210 210 Frascati (ESA/ESRIN)
 211 211 Lannion
 212 212 Lisboa
-213 213 Reykjavik
+213 birk Reykjavik
 214 lemm INM
 215 lssw Zurich
 216 216 Service ARGOS Toulouse

--- a/definitions/grib3/centre.table
+++ b/definitions/grib3/centre.table
@@ -78,7 +78,7 @@
 210 210  Frascati (ESA/ESRIN)
 211 211  Lannion
 212 212  Lisboa
-213 213  Reykjavik
+213 birk Reykjavik
 214 lemm INM
 215 lssw Zurich
 216 216  Service ARGOS Toulouse

--- a/definitions/grib3/local/2.0.table
+++ b/definitions/grib3/local/2.0.table
@@ -78,7 +78,7 @@
 210 210 Frascati (ESA/ESRIN)
 211 211 Lannion
 212 212 Lisboa
-213 213 Reykjavik
+213 birk Reykjavik
 214 lemm INM
 215 lssw Zurich
 216 216 Service ARGOS Toulouse

--- a/src/bufr_util.cc
+++ b/src/bufr_util.cc
@@ -742,6 +742,8 @@ static const char* codes_bufr_header_get_centre_name(long edition, long centre_c
             return "wiix";
         case 204:
             return "niwa";
+        case 213:
+            return "birk";
         case 214:
             return "lemm";
         case 215:


### PR DESCRIPTION
Minor change to add abbreviation for Reykjavík Iceland, i.e. birk instead of 213.
This is helpful for some downstream applications at Icelandic Met. Office.