### PR TITLE
Feature/chem id mars

### DIFF
--- a/definitions/chemSpecies.csv
+++ b/definitions/chemSpecies.csv
@@ -5,7 +5,6 @@ chemId	chemName	name	aerosolType	constituentType	localTablesVersion	sourceSinkCh
 5	HCHO	Formaldehyde		7		
 6	HNO3	Nitric acid		17		
 7	CH3OOH	Methyl peroxide		10002		
-8	SO2	Sulfur dioxide		8		
 9	par	Paraffins		60009		
 10	C2H4	Ethene		10009		
 11	Rn	Radon		23		

--- a/definitions/grib2/chemFormula.def
+++ b/definitions/grib2/chemFormula.def
@@ -18,10 +18,6 @@
 'CH3OOH' = {
 	constituentType = 10002 ;
 	}
-#Sulfur dioxide
-'SO2' = {
-	constituentType = 8 ;
-	}
 #Paraffins
 'par' = {
 	constituentType = 60009 ;

--- a/definitions/grib2/chemId.def
+++ b/definitions/grib2/chemId.def
@@ -18,10 +18,6 @@
 '7' = {
 	constituentType = 10002 ;
 	}
-#Sulfur dioxide
-'8' = {
-	constituentType = 8 ;
-	}
 #Paraffins
 '9' = {
 	constituentType = 60009 ;

--- a/definitions/grib2/chemName.def
+++ b/definitions/grib2/chemName.def
@@ -18,10 +18,6 @@
 'Methyl peroxide' = {
 	constituentType = 10002 ;
 	}
-#Sulfur dioxide
-'Sulfur dioxide' = {
-	constituentType = 8 ;
-	}
 #Paraffins
 'Paraffins' = {
 	constituentType = 60009 ;

--- a/definitions/grib2/chemShortName.def
+++ b/definitions/grib2/chemShortName.def
@@ -18,10 +18,6 @@
 'CH3OOH' = {
 	constituentType = 10002 ;
 	}
-#Sulfur dioxide
-'SO2' = {
-	constituentType = 8 ;
-	}
 #Paraffins
 'par' = {
 	constituentType = 60009 ;


### PR DESCRIPTION
SO2 for volcanic emissions removed. Blank SO2 with chemId 233 should be used instead.