### PR TITLE
Add libaec_ROOT as search hint for FindAEC

### DIFF
--- a/cmake/FindAEC.cmake
+++ b/cmake/FindAEC.cmake
@@ -22,14 +22,15 @@
 #  libaec_DIR
 #  LIBAEC_PATH
 #  libaec_PATH
+#  libaec_ROOT
 
 find_path( AEC_INCLUDE_DIR libaec.h
-           PATHS ${AEC_DIR} ${AEC_PATH} ${LIBAEC_DIR} ${libaec_DIR} ${LIBAEC_PATH} ${libaec_PATH} ENV AEC_DIR ENV AEC_PATH ENV LIBAEC_DIR ENV libaec_DIR ENV LIBAEC_PATH ENV libaec_PATH
+           PATHS ${AEC_DIR} ${AEC_PATH} ${LIBAEC_DIR} ${libaec_DIR} ${LIBAEC_PATH} ${libaec_PATH} ${libaec_ROOT} ENV AEC_DIR ENV AEC_PATH ENV LIBAEC_DIR ENV libaec_DIR ENV LIBAEC_PATH ENV libaec_PATH ENV libaec_ROOT
            PATH_SUFFIXES include include/aec NO_DEFAULT_PATH )
 find_path( AEC_INCLUDE_DIR libaec.h PATH_SUFFIXES include include/aec )
 
 find_library( AEC_LIBRARY  NAMES aec
-              PATHS ${AEC_DIR} ${AEC_PATH} ${LIBAEC_DIR} ${libaec_DIR} ${LIBAEC_PATH} ${libaec_PATH} ENV AEC_DIR ENV AEC_PATH ENV LIBAEC_DIR ENV libaec_DIR ENV LIBAEC_PATH ENV libaec_PATH
+              PATHS ${AEC_DIR} ${AEC_PATH} ${LIBAEC_DIR} ${libaec_DIR} ${LIBAEC_PATH} ${libaec_PATH} ${libaec_ROOT} ENV AEC_DIR ENV AEC_PATH ENV LIBAEC_DIR ENV libaec_DIR ENV LIBAEC_PATH ENV libaec_PATH ENV libaec_ROOT
               PATH_SUFFIXES lib lib64 lib/aec lib64/aec NO_DEFAULT_PATH )
 find_library( AEC_LIBRARY NAMES aec PATH_SUFFIXES lib lib64 lib/aec lib64/aec )
 


### PR DESCRIPTION
Since CMake 3.12 it is accustomed that find_package can also receive hints from the [`<PackageName>_ROOT`](https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html#variable:%3CPackageName%3E_ROOT) variable.
This PR adds support for this variable within FindAEC. The cmake package name should be libaec as that is how the package normally advertises itself if config mode were to be used.

This means that a libaec module can now set "export libaec_ROOT=..."

This PR is harmless, just adding extra search hints.