### PR TITLE
tools/bufs_compare_dir: Make compatible with POSIX sh

### DIFF
--- a/tools/bufr_compare_dir
+++ b/tools/bufr_compare_dir
@@ -23,8 +23,8 @@ then
   exit 1
 fi
 
-bufr_index_build -k $keys -o 1.idx $dir1/* > /dev/null
-bufr_index_build -k $keys -o 2.idx $dir2/* > /dev/null
+bufr_index_build -k $keys -o 1.idx "$dir1"/* > /dev/null
+bufr_index_build -k $keys -o 2.idx "$dir2"/* > /dev/null
 
 bufr_compare -f $opt 1.idx 2.idx
 rm -f 1.idx 2.idx

--- a/tools/bufr_compare_dir
+++ b/tools/bufr_compare_dir
@@ -1,23 +1,23 @@
-#!/bin/ksh
+#!/bin/sh
 
 keys="md5Structure,md5Data,typicalDate,typicalTime,rdbType,rdbSubtype,ident,satelliteID,localLatitude,localLongitude,localLatitude1,localLongitude1,localLatitude2,localLongitude2"
 
 opt=""
 
-if [[ $# -eq 3  ]]
+if [ $# -eq 3  ]
 then
   opt=$1
   dir1=$2
   dir2=$3
 fi
 
-if [[ $# -eq 2 ]]
+if [ $# -eq 2 ]
 then
   dir1=$1
   dir2=$2
 fi
 
-if [[ $# -gt 3 ]] || [[ $# -lt 2 ]]
+if [ $# -gt 3 ] || [ $# -lt 2 ]
 then
   echo usage: [bufr_compare options] bufr_compare_dir directory1 directory2
   exit 1


### PR DESCRIPTION
`bufr_compare_dir` is the only installed script that requires `ksh`. With minor changes it is possible to make this script compatible with standard POSIX sh.

Removing the need to use `ksh` greatly simplifies many aspects of the efforts needed to package, install and maintain eccodes in distributions like Debian.

See: https://bugs.debian.org/1078095