### PR TITLE
Add version to nightly ci install path

### DIFF
--- a/.github/ci-nightly-test.sh
+++ b/.github/ci-nightly-test.sh
@@ -12,8 +12,10 @@ module load netcdf4/new
 module load gnuparallel/new
 module load python3
 
+version=$(cat $TMPDIR/eccodes/VERSION)
+
 cd ~masn/REGRESSION_TESTING/ecCodes
-./par-suite.sh -w $TMPDIR/install/eccodes
+./par-suite.sh -w $TMPDIR/install/eccodes/$version
 
 # For debugging specific test(s)
-# ./seq-suite.sh -w $TMPDIR/install/eccodes -d -t py_
+# ./seq-suite.sh -w $TMPDIR/install/eccodes/$version -d -t py_


### PR DESCRIPTION
Fixes nightly ci script to include a version in the install path.
Test nightly run: https://github.com/ecmwf/eccodes/actions/runs/7165520431/job/19507636503