### PR TITLE
ECC-1914: levtype for isothermal atm parameters

### DIFF
--- a/definitions/grib2/marsLevtypeConcept.def
+++ b/definitions/grib2/marsLevtypeConcept.def
@@ -8,9 +8,8 @@
 'sfc'  = {typeOfFirstFixedSurface=8; typeOfSecondFixedSurface=255;}
 'sfc'  = {typeOfFirstFixedSurface=17; typeOfSecondFixedSurface=255;}
 'sfc'  = {typeOfFirstFixedSurface=18; typeOfSecondFixedSurface=255;}
-'o2d'  = {typeOfFirstFixedSurface=20; scaleFactorOfFirstFixedSurface=-2;
-          scaledValueOfFirstFixedSurface=29315; typeOfSecondFixedSurface=255;}
-'o2d'  = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'o2d'  = {discipline=10; typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'sfc'  = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
 'pl'   = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=255;}
 'pl'   = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=100;}
 'sfc'  = {typeOfFirstFixedSurface=1; typeOfSecondFixedSurface=100;


### PR DESCRIPTION
Please merge this branch into develop. It contains an adaptation for isothermal parameters. Atmospheric isothermal parameters got erroneously the mars levtype o2d instead of sfc. This is corrected with this branch.