### PR TITLE
Fix issue with grid_second_order hanging when encoding fields with Infinite values

### DIFF
--- a/examples/F90/CMakeLists.txt
+++ b/examples/F90/CMakeLists.txt
@@ -9,6 +9,7 @@ configure_file( include.ctest.sh.in  include.ctest.sh  @ONLY )
 if( HAVE_BUILD_TOOLS )
     list( APPEND tests_sanity
           codes_ecc-1392
+          grib_infinity_grid_second_order
           codes_datetime_julian
           codes_set_paths
           codes_f90_misc


### PR DESCRIPTION
Enabling grid_second_order encoding does not fail when the field to encode contains Infinite values. Instead, it never terminates.

This PR :

- adds a test to highlight the problem 
- adds a test in grib_scaling.cc to fix the issue; make the program abort when infinite (or nan) values are encountered
