### PR TITLE
ECC-1774 adding MARS system keyword for mmsf/fc and msmm/fcmean

### DIFF
--- a/definitions/mars/grib.mmsf.fc.def
+++ b/definitions/mars/grib.mmsf.fc.def
@@ -8,6 +8,7 @@ if (class is "od") { alias mars.system = systemNumber; }
 if (class is "me") { alias mars.system = systemNumber; }
 if (class is "en") { alias mars.system = systemNumber; }
 if (class is "c3") { alias mars.system = systemNumber; }
+if (class is "ci") { alias mars.system = systemNumber; }
 alias mars.number = perturbationNumber;
 alias mars.method = methodNumber;
 

--- a/definitions/mars/grib.msmm.fcmean.def
+++ b/definitions/mars/grib.msmm.fcmean.def
@@ -10,6 +10,7 @@ if (class is "od") { alias mars.system = systemNumber; }
 if (class is "me") { alias mars.system = systemNumber; }
 if (class is "en") { alias mars.system = systemNumber; }
 if (class is "c3") { alias mars.system = systemNumber; }
+if (class is "ci") { alias mars.system = systemNumber; }
 
 # See ECC-624
 if (centre == 80 && subCentre == 98 && class is "c3") {


### PR DESCRIPTION
we neeed to merge this for the next hotfix version. 

The branch contains the necessary changes to add the MARS keyword "system" for class cerise (class=ci) and stream type combination mmsf/gc and msmm/fcmean