### PR TITLE
Default native step type is string. It's long if unit is not shown.

### DIFF
--- a/src/grib_accessor_class_g2end_step.cc
+++ b/src/grib_accessor_class_g2end_step.cc
@@ -744,14 +744,15 @@ static int pack_string(grib_accessor* a, const char* val, size_t* len)
 
 static int get_native_type(grib_accessor* a)
 {
-    // TODO: Still experimental.
-    // Change the type to depend on the stepUnits for backward compatibility
-
     grib_handle* h = grib_handle_of_accessor(a);
-    long step_units = 0;
-    if (grib_get_long_internal(h, "stepUnits", &step_units) == GRIB_SUCCESS) {
-        if (step_units == 1) {
-            return GRIB_TYPE_LONG;
+    int show_hours = a->context->show_hour_stepunit;
+
+    if (!show_hours) {
+        long step_units = 0;
+        if (grib_get_long_internal(h, "stepUnits", &step_units) == GRIB_SUCCESS) {
+            if (eccodes::Unit{step_units} == eccodes::Unit::Value::HOUR) {
+                return GRIB_TYPE_LONG;
+            }
         }
     }
 

--- a/src/grib_accessor_class_step_in_units.cc
+++ b/src/grib_accessor_class_step_in_units.cc
@@ -349,16 +349,16 @@ static int unpack_string(grib_accessor* a, char* val, size_t* len)
 
 static int get_native_type(grib_accessor* a)
 {
-    // TODO: Still experimental.
-    // Change the type to depend on the stepUnits for backward compatibility
-
     grib_handle* h = grib_handle_of_accessor(a);
-    long step_units = 0;
-    if (grib_get_long_internal(h, "stepUnits", &step_units) == GRIB_SUCCESS) {
-        if (step_units == 1) {
-            return GRIB_TYPE_LONG;
+    int show_hours = a->context->show_hour_stepunit;
+
+    if (!show_hours) {
+        long step_units = 0;
+        if (grib_get_long_internal(h, "stepUnits", &step_units) == GRIB_SUCCESS) {
+            if (eccodes::Unit{step_units} == eccodes::Unit::Value::HOUR) {
+                return GRIB_TYPE_LONG;
+            }
         }
     }
-
     return GRIB_TYPE_STRING;
 }

--- a/tests/grib_sub_hourly.sh
+++ b/tests/grib_sub_hourly.sh
@@ -490,6 +490,15 @@ grib_check_key_equals $temp '-p startStep' '16m'
 grib_check_key_equals $temp '-p indicatorOfUnitOfTimeRange' '0'
 grib_check_key_equals $temp '-p forecastTime' '16'
 
+
+export ECCODES_GRIB_SHOW_HOUR_STEPUNIT=1
+cat >$tempFilt<<EOF
+    assert ( step is "6h" );
+EOF
+cat $tempFilt
+${tools_dir}/grib_filter $tempFilt $data_dir/constant_field.grib2
+unset ECCODES_GRIB_SHOW_HOUR_STEPUNIT
+
 # Bad stepUnits
 set +e
 ${tools_dir}/grib_set -s stepUnits=190 $sample_g2 $temp > $tempText 2>&1


### PR DESCRIPTION
For backward compatibility