### PR TITLE
Add macos nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,15 +8,53 @@ on:
     - cron: '0 20 * * *'
 
 jobs:
-  test:
+  test-hpc:
     uses: ./.github/workflows/reusable-ci-hpc.yml
     with:
       eccodes: ecmwf/eccodes@${{ github.event.pull_request.head.sha || github.sha }}
       nightly_test: true
     secrets: inherit
 
+  test-macos:
+    strategy:
+      matrix:
+        name:
+          - clang@macos-13-arm
+          - clang@macos-13-x86
+        include:
+          - name: clang@macos-13-arm
+            labels: [self-hosted, platform-builder-macosx-13.4.1-arm64]
+            os: macos-13-arm
+            compiler: clang
+            compiler_cc: clang
+            compiler_cxx: clang++
+            compiler_fc: gfortran
+          - name: clang@macos-13-x86
+            labels: [self-hosted, platform-builder-macosx-13.4.1-x86_64]
+            os: macos-13-x86
+            compiler: clang
+            compiler_cc: clang
+            compiler_cxx: clang++
+            compiler_fc: gfortran
+    runs-on: ${{ matrix.labels }}
+    env:
+      DEP_TREE: |
+        ecbuild: ~
+        libaec:
+          deps:
+            - ecbuild
+        eccodes:
+          deps:
+            - libaec
+            - ecbuild
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/build-package-with-config@v2
+        with:
+          repository: ecmwf/eccodes@${{ github.sha }}
+          build_config: .github/ci-config.yml
+
   deploy:
-    needs: [test]
+    needs: [test-hpc, test-macos]
     uses: ecmwf-actions/reusable-workflows/.github/workflows/create-package.yml@v2
     with:
       skip_checks: true
@@ -33,7 +71,8 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     needs:
-      - test
+      - test-hpc
+      - test-macos
       - deploy
     if: always()
     steps:


### PR DESCRIPTION
Adds macos tests to the nightly CI. Macos is only added to the nightly as we have just a few machines right now.
Tests on both intel and m2 architectures.