### PR TITLE
initial commit

### DIFF
--- a/definitions/grib2/section.1.def
+++ b/definitions/grib2/section.1.def
@@ -95,6 +95,7 @@ concept stepType {
     "sum"     = {selectStepTemplateInterval=1; stepTypeInternal="sum";}
     "severity" = {selectStepTemplateInterval=1; stepTypeInternal="severity";}
     "mode"    = {selectStepTemplateInterval=1; stepTypeInternal="mode";}
+    "index"   = {selectStepTemplateInterval=1; stepTypeInternal="index";}
 }
 
 # 0=atmospheric chemical constituents

--- a/definitions/grib2/templates/template.4.statistical.def
+++ b/definitions/grib2/templates/template.4.statistical.def
@@ -69,6 +69,7 @@ if (numberOfTimeRanges == 1 || numberOfTimeRanges == 2) {
     "sum"     = {typeOfStatisticalProcessing=11;}
     "severity" = {typeOfStatisticalProcessing=100;}
     "mode"     = {typeOfStatisticalProcessing=101;}
+    "index"    = {typeOfStatisticalProcessing=102;}
   }
   meta startStep step_in_units(forecastTime,indicatorOfUnitOfTimeRange,stepUnits,
     indicatorOfUnitForTimeRange,lengthOfTimeRange) : no_copy;


### PR DESCRIPTION
Please merge this branch to develop.

In WMO table 4.10 an entry 102, Index processing was added recently, see
https://github.com/wmo-im/GRIB2/blob/master/GRIB2_CodeFlag_4_10_CodeTable_en.csv#L19

If setting the value 102 for typeOfStatisticalProcessing, stepType is not existing and trying to get the value of this key leads to an error.
This branch extends section.1.def and template.4.statistical.def so that stepType=index if typeOfStatisticalProcessing=102.