### PR TITLE
Added support for stepTypes while typeOfTimeIncrement is 255

### DIFF
--- a/definitions/grib2/template.4.statistical.def
+++ b/definitions/grib2/template.4.statistical.def
@@ -56,8 +56,10 @@ if (numberOfTimeRange == 1 || numberOfTimeRange == 2) {
     "instant" = {typeOfStatisticalProcessing=255;}
     "avg"     = {typeOfStatisticalProcessing=0;typeOfTimeIncrement=2;}
     "avg"     = {typeOfStatisticalProcessing=0;typeOfTimeIncrement=3;}
+    "avg"     = {typeOfStatisticalProcessing=0;typeOfTimeIncrement=255;}
     "avgd"    = {typeOfStatisticalProcessing=0;typeOfTimeIncrement=1;}
     "accum"   = {typeOfStatisticalProcessing=1;typeOfTimeIncrement=2;}
+    "accum"   = {typeOfStatisticalProcessing=1;typeOfTimeIncrement=255;}
     "max"     = {typeOfStatisticalProcessing=2;}
     "min"     = {typeOfStatisticalProcessing=3;}
     "diff"    = {typeOfStatisticalProcessing=4;} # end-start


### PR DESCRIPTION
Due to the current definition of the concept `stepTypeInternal` in `template.4.statistical.def`, ecCodes fails to provide a value for the concept `stepTypeInternal` and by extention the concept `stepType`, in case of GRIB2 messages with Product Definition Template 8 and `typeOfStatisticalProcessing` 0 or 1 ('avg' and 'accum' as per Table 4.10), if the value for `typeOfTimeIncrement` is not provided (i.e. set to 255 = 'Missing' as per Table 4.11). 

This simple PR aims to amend that by adding entries for this default situation, while preserving the specific cases that are already explicitly defined.