### PR TITLE
ECC-1771: Fix step units initialisation in static library

### DIFF
--- a/src/step_unit.cc
+++ b/src/step_unit.cc
@@ -12,8 +12,6 @@
 
 namespace eccodes {
 
-Unit::Map Unit::map_{};
-
 std::vector<Unit::Value> Unit::grib_selected_units = {
     Unit::Value::SECOND,
     Unit::Value::MINUTE,
@@ -39,7 +37,7 @@ std::vector<Unit::Value> Unit::complete_unit_order_ = {
 };
 
 template <> long Unit::value<long>() const {
-    return map_.unit_to_long(internal_value_);
+    return get_converter().unit_to_long(internal_value_);
 }
 
 template <> Unit::Value Unit::value<Unit::Value>() const {
@@ -47,7 +45,7 @@ template <> Unit::Value Unit::value<Unit::Value>() const {
 }
 
 template <> std::string Unit::value<std::string>() const {
-    return map_.unit_to_name(internal_value_);
+    return get_converter().unit_to_name(internal_value_);
 }
 
 } // namespace eccodes

--- a/src/step_unit.h
+++ b/src/step_unit.h
@@ -68,7 +68,7 @@ public:
 
     explicit Unit(const std::string& unit_value) {
         try {
-            internal_value_ = map_.name_to_unit(unit_value);
+            internal_value_ = get_converter().name_to_unit(unit_value);
         } catch (std::exception& e) {
             throw std::runtime_error(std::string{"Unit not found "} + e.what());
         }
@@ -76,15 +76,15 @@ public:
 
     explicit Unit(long unit_value) {
         try {
-            internal_value_ = map_.long_to_unit(unit_value);
+            internal_value_ = get_converter().long_to_unit(unit_value);
         } catch (std::exception& e) {
             throw std::runtime_error(std::string{"Unit not found "} + e.what());
         }
     }
 
-    bool operator>(const Unit& other) const {return map_.unit_to_duration(internal_value_) > map_.unit_to_duration(other.internal_value_);}
-    bool operator==(const Value value) const {return map_.unit_to_duration(internal_value_) == map_.unit_to_duration(value);}
-    bool operator==(const Unit& unit) const {return map_.unit_to_duration(internal_value_) == map_.unit_to_duration(unit.internal_value_);}
+    bool operator>(const Unit& other) const {return get_converter().unit_to_duration(internal_value_) > get_converter().unit_to_duration(other.internal_value_);}
+    bool operator==(const Value value) const {return get_converter().unit_to_duration(internal_value_) == get_converter().unit_to_duration(value);}
+    bool operator==(const Unit& unit) const {return get_converter().unit_to_duration(internal_value_) == get_converter().unit_to_duration(unit.internal_value_);}
     bool operator!=(const Unit& unit) const {return !(*this == unit);}
     bool operator!=(const Value value) const {return !(*this == value);}
 
@@ -177,11 +177,12 @@ private:
 
 
     Value internal_value_;
-    static Map map_;
 public:
-    static Map& get_converter() {return map_;}
+    static Map& get_converter() {
+        static Map map_;
+        return map_;
+    }
 };
-
 
 
 template <typename T>


### PR DESCRIPTION
This fix resolves the problem with the initialisation of static members when compiling ecCodes with the -DBUILD_SHARED_LIBS=*OFF* flag.