### PR TITLE
remove the model keyword from the MARS namespace for class ml

### DIFF
--- a/definitions/grib2/local/ecmf/section4_extras.def
+++ b/definitions/grib2/local/ecmf/section4_extras.def
@@ -8,7 +8,7 @@ concept modelName(unknown, "modelNameConcept.def", conceptsDir2, conceptsLocalDi
 
 if (modelName isnot "unknown") {
    concept modelVersion(unknown, "modelVersionConcept.[modelName].def", conceptsDir2, conceptsLocalDirAll): no_copy, dump, read_only;
-   if ( defined(marsClass) && (marsClass is "ai" || marsClass is "ml") ) {
+   if ( defined(marsClass) && (marsClass is "ai") ) {
       alias ls.model = modelName;
       alias mars.model = modelName;
    }


### PR DESCRIPTION
This is needed for class ml where we do not wanrt the model keyword in the mars namespace