### PR TITLE
Update ci.yml to fix notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - private-downstream-ci
       - downstream-ci-hpc
       - private-downstream-ci-hpc
-    if: always() && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    if: ${{ always() && !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     steps:
       - name: Trigger Teams notification
         uses: ecmwf-actions/notify-teams@v1


### PR DESCRIPTION
The notify step was skipped on failing jobs because the `always()` was not handled properly. Instead of `always() && ${{ ... }}` we have to pull in the always `${{ always() && .. }}`