### PR TITLE
Specification volcanic removed from SO2 chem definition

### DIFF
--- a/definitions/chemSpecies.csv
+++ b/definitions/chemSpecies.csv
@@ -5,7 +5,7 @@ chemId	chemName	name	aerosolType	constituentType	localTablesVersion	sourceSinkCh
 5	HCHO	Formaldehyde		7		
 6	HNO3	Nitric acid		17		
 7	CH3OOH	Methyl peroxide		10002		
-8	SO2_v	Volcanic sulfur dioxide		8		7
+8	SO2	Sulfur dioxide		8		
 9	par	Paraffins		60009		
 10	C2H4	Ethene		10009		
 11	Rn	Radon		23		

--- a/definitions/grib2/chemFormula.def
+++ b/definitions/grib2/chemFormula.def
@@ -18,10 +18,9 @@
 'CH3OOH' = {
 	constituentType = 10002 ;
 	}
-#Volcanic sulfur dioxide
-'SO2_v' = {
+#Sulfur dioxide
+'SO2' = {
 	constituentType = 8 ;
-	sourceSinkChemicalPhysicalProcess = 7 ;
 	}
 #Paraffins
 'par' = {

--- a/definitions/grib2/chemId.def
+++ b/definitions/grib2/chemId.def
@@ -18,10 +18,9 @@
 '7' = {
 	constituentType = 10002 ;
 	}
-#Volcanic sulfur dioxide
+#Sulfur dioxide
 '8' = {
 	constituentType = 8 ;
-	sourceSinkChemicalPhysicalProcess = 7 ;
 	}
 #Paraffins
 '9' = {

--- a/definitions/grib2/chemName.def
+++ b/definitions/grib2/chemName.def
@@ -18,10 +18,9 @@
 'Methyl peroxide' = {
 	constituentType = 10002 ;
 	}
-#Volcanic sulfur dioxide
-'Volcanic sulfur dioxide' = {
+#Sulfur dioxide
+'Sulfur dioxide' = {
 	constituentType = 8 ;
-	sourceSinkChemicalPhysicalProcess = 7 ;
 	}
 #Paraffins
 'Paraffins' = {

--- a/definitions/grib2/chemShortName.def
+++ b/definitions/grib2/chemShortName.def
@@ -18,10 +18,9 @@
 'CH3OOH' = {
 	constituentType = 10002 ;
 	}
-#Volcanic sulfur dioxide
-'SO2_v' = {
+#Sulfur dioxide
+'SO2' = {
 	constituentType = 8 ;
-	sourceSinkChemicalPhysicalProcess = 7 ;
 	}
 #Paraffins
 'par' = {


### PR DESCRIPTION
The key sourceSinkChemicalPhysicalProcess from the chemistry definitions for SO2 was removed.