### PR TITLE
Feature/mars namespace quantiles

### DIFF
--- a/definitions/mars/grib.dacl.pb.def
+++ b/definitions/mars/grib.dacl.pb.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.dacl.pb.def
+++ b/definitions/mars/grib.dacl.pb.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.dacl.pb.def
+++ b/definitions/mars/grib.dacl.pb.def
@@ -1,4 +1,10 @@
-alias   mars.step     = stepRange;
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.dacw.pb.def
+++ b/definitions/mars/grib.dacw.pb.def
@@ -1,4 +1,11 @@
-alias   mars.step     = stepRange;
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
 
+alias mars.step     = stepRange;
+
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.dacw.pb.def
+++ b/definitions/mars/grib.dacw.pb.def
@@ -4,8 +4,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.dacw.pb.def
+++ b/definitions/mars/grib.dacw.pb.def
@@ -1,10 +1,4 @@
 
 alias mars.step     = stepRange;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.eefo.pb.def
+++ b/definitions/mars/grib.eefo.pb.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.eefo.pb.def
+++ b/definitions/mars/grib.eefo.pb.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.eefo.pb.def
+++ b/definitions/mars/grib.eefo.pb.def
@@ -1,4 +1,10 @@
-alias   mars.step     = stepRange;
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.eefo.pd.def
+++ b/definitions/mars/grib.eefo.pd.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.eefo.pd.def
+++ b/definitions/mars/grib.eefo.pd.def
@@ -1,3 +1,10 @@
-alias   mars.step     = stepRange;
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+alias mars.step     = stepRange;
+
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.eefo.pd.def
+++ b/definitions/mars/grib.eefo.pd.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.eehs.cd.def
+++ b/definitions/mars/grib.eehs.cd.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- # defined in local section 19
- alias mars.quantile = quantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.eehs.cd.def
+++ b/definitions/mars/grib.eehs.cd.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  # defined in local section 19
  alias mars.quantile = quantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.eehs.cd.def
+++ b/definitions/mars/grib.eehs.cd.def
@@ -1,3 +1,10 @@
-alias   mars.step     = stepRange;
-alias   mars.quantile = quantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ # defined in local section 19
+ alias mars.quantile = quantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.efhs.cd.def
+++ b/definitions/mars/grib.efhs.cd.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  # defined in local section 19
  alias mars.quantile = quantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.efhs.cd.def
+++ b/definitions/mars/grib.efhs.cd.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- # defined in local section 19
- alias mars.quantile = quantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"}

--- a/definitions/mars/grib.efhs.cd.def
+++ b/definitions/mars/grib.efhs.cd.def
@@ -1,3 +1,10 @@
-alias   mars.step     = stepRange;
-alias   mars.quantile = quantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ # defined in local section 19
+ alias mars.quantile = quantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.efhs.cd.def
+++ b/definitions/mars/grib.efhs.cd.def
@@ -1,3 +1,3 @@
 alias mars.step     = stepRange;
 
-include "mars/mars.quantile.def"}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.enfo.pb.def
+++ b/definitions/mars/grib.enfo.pb.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.enfo.pb.def
+++ b/definitions/mars/grib.enfo.pb.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.enfo.pb.def
+++ b/definitions/mars/grib.enfo.pb.def
@@ -1,4 +1,10 @@
-alias   mars.step     = stepRange;
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.enfo.pd.def
+++ b/definitions/mars/grib.enfo.pd.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.enfo.pd.def
+++ b/definitions/mars/grib.enfo.pd.def
@@ -1,3 +1,10 @@
-alias   mars.step     = stepRange;
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+alias mars.step     = stepRange;
+
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.enfo.pd.def
+++ b/definitions/mars/grib.enfo.pd.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.mfam.pb.def
+++ b/definitions/mars/grib.mfam.pb.def
@@ -3,8 +3,14 @@ alias mars.origin = centre;
 meta    forecastperiod    g1fcperiod(P1,P2,timeRangeIndicator,indicatorOfUnitOfTimeRange) : no_copy;
 alias   mars.fcperiod = forecastperiod;
 
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}
 
 # TODO: Check why they are set in the first place
 unalias mars.step;

--- a/definitions/mars/grib.mfam.pb.def
+++ b/definitions/mars/grib.mfam.pb.def
@@ -3,13 +3,7 @@ alias mars.origin = centre;
 meta    forecastperiod    g1fcperiod(P1,P2,timeRangeIndicator,indicatorOfUnitOfTimeRange) : no_copy;
 alias   mars.fcperiod = forecastperiod;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"
 
 # TODO: Check why they are set in the first place
 unalias mars.step;

