### PR TITLE
Enable extended tests in HPC CI

### DIFF
--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -25,6 +25,7 @@ jobs:
           aec
           netcdf4/new
         --parallel: 64
+        --cmake-options: -DENABLE_EXTRA_TESTS=1
         ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' || '' }}
         ${{ inputs.nightly_test && '--force-build: true' || '' }}
         ${{ inputs.nightly_test && '--cmake-options: -DENABLE_PNG=1,-DENABLE_NETCDF=1' || '' }}

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -25,8 +25,9 @@ jobs:
           aec
           netcdf4/new
         --parallel: 64
-        --cmake-options: -DENABLE_EXTRA_TESTS=1
+        --cmake-options: |
+          -DENABLE_EXTRA_TESTS=1
+          ${{ inputs.nightly_test && '-DENABLE_PNG=1,-DENABLE_NETCDF=1' || '' }}
         ${{ inputs.nightly_test && '--post-script: .github/ci-nightly-test.sh' || '' }}
         ${{ inputs.nightly_test && '--force-build: true' || '' }}
-        ${{ inputs.nightly_test && '--cmake-options: -DENABLE_PNG=1,-DENABLE_NETCDF=1' || '' }}
     secrets: inherit


### PR DESCRIPTION
Enables extended tests for CI running on HPC using the `-DENABLE_EXTRA_TESTS=1` build option.