### PR TITLE
Fix workflow_id for notifications about nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
           needs_context: ${{ toJSON(needs) }}
+          workflow_id: nightly.yml


### PR DESCRIPTION
This allows us to correctly check the previous conclusion of the nightly CI so we can send a notification if previously-failing CI is now passing.

The default workflow_id is `ci.yml` so we've been checking the conclusion of the wrong workflow.