--- a/definitions/mars/grib.mfam.pb.def
+++ b/definitions/mars/grib.mfam.pb.def
@@ -6,8 +6,7 @@ alias   mars.fcperiod = forecastperiod;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.mfam.pd.def
+++ b/definitions/mars/grib.mfam.pd.def
@@ -3,8 +3,14 @@ alias mars.origin = centre;
 meta    forecastperiod    g1fcperiod(P1,P2,timeRangeIndicator,indicatorOfUnitOfTimeRange) : no_copy;
 alias   mars.fcperiod = forecastperiod;
 
-meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
-alias   mars.quantile = marsQuantile;
+if (edition == 1){
+ meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+ alias mars.quantile = marsQuantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}
 
 # TODO: Check why they are set in the first place
 unalias mars.step;

--- a/definitions/mars/grib.mfam.pd.def
+++ b/definitions/mars/grib.mfam.pd.def
@@ -3,13 +3,7 @@ alias mars.origin = centre;
 meta    forecastperiod    g1fcperiod(P1,P2,timeRangeIndicator,indicatorOfUnitOfTimeRange) : no_copy;
 alias   mars.fcperiod = forecastperiod;
 
-if (edition == 1){
- meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
- alias mars.quantile = marsQuantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"
 
 # TODO: Check why they are set in the first place
 unalias mars.step;

--- a/definitions/mars/grib.mfam.pd.def
+++ b/definitions/mars/grib.mfam.pd.def
@@ -6,8 +6,7 @@ alias   mars.fcperiod = forecastperiod;
 if (edition == 1){
  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
  alias mars.quantile = marsQuantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.wees.cd.def
+++ b/definitions/mars/grib.wees.cd.def
@@ -1,8 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- alias mars.quantile = quantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.wees.cd.def
+++ b/definitions/mars/grib.wees.cd.def
@@ -1,3 +1,9 @@
-alias   mars.step     = stepRange;
-alias   mars.quantile = quantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ alias mars.quantile = quantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/grib.wees.cd.def
+++ b/definitions/mars/grib.wees.cd.def
@@ -2,8 +2,7 @@ alias mars.step     = stepRange;
 
 if (edition == 1){
  alias mars.quantile = quantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.wehs.cd.def
+++ b/definitions/mars/grib.wehs.cd.def
@@ -1,9 +1,3 @@
 alias mars.step     = stepRange;
 
-if (edition == 1){
- # defined in local section 19
- alias mars.quantile = quantile;
-} else {
- meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
- alias mars.quantile = marsQuantile;
-}
+include "mars/mars.quantile.def"

--- a/definitions/mars/grib.wehs.cd.def
+++ b/definitions/mars/grib.wehs.cd.def
@@ -3,8 +3,7 @@ alias mars.step     = stepRange;
 if (edition == 1){
  # defined in local section 19
  alias mars.quantile = quantile;
-}
-if (edition == 2){
+} else {
  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
  alias mars.quantile = marsQuantile;
 }

--- a/definitions/mars/grib.wehs.cd.def
+++ b/definitions/mars/grib.wehs.cd.def
@@ -1,3 +1,10 @@
-alias   mars.step     = stepRange;
-alias   mars.quantile = quantile;
+alias mars.step     = stepRange;
 
+if (edition == 1){
+ # defined in local section 19
+ alias mars.quantile = quantile;
+}
+if (edition == 2){
+ meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+ alias mars.quantile = marsQuantile;
+}

--- a/definitions/mars/mars.quantile.def
+++ b/definitions/mars/mars.quantile.def
@@ -1,0 +1,18 @@
+if ((stream is "eehs" or stream is "efhs" or stream is "wees" or stream is "wehs") and (type is "cd")){
+ if (edition == 1){
+  # defined in local section 19
+  alias mars.quantile = quantile;
+ }
+ if (edition == 2){
+  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+  alias mars.quantile = marsQuantile;
+ }
+ } else { 
+if (edition == 1){
+  meta marsQuantile sprintf("%d:%d",perturbationNumber,numberOfForecastsInEnsemble);
+  alias mars.quantile = marsQuantile;
+ } else {
+  meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+  alias mars.quantile = marsQuantile;
+ }
+}

--- a/definitions/mars/mars.quantile.def
+++ b/definitions/mars/mars.quantile.def
@@ -2,8 +2,7 @@ if ((stream is "eehs" or stream is "efhs" or stream is "wees" or stream is "wehs
  if (edition == 1){
   # defined in local section 19
   alias mars.quantile = quantile;
- }
- if (edition == 2){
+ } else {
   meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
   alias mars.quantile = marsQuantile;
  }


### PR DESCRIPTION
For GRIB1 messages which include the mars.quantile keyword, the quantile is encoded using the keys perturbationNumber and numberOfForecastsInEnsemble. In GRIB2, there are specific quantile templates which should be used for this purpose. This branch is to extend the mars namespace for those cases to map mars.quantile to the keys quantileValue and totalNumberOfQuantiles. In GRIB3, the same keys are expected to be used, so the mars namespace uses an if(grib1) ... else construct.

https://jira.ecmwf.int/browse/ECC-1935