### PR TITLE
ECC-2046: GRIB2: typeOfLevel for heigthAboveGroundAt 0,2,10 metres

### DIFF
--- a/definitions/grib1/typeOfLevel.def
+++ b/definitions/grib1/typeOfLevel.def
@@ -17,7 +17,12 @@
 'heightAboveSea' = {indicatorOfTypeOfLevel=103;}
 'heightAboveSeaLayer' = {indicatorOfTypeOfLevel=104;}
 'heightAboveGroundHighPrecision' = {indicatorOfTypeOfLevel=125;}
+
 'heightAboveGround' = {indicatorOfTypeOfLevel=105;}
+'heightAboveGroundAt0metres' = {indicatorOfTypeOfLevel=105;level=0;}
+'heightAboveGroundAt2metres' = {indicatorOfTypeOfLevel=105;level=2;}
+'heightAboveGroundAt10metres' = {indicatorOfTypeOfLevel=105;level=10;}
+
 'heightAboveGroundLayer' = {indicatorOfTypeOfLevel=106;}
 'sigma' = {indicatorOfTypeOfLevel=107;}
 'sigmaLayer' = {indicatorOfTypeOfLevel=108;}

--- a/definitions/grib2/typeOfLevelConcept.def
+++ b/definitions/grib2/typeOfLevelConcept.def
@@ -35,6 +35,12 @@
 'heightAboveSea'               = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;}
 'heightAboveSeaLayer'          = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=102;}
 'heightAboveGround'            = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=255;}
+'heightAboveGroundAt0metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=0;typeOfSecondFixedSurface=255;}
+'heightAboveGroundAt2metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=2; typeOfSecondFixedSurface=255;}
+'heightAboveGroundAt10metres'  = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=10; typeOfSecondFixedSurface=255;}
 'heightAboveGroundLayer'       = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=103;}
 'sigma'                        = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=255;}
 'sigmaLayer'                   = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=104;}

--- a/definitions/grib3/template.4.horizontal.def
+++ b/definitions/grib3/template.4.horizontal.def
@@ -44,6 +44,14 @@ concept vertical.typeOfLevel (unknown) {
   'heightAboveSea' = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;}
   'heightAboveSeaLayer' = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=102;}
   'heightAboveGround' = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=255;}
+
+  'heightAboveGroundAt0metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=0;typeOfSecondFixedSurface=255;}
+  'heightAboveGroundAt2metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=2; typeOfSecondFixedSurface=255;}
+  'heightAboveGroundAt10metres'  = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=10; typeOfSecondFixedSurface=255;}
+
   'heightAboveGroundLayer' = {typeOfFirstFixedSurface=103;typeOfSecondFixedSurface=103;}
   'sigma' = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=255;}
   'sigmaLayer' = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=104;}

--- a/definitions/grib3/template.component.5.0.def
+++ b/definitions/grib3/template.component.5.0.def
@@ -34,6 +34,13 @@ concept vertical.typeOfLevel (unknown) {
   'heightAboveSea' = {typeOfFirstFixedSurface=102; }
   # 'heightAboveSeaLayer' = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=102;}
   'heightAboveGround' = {typeOfFirstFixedSurface=103; }
+  'heightAboveGroundAt0metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=0;}
+  'heightAboveGroundAt2metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=2;}
+  'heightAboveGroundAt10metres'  = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=10;}
+
   # 'heightAboveGroundLayer' = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=103;}
   'sigma' = {typeOfFirstFixedSurface=104; }
   # 'sigmaLayer' = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=104;}

--- a/definitions/grib3/template.component.5.1.def
+++ b/definitions/grib3/template.component.5.1.def
@@ -46,6 +46,14 @@ concept vertical.typeOfLevel (unknown) {
   'heightAboveSea' = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;}
   'heightAboveSeaLayer' = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=102;}
   'heightAboveGround' = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=255;}
+
+  'heightAboveGroundAt0metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=0;typeOfSecondFixedSurface=255;}
+  'heightAboveGroundAt2metres'   = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=2; typeOfSecondFixedSurface=255;}
+  'heightAboveGroundAt10metres'  = {typeOfFirstFixedSurface=103; scaleFactorOfFirstFixedSurface=0;
+                                  scaledValueOfFirstFixedSurface=10; typeOfSecondFixedSurface=255;}
+
   'heightAboveGroundLayer' = {typeOfFirstFixedSurface=103;typeOfSecondFixedSurface=103;}
   'sigma' = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=255;}
   'sigmaLayer' = {typeOfFirstFixedSurface=104; typeOfSecondFixedSurface=104;}


### PR DESCRIPTION
Please merge the branch into develop. It extends the typeOfLevel concept by three additional entries for height above ground at 0, 2 1na 10 metres. This is because the typeOfLevel heigthAboveGround is associated in MARS with either levtype sfc or hl.
levtype hl are normally only height > 10 metres and heights <= 10 metres remain sfc.

See https://jira.ecmwf.int/browse/ECC-2046