### PR TITLE
CMakeLIsts.txt simplification of tools configuration

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -19,55 +19,75 @@ if( EC_OS_NAME MATCHES "windows" )
 endif()
 
 # tools library
-ecbuild_add_library( TARGET    ecc_tools
-                     TYPE      STATIC
+ecbuild_add_library( TARGET       ecc_tools
+                     TYPE         STATIC
                      NOINSTALL
-                     SOURCES   ${ecc_tools_sources}
-                     PRIVATE_LIBS      eccodes )
-
-# tools binaries
-list( APPEND ecc_tools_binaries
-             codes_info codes_count codes_split_file
-             grib_histogram grib_filter grib_ls grib_dump
-             grib2ppm grib_set grib_get grib_get_data grib_copy
-             grib_compare codes_parser grib_index_build bufr_index_build
-             bufr_ls bufr_dump bufr_set bufr_get
-             bufr_copy bufr_compare
-             gts_get gts_compare gts_copy gts_dump gts_filter gts_ls
-             metar_dump metar_ls metar_compare metar_get metar_filter metar_copy )
-
-list( APPEND ecc_tools_binaries_extra
-             grib_repair
-             grib_to_json
-             codes_export_resource
-             grib_check_gaussian_grid
-             bufr_split_by_rdbSubtype )
+                     SOURCES      ${ecc_tools_sources}
+                     PRIVATE_LIBS eccodes )
 
 # Install generic tools
-foreach( tool ${ecc_tools_binaries} )
-    # here we use the fact that each tool has only one C file that matches its name
-    ecbuild_add_executable( TARGET     ${tool}
-                            SOURCES    ${tool}.cc
-                            LIBS       ecc_tools )
+foreach( _tool
+         bufr_compare
+         bufr_copy
+         bufr_dump
+         bufr_get
+         bufr_index_build
+         bufr_ls
+         bufr_set
+         codes_count
+         codes_info
+         codes_parser
+         codes_split_file
+         grib2ppm
+         grib_compare
+         grib_copy
+         grib_dump
+         grib_filter
+         grib_get
+         grib_get_data
+         grib_histogram
+         grib_index_build
+         grib_ls
+         grib_set
+         gts_compare
+         gts_copy
+         gts_dump
+         gts_filter
+         gts_get
+         gts_ls
+         metar_compare
+         metar_copy
+         metar_dump
+         metar_filter
+         metar_get
+         metar_ls )
+    ecbuild_add_executable( TARGET  ${_tool}
+                            SOURCES ${_tool}.cc
+                            LIBS    ecc_tools )
 endforeach()
 
 # Install extra tools
-# User must run cmake with -DECCODES_INSTALL_EXTRA_TOOLS=ON
-foreach( tool ${ecc_tools_binaries_extra} )
-    ecbuild_add_executable( TARGET     ${tool}
-                            SOURCES    ${tool}.cc
-                            CONDITION  ECCODES_INSTALL_EXTRA_TOOLS
-                            LIBS       ecc_tools )
+foreach( _tool
+         bufr_split_by_rdbSubtype
+         codes_export_resource
+         grib_check_gaussian_grid
+         grib_repair
+         grib_to_json )
+    ecbuild_add_executable( TARGET    ${_tool}
+                            SOURCES   ${_tool}.cc
+                            CONDITION ECCODES_INSTALL_EXTRA_TOOLS
+                            LIBS      ecc_tools )
 endforeach()
-
 
 # grib_count/bufr_count etc. Same source code, different executable names
 ecbuild_add_executable( TARGET     grib_count
                         SOURCES    codes_count.cc
                         LIBS       ecc_tools )
+
 ecbuild_add_executable( TARGET     bufr_count
                         SOURCES    codes_count.cc
                         LIBS       ecc_tools )
+
 ecbuild_add_executable( TARGET     gts_count
                         SOURCES    codes_count.cc
                         LIBS       ecc_tools )
@@ -77,7 +97,6 @@ ecbuild_add_executable( TARGET     grib_to_netcdf
                         SOURCES    grib_to_netcdf.cc
                         CONDITION  HAVE_NETCDF
                         LIBS       ecc_tools NetCDF::NetCDF_C )
-
 
 ecbuild_add_executable( TARGET     grib_list_keys
                         SOURCES    list_keys.cc


### PR DESCRIPTION
There will be future larger changes on merging with the branch using the upcoming eckit::geo library.

This PR is only to simplify the configuration of the eccodes tools, so that a larger merge is simpler.