### PR TITLE
Modification of mars levtype for ocean parameters on height above sea…

### DIFF
--- a/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
@@ -1,0 +1,5 @@
+# Concept marsLevtype
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=1}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=2}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=3}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=4}

--- a/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
@@ -1,5 +1,5 @@
 # Concept marsLevtype
-'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=1}
-'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=2}
-'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=3}
-'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101,numberOfGridUsed=4}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=1;}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=2;}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=3;}
+'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=4;}


### PR DESCRIPTION
Regarding DGOV-423, we would like to have mars.levtype = o2d for parameters
262902, 262903, 263902 and 263903 which have with the original implementation mars levtype sfc. A local mars levtype concept was added to the localConcepts/ecmf folder which redefines the levtype for parameters which are on height above the sea surface and are on one of the ocean models.