### PR TITLE
ECC-1796: Implement stepRange indexing for DestinE ExtremesDT and On-Demand ExtremesDT data

### DIFF
--- a/definitions/grib2/post_meta_data.hook.products_12.def
+++ b/definitions/grib2/post_meta_data.hook.products_12.def
@@ -7,3 +7,8 @@ concept destineOrigin(unknown, "destineOriginConcept.def", conceptsDir2, concept
 
 # ECC-1794: DestinE data does not have the domain key
 unalias mars.domain;
+
+# ECC-1796: stepRange indexing for DestinE ExtremesDT and On-Demand ExtremesDT data
+if (!(dataset is "climate-dt")) {
+    alias mars.step=stepRange;
+}

--- a/tests/grib_ecc-1691.sh
+++ b/tests/grib_ecc-1691.sh
@@ -64,11 +64,12 @@ ${tools_dir}/grib_set -s numberOfDataPoints=12582912,gridDefinitionTemplateNumbe
 
 grib_check_key_equals $temp_grib_a "gridSpecification" "H1024"
 
-# Now check streams.
+# Now check streams for use in climate-dt.
 # Setting stream clte and type fc should set mars.date and mars.time to dataDate and dataTime,
 # and mars.step should be unaliased
+# We must also set dataset=climate-dt, since in other datasets mars.step is set to stepRange
 
-${tools_dir}/grib_set -s stream=clte,type=fc $destine_sample $temp_grib_a
+${tools_dir}/grib_set -s dataset=climate-dt,stream=clte,type=fc $destine_sample $temp_grib_a
 
 result1=$( ${tools_dir}/grib_get -p mars.date,mars.time $temp_grib_a )
 result2=$( ${tools_dir}/grib_get -p dataDate,dataTime $temp_grib_a )
@@ -79,8 +80,9 @@ ${tools_dir}/grib_ls -jm $temp_grib_a
 
 # Setting stream clmn and type fc should set mars.year and mars.month to year and month,
 # and mars.date, mars.time, mars.step should be unaliased
+# We must also set dataset=climate-dt, since in other datasets mars.step is set to stepRange
 
-${tools_dir}/grib_set -s stream=clmn,type=fc $destine_sample $temp_grib_a
+${tools_dir}/grib_set -s dataset=climate-dt,stream=clmn,type=fc $destine_sample $temp_grib_a
 
 result1=$( ${tools_dir}/grib_get -p mars.year,mars.month $temp_grib_a )
 result2=$( ${tools_dir}/grib_get -p year,month $temp_grib_a )


### PR DESCRIPTION
Development so that stepRange is used to index temporally processed fields rather than endStep. This is an important addition which means that two temporally processed fields over different time ranges can be distinguished and won't overwrite each other when written to the fdb or archived.
ClimateDT uses date and time to index and not step, so we apply this change to all other datasets.

See https://jira.ecmwf.int/browse/ECC-1796