### PR TITLE
ECC-1762: add GRIB1 key name aliases to wave spectra template with ex…

### DIFF
--- a/definitions/grib2/template.4.wave.def
+++ b/definitions/grib2/template.4.wave.def
@@ -3,16 +3,20 @@
 ## Direction part
 unsigned[2] waveDirectionNumber : dump;
 alias mars.direction = waveDirectionNumber;
+alias directionNumber = waveDirectionNumber;
 
 unsigned[2] numberOfWaveDirections = 1 : dump;
 alias totalNumberOfWaveDirections = numberOfWaveDirections;
+alias numberOfDirections = totalNumberOfWaveDirections;
 
 ## Frequency part
 unsigned[2] waveFrequencyNumber : dump;
 alias mars.frequency = waveFrequencyNumber;
+alias frequencyNumber = waveFrequencyNumber;
 
 unsigned[2] numberOfWaveFrequencies = 1 : dump;
 alias totalNumberOfWaveFrequencies = numberOfWaveFrequencies;
+alias numberOfFrequencies = totalNumberOfWaveFrequencies;
 
 constant waveLevType="sfc";
 alias mars.levtype = waveLevType;

--- a/definitions/grib2/template.4.wave_spectra_list.def
+++ b/definitions/grib2/template.4.wave_spectra_list.def
@@ -3,11 +3,15 @@
 ## Direction part
 signed[1] scaleFactorOfWaveDirections : dump;
 alias integerScalingFactorAppliedToDirections = scaleFactorOfWaveDirections;
+alias directionScalingFactor = integerScalingFactorAppliedToDirections;
 
 unsigned[4] scaledValuesOfWaveDirections[numberOfWaveDirections] : dump;
+alias scaledDirections = scaledValuesOfWaveDirections ;
 
 ## Frequency part
 signed[1] scaleFactorOfWaveFrequencies : dump;
 alias integerScalingFactorAppliedToFrequencies = scaleFactorOfWaveFrequencies;
+alias frequencyScalingFactor = integerScalingFactorAppliedToFrequencies;
 
 unsigned[4] scaledValuesOfWaveFrequencies[numberOfWaveFrequencies] : dump;
+alias scaledFrequencies = scaledValuesOfWaveFrequencies;


### PR DESCRIPTION
Please merge this branch to develop. It contains aliases for the wave spectra templates to include in GRIB2 the same names as used in GRIB1.