### PR TITLE
Fix HPC CI build inputs

### DIFF
--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -25,7 +25,7 @@ jobs:
           aec
           netcdf4/new
         --parallel: 64
-        ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' }}
-        ${{ inputs.nightly_test && '--force-build: true' }}
-        ${{ inputs.nightly_test && '--cmake-options: -DENABLE_PNG=1,-DENABLE_NETCDF=1' }}
+        ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' || '' }}
+        ${{ inputs.nightly_test && '--force-build: true' || '' }}
+        ${{ inputs.nightly_test && '--cmake-options: -DENABLE_PNG=1,-DENABLE_NETCDF=1' || '' }}
     secrets: inherit


### PR DESCRIPTION
Fixes build-package-hpc inputs for regular CI. Caused by optional inputs for nightly tests which produce invalid yaml file when running the regular CI.