### PR TITLE
ECC-1850: Extended metadata keys along with corresponding test

### DIFF
--- a/definitions/grib2/local.98.43.def
+++ b/definitions/grib2/local.98.43.def
@@ -31,4 +31,4 @@ alias mars.resolution = resolution;
 unalias mars.domain;
 
 # Add some padding just in case we want more keys in the future
-pad padding_loc43(25);
+pad padding_loc43(30);

--- a/definitions/grib2/local.98.43.def
+++ b/definitions/grib2/local.98.43.def
@@ -10,12 +10,25 @@ alias mars.activity = activity;
 codetable[2] experiment "grib2/destine_experiment.table" ;
 alias mars.experiment = experiment;
 
+# Generation keyword - synergise with DestinE ClimateDT and use this to version the dataset
+unsigned[1] generation = 255 : dump;
+alias mars.generation = generation;
+
+# Model keyword to index multiple models within EERIE
+codetable[2] model "grib2/destine_model.table" : dump;
+alias mars.model = model;
+
 # Climate run realization keyword, which relates to an initial condition perturbation
 unsigned[1] realization = 255 ;
 alias mars.realization = realization;
+
+# Allows simultaneous archiving of resolutions
+# high resolution for best available vs standard resolution for quick access and plotting
+codetable[2] resolution "grib2/destine_resolution.table" : dump;
+alias mars.resolution = resolution;
 
 # Remove mars domain from this data
 unalias mars.domain;
 
 # Add some padding just in case we want more keys in the future
-pad padding_loc43(30);
+pad padding_loc43(25);

--- a/tests/grib_ecc-1766.sh
+++ b/tests/grib_ecc-1766.sh
@@ -41,5 +41,16 @@ ${tools_dir}/grib_set -s activity=1,experiment=1,realization=1 $eerie_sample $te
 grib_check_key_equals $temp_grib "activity,experiment,realization" "1 1 1"
 grib_check_key_equals $temp_grib "activity:s,experiment:s" "CMIP6 hist"
 
+# ECC-1850: Additional keys added
+# Check additional keys are present and correct
+grib_check_key_exists $eerie_sample generation,model,resolution
+grib_check_key_equals $eerie_sample "generation,model,resolution" "255 0 0"
+
+# Check an example where a few additional things are set
+${tools_dir}/grib_set -s generation=1,model=2,resolution=1 $eerie_sample $temp_grib
+
+grib_check_key_equals $temp_grib "generation,model,resolution" "1 2 1"
+grib_check_key_equals $temp_grib "model:s,resolution:s" "IFS-NEMO standard"
+
 # Clean up
 rm -f $temp_grib $eerie_sample


### PR DESCRIPTION
After a discussion with modelling partners at BSC who will also contribute to EERIE it was clear several keys used in the DestinE ClimateDT layout would be useful within the context of the EERIE data layout.
Therefore we will add the keys generation, model and resolution to the EERIE data layout (localTemplateNumber 43), taking the same values as within the ClimateDT.
This has been agreed as an acceptable change with those involved with EERIE given that this will produce better synergies in the future with other datasets and allow the same processing pipelines to be used. Previous GRIB fields with centre 98, local def 43 will have to be DISCARDED.