### PR TITLE
ECC-1968: GRIB2 grid_complex_spatial_differencing: Encoding with bitsPerValue=24 fails

### DIFF
--- a/src/accessor/grib_accessor_class_data_g22order_packing.cc
+++ b/src/accessor/grib_accessor_class_data_g22order_packing.cc
@@ -808,6 +808,13 @@ int grib_accessor_data_g22order_packing_t::pack_double(const double* val, size_t
 
     if ((err = grib_get_long_internal(gh, bits_per_value_, &bits_per_value)) != GRIB_SUCCESS)
         return err;
+
+    // ECC-1968: For bits_per_value > 23, the complex packing algorithm may use more than 25 bits per value.
+    // However, this exceeds the maximum number of bits for the packing algorithm.
+    if (bits_per_value > 23) {
+        bits_per_value = 23;
+    }
+
     if ((err = grib_get_long_internal(gh, decimal_scale_factor_, &decimal_scale_factor)) != GRIB_SUCCESS)
         return err;
 
@@ -1463,7 +1470,7 @@ template <typename T>
 int grib_accessor_data_g22order_packing_t::unpack(T* val, size_t* len)
 {
     static_assert(std::is_floating_point<T>::value, "Requires floating points numbers");
-    grib_handle* gh         = grib_handle_of_accessor(this);
+    grib_handle* gh = grib_handle_of_accessor(this);
 
     size_t i                  = 0;
     size_t j                  = 0;

--- a/src/action_class_when.cc
+++ b/src/action_class_when.cc
@@ -188,8 +188,8 @@ static int notify_change(grib_action* a, grib_accessor* observer, grib_accessor*
 #ifdef CHECK_LOOP
     if (self->loop) {
         printf("LOOP detected...\n");
-        printf("WHEN triggered by %s %ld\n", observed->name, lres);
-        grib_expression_print(observed->context, self->expression, 0, stderr);
+        printf("WHEN triggered by %s %ld\n", observed->name_, lres);
+        grib_expression_print(observed->context_, self->expression, 0, stderr);
         fprintf(stderr, "\n");
         return ret;
     }

--- a/tests/grib_bitmap.sh
+++ b/tests/grib_bitmap.sh
@@ -246,6 +246,12 @@ ${tools_dir}/grib_set -r -s packingType=grid_complex_spatial_differencing $temp2
 stats=`${tools_dir}/grib_get -F%.2f -p max,min,avg $temp2`
 [ "$stats" = '549.61 11.61 203.28'  ]
 
+# ECC-1968
+# ---------
+in=${data_dir}/grid_complex_spatial_differencing.grib2
+${tools_dir}/grib_set -s setBitsPerValue=25 $in $temp2
+${tools_dir}/grib_get -p bitsPerValue $temp2
+
 # Clean up for ECC-1858
 rm -f $in_with_bitmap $in_no_bitmap
 rm -f $tempSimple


### PR DESCRIPTION
https://jira.ecmwf.int/browse/ECC-1968