### PR TITLE
CD: ignore tags starting with a letter

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: cd
 on:
   push:
     tags:
-      - '**'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deploy:


### PR DESCRIPTION
Tags starting with a letter, usually used for experimentation won't trigger CD.