### PR TITLE
ECC-2042: GRIB2: add new origin ecmf_l5 for the Global Fire Information System (class=gw)

### DIFF
--- a/definitions/grib2/fireTemplate.def
+++ b/definitions/grib2/fireTemplate.def
@@ -3,6 +3,7 @@ meta originatingClass evaluate(inputProcessIdentifier/1000);
 concept originOfPostProcessing(unknown) {
  'ecmf_od' = { originatingClass =  1; inputOriginatingCentre = 98; }
  'ecmf_ea' = { originatingClass = 23; inputOriginatingCentre = 98; }
+ 'ecmf_l5' = { originatingClass = 33; inputOriginatingCentre = 98; }
 }
 
 alias mars.origin = originOfPostProcessing;


### PR DESCRIPTION
https://jira.ecmwf.int/browse/ECC-2042