### PR TITLE
ECC-1953: leave step in mars namespace for mmsf/an data

### DIFF
--- a/definitions/mars/grib.mmsf.an.def
+++ b/definitions/mars/grib.mmsf.an.def
@@ -1,6 +1,3 @@
-#no step in type an
-unalias mars.step;
-
 if (class is "od" || class is "me" || class is "en" ||
     class is "c3" || class is "ci")
 {


### PR DESCRIPTION
Please merge this change into develop. It is needed as step must be also for type=an in the mars namespace as the mars client compares this key before archiving data.
https://jira.ecmwf.int/browse/ECC-1953