### PR TITLE
feature/ECC-1829-MARS-AIFS-ensemble

### DIFF
--- a/definitions/mars/grib.oper.efi.def
+++ b/definitions/mars/grib.oper.efi.def
@@ -1,0 +1,1 @@
+alias mars.step = stepRange;

--- a/definitions/mars/grib.oper.em.def
+++ b/definitions/mars/grib.oper.em.def
@@ -1,0 +1,1 @@
+alias mars.step = stepRange;

--- a/definitions/mars/grib.oper.es.def
+++ b/definitions/mars/grib.oper.es.def
@@ -1,0 +1,1 @@
+alias mars.step = stepRange;

--- a/definitions/mars/grib.oper.pf.def
+++ b/definitions/mars/grib.oper.pf.def
@@ -1,0 +1,7 @@
+if (levtype is "o2d" || levtype is "o3d") {
+   alias mars.step = stepRange;
+} else {
+   alias mars.step = endStep;
+}
+
+alias mars.number = perturbationNumber;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-1691
         grib_ecc-1766
         grib_ecc-1806
+        grib_ecc-1829
         bufr_ecc-1028
         bufr_ecc-1195
         bufr_ecc-1259

--- a/tests/grib_ecc-1829.sh
+++ b/tests/grib_ecc-1829.sh
@@ -19,19 +19,31 @@ temp_grib=temp.$label.grib
 mars_sample=temp.$label.mars.grib
 sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
 
-# Setup ensemble GRIB2 message with MARS keys
+# Setup GRIB2 message with MARS keys
 ${tools_dir}/grib_set -s setLocalDefinition=1,grib2LocalSectionNumber=1 $sample_grib2 $mars_sample
 
-# Set ensemble related keys and check number key is present
-${tools_dir}/grib_set -s productDefinitionTemplateNumber=1,stream=oper,type=pf $mars_sample $temp_grib
+# Now set ensemble related keys and check number key is present
+${tools_dir}/grib_set -s stream=oper,type=pf,productDefinitionTemplateNumber=1 $mars_sample $temp_grib
 grib_check_key_exists $temp_grib mars.number
 
-# Now check stepRange is used for mars.step for o2d and o3d fields, and that number is still present
-${tools_dir}/grib_set -s productDefinitionTemplateNumber=11,stream=oper,type=pf,param=263101,typeOfLevel=oceanSurface,startStep=0,endStep=6 $mars_sample $temp_grib
+# Now set keys and check stepRange is used for mars.step for o2d and o3d fields, and that number is still present
+${tools_dir}/grib_set -s stream=oper,type=pf,productDefinitionTemplateNumber=11,param=263101,typeOfLevel=oceanSurface,startStep=0,endStep=6 $mars_sample $temp_grib
 grib_check_key_exists $temp_grib mars.number
 grib_check_key_equals $temp_grib "step" "0-6"
-${tools_dir}/grib_set -s productDefinitionTemplateNumber=11,stream=oper,type=pf,param=263501,typeOfLevel=oceanModel,level=1,startStep=0,endStep=6 $mars_sample $temp_grib
+${tools_dir}/grib_set -s stream=oper,type=pf,productDefinitionTemplateNumber=11,param=263501,typeOfLevel=oceanModel,level=1,startStep=0,endStep=6 $mars_sample $temp_grib
 grib_check_key_exists $temp_grib mars.number
+grib_check_key_equals $temp_grib "step" "0-6"
+
+# Now set keys and check stepRange is used for type efi data (just need any template with stat proc keys)
+${tools_dir}/grib_set -s stream=oper,type=efi,productDefinitionTemplateNumber=12,startStep=0,endStep=6 $mars_sample $temp_grib
+grib_check_key_equals $temp_grib "step" "0-6"
+
+# Now set keys and check stepRange is used for type em data
+${tools_dir}/grib_set -s stream=oper,type=em,productDefinitionTemplateNumber=12,startStep=0,endStep=6 $mars_sample $temp_grib
+grib_check_key_equals $temp_grib "step" "0-6"
+
+# Now set keys and check stepRange is used for type es data
+${tools_dir}/grib_set -s stream=oper,type=es,productDefinitionTemplateNumber=12,startStep=0,endStep=6 $mars_sample $temp_grib
 grib_check_key_equals $temp_grib "step" "0-6"
 
 # Clean up

--- a/tests/grib_ecc-1829.sh
+++ b/tests/grib_ecc-1829.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+REDIRECT=/dev/null
+
+# ECC-1829: Add MARS support for stream & type combinations required for AIFS ensemble
+
+label="grib_ecc-1829_test"
+temp_grib=temp.$label.grib
+mars_sample=temp.$label.mars.grib
+sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
+
+# Setup ensemble GRIB2 message with MARS keys
+${tools_dir}/grib_set -s setLocalDefinition=1,grib2LocalSectionNumber=1 $sample_grib2 $mars_sample
+
+# Set ensemble related keys and check number key is present
+${tools_dir}/grib_set -s productDefinitionTemplateNumber=1,stream=oper,type=pf $mars_sample $temp_grib
+grib_check_key_exists $temp_grib mars.number
+
+# Now check stepRange is used for mars.step for o2d and o3d fields, and that number is still present
+${tools_dir}/grib_set -s productDefinitionTemplateNumber=11,stream=oper,type=pf,param=263101,typeOfLevel=oceanSurface,startStep=0,endStep=6 $mars_sample $temp_grib
+grib_check_key_exists $temp_grib mars.number
+grib_check_key_equals $temp_grib "step" "0-6"
+${tools_dir}/grib_set -s productDefinitionTemplateNumber=11,stream=oper,type=pf,param=263501,typeOfLevel=oceanModel,level=1,startStep=0,endStep=6 $mars_sample $temp_grib
+grib_check_key_exists $temp_grib mars.number
+grib_check_key_equals $temp_grib "step" "0-6"
+
+# Clean up
+rm -f $temp_grib $mars_sample


### PR DESCRIPTION
We add support for stream and type combinations required for the AIFS ensemble:

- grib.oper.efi.def
- grib.oper.em.def
- grib.oper.es.def
- grib.oper.pf.def

As well as a test to confirm all is working as expected.

DGOV via [DGOV-462](https://jira.ecmwf.int/browse/DGOV-462).