### PR TITLE
Feature/grid type=lambert,edition=2

### DIFF
--- a/src/eccodes/grib_util.cc
+++ b/src/eccodes/grib_util.cc
@@ -939,7 +939,7 @@ grib_handle* grib_util_set_spec(grib_handle* h,
 {
 #define SET_LONG_VALUE(n, v)                       \
     do {                                           \
-        ECCODES_ASSERT(count < 1024);                      \
+        ECCODES_ASSERT(count < 1024);              \
         values[count].name       = n;              \
         values[count].type       = GRIB_TYPE_LONG; \
         values[count].long_value = v;              \
@@ -947,7 +947,7 @@ grib_handle* grib_util_set_spec(grib_handle* h,
     } while (0)
 #define SET_DOUBLE_VALUE(n, v)                         \
     do {                                               \
-        ECCODES_ASSERT(count < 1024);                          \
+        ECCODES_ASSERT(count < 1024);                  \
         values[count].name         = n;                \
         values[count].type         = GRIB_TYPE_DOUBLE; \
         values[count].double_value = v;                \
@@ -955,7 +955,7 @@ grib_handle* grib_util_set_spec(grib_handle* h,
     } while (0)
 #define SET_STRING_VALUE(n, v)                         \
     do {                                               \
-        ECCODES_ASSERT(count < 1024);                          \
+        ECCODES_ASSERT(count < 1024);                  \
         values[count].name         = n;                \
         values[count].type         = GRIB_TYPE_STRING; \
         values[count].string_value = v;                \
@@ -964,7 +964,7 @@ grib_handle* grib_util_set_spec(grib_handle* h,
 
 #define COPY_SPEC_LONG(x)                          \
     do {                                           \
-        ECCODES_ASSERT(count < 1024);                      \
+        ECCODES_ASSERT(count < 1024);              \
         values[count].name       = #x;             \
         values[count].type       = GRIB_TYPE_LONG; \
         values[count].long_value = spec->x;        \
@@ -972,7 +972,7 @@ grib_handle* grib_util_set_spec(grib_handle* h,
     } while (0)
 #define COPY_SPEC_DOUBLE(x)                            \
     do {                                               \
-        ECCODES_ASSERT(count < 1024);                          \
+        ECCODES_ASSERT(count < 1024);                  \
         values[count].name         = #x;               \
         values[count].type         = GRIB_TYPE_DOUBLE; \
         values[count].double_value = spec->x;          \
@@ -995,6 +995,7 @@ grib_handle* grib_util_set_spec(grib_handle* h,
     bool grib1_high_resolution_fix = false; // See GRIB-863
     bool global_grid               = false;
     int expandBoundingBox         = 0;
+    grib_util_grid_spec* nonConstSpec = const_cast<grib_util_grid_spec*>(spec);
 
     ECCODES_ASSERT(h);
 
@@ -1178,6 +1179,8 @@ grib_handle* grib_util_set_spec(grib_handle* h,
         case GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL:
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
+            // A -ve longitude passed in (could be from GRIB1). Lambert longitude in GRIB2 must be +ve
+            nonConstSpec->longitudeOfFirstGridPointInDegrees = normalise_longitude_in_degrees(spec->longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(latitudeOfFirstGridPointInDegrees);
             COPY_SPEC_LONG(Ni); // same as Nx

--- a/src/eccodes/grib_util.cc
+++ b/src/eccodes/grib_util.cc
@@ -1138,8 +1138,10 @@ grib_handle* grib_util_set_spec(grib_handle* h,
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
 
-            // A -ve longitude passed in (could be from GRIB1). Polar stereo longitude in GRIB2 must be +ve
-            nonConstSpec->longitudeOfFirstGridPointInDegrees = normalise_longitude_in_degrees(spec->longitudeOfFirstGridPointInDegrees);
+            if (editionNumber == 2) {
+                // A -ve longitude passed in (could be from GRIB1). Polar stereo longitude in GRIB2 must be +ve
+                nonConstSpec->longitudeOfFirstGridPointInDegrees = normalise_longitude_in_degrees(spec->longitudeOfFirstGridPointInDegrees);
+            }
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(latitudeOfFirstGridPointInDegrees);
             COPY_SPEC_LONG(Ni);
@@ -1181,8 +1183,11 @@ grib_handle* grib_util_set_spec(grib_handle* h,
         case GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL:
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
-            // A -ve longitude passed in (could be from GRIB1). Lambert longitude in GRIB2 must be +ve
-            nonConstSpec->longitudeOfFirstGridPointInDegrees = normalise_longitude_in_degrees(spec->longitudeOfFirstGridPointInDegrees);
+
+            if (editionNumber == 2) {
+                // A -ve longitude passed in (could be from GRIB1). Lambert longitude in GRIB2 must be +ve
+                nonConstSpec->longitudeOfFirstGridPointInDegrees = normalise_longitude_in_degrees(spec->longitudeOfFirstGridPointInDegrees);
+            }
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(latitudeOfFirstGridPointInDegrees);
             COPY_SPEC_LONG(Ni); // same as Nx

--- a/src/eccodes/grib_util.cc
+++ b/src/eccodes/grib_util.cc
@@ -1138,6 +1138,8 @@ grib_handle* grib_util_set_spec(grib_handle* h,
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
 
+            // A -ve longitude passed in (could be from GRIB1). Polar stereo longitude in GRIB2 must be +ve
+            nonConstSpec->longitudeOfFirstGridPointInDegrees = normalise_longitude_in_degrees(spec->longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(latitudeOfFirstGridPointInDegrees);
             COPY_SPEC_LONG(Ni);

--- a/tests/grib_util_set_spec2.cc
+++ b/tests/grib_util_set_spec2.cc
@@ -14,10 +14,10 @@
 static void dump_it(grib_handle* h)
 {
     int dump_flags = GRIB_DUMP_FLAG_CODED | GRIB_DUMP_FLAG_OCTET | GRIB_DUMP_FLAG_VALUES | GRIB_DUMP_FLAG_READ_ONLY;
-    grib_dump_content(h, stderr, "wmo", dump_flags, NULL);
+    grib_dump_content(h, stderr, "wmo", dump_flags, nullptr);
 }
 
-// Lambert conformal
+// Lambert conformal conic (edition=1)
 static grib_handle* test0()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
@@ -32,6 +32,7 @@ static grib_handle* test0()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
+    auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB1");
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB1");
     spec.grid_type      = GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL;
     spec.Ni             = 2;
@@ -49,7 +50,7 @@ static grib_handle* test0()
     return finalh;
 }
 
-// Lambert azimuthal
+// Lambert azimuthal equal area
 static grib_handle* test1()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
@@ -64,7 +65,7 @@ static grib_handle* test1()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
+    grib_handle* handle = grib_handle_new_from_samples(nullptr, "GRIB2");
     grib_set_long(handle, "tablesVersion", 32);
     spec.grid_type = GRIB_UTIL_GRID_SPEC_LAMBERT_AZIMUTHAL_EQUAL_AREA;
 
@@ -90,7 +91,7 @@ static grib_handle* test2()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB1");
+    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB1");
     spec.grid_type      = GRIB_UTIL_GRID_SPEC_HEALPIX;
     spec.N              = 2;
 
@@ -120,7 +121,7 @@ static grib_handle* test3()
     int set_spec_flags = 0;
     size_t outlen      = 0;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "sh_pl_grib2");
+    auto* handle        = grib_handle_new_from_samples(nullptr, "sh_pl_grib2");
     spec.grid_type      = GRIB_UTIL_GRID_SPEC_SH;
     spec.truncation     = 20;
     outlen              = 2;
@@ -152,7 +153,7 @@ static grib_handle* test4()
     int set_spec_flags = 0;
     size_t outlen      = 0;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
+    auto* handle = grib_handle_new_from_samples(nullptr, "GRIB2");
     // grib_set_long(handle, "tablesVersion", 32);
     spec.grid_type = GRIB_UTIL_GRID_SPEC_POLAR_STEREOGRAPHIC;
     outlen         = 4;
@@ -184,7 +185,7 @@ static grib_handle* test5()
     int set_spec_flags = 0;
     size_t outlen      = 0;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
+    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB2");
     spec.grid_type      = GRIB_UTIL_GRID_SPEC_REGULAR_GG;
     spec.Ni = spec.Nj = 2;
     outlen            = 4;
@@ -211,7 +212,7 @@ static grib_handle* test6()
     int set_spec_flags = 0;
     size_t outlen      = 0;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
+    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB2");
     spec.grid_type      = GRIB_UTIL_GRID_SPEC_REDUCED_LL;
     spec.Nj             = 2;
     outlen              = 4;
@@ -238,7 +239,7 @@ static grib_handle* test7()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
+    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB2");
     spec.grid_type      = GRIB_UTIL_GRID_SPEC_UNSTRUCTURED;
 
     grib_handle* finalh = grib_util_set_spec(
@@ -250,16 +251,13 @@ static grib_handle* test7()
 
 int main()
 {
-    typedef grib_handle* (*test_func)(void);
-    test_func funcs[] = { test0, test1, test2, test3, test4, test5, test6, test7 };
+    using test_func = grib_handle* (*)();
 
-    // grib_handle* (*p[8]) (void) = {test0, test1, test2, test3, test4, test5, test6, test7};
-
-    const size_t num_tests = sizeof(funcs) / sizeof(funcs[0]);
-    for (size_t i = 0; i < num_tests; i++) {
-        grib_handle* result = funcs[i]();
-        ECCODES_ASSERT(result);
+    for (auto func : { test0, test1, test2, test3, test4, test5, test6, test7 }) {
+        auto* result = func();
+        ECCODES_ASSERT(result != nullptr);
         dump_it(result);
     }
+
     return 0;
 }

--- a/tests/grib_util_set_spec2.cc
+++ b/tests/grib_util_set_spec2.cc
@@ -33,10 +33,11 @@ static grib_handle* test0()
     size_t outlen      = 4;
 
     auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB1");
-    grib_handle* handle = grib_handle_new_from_samples(0, "GRIB1");
-    spec.grid_type      = GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL;
-    spec.Ni             = 2;
-    spec.Nj             = 2;
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL;
+    spec.Ni        = 2;
+    spec.Nj        = 2;
+
+    spec.longitudeOfFirstGridPointInDegrees = -1.;
 
     // packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_GRID_SIMPLE;
     // packing_spec.bitsPerValue = 16;
@@ -50,7 +51,7 @@ static grib_handle* test0()
     return finalh;
 }
 
-// Lambert azimuthal equal area
+// Lambert conformal conic (edition=2)
 static grib_handle* test1()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
@@ -65,18 +66,26 @@ static grib_handle* test1()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
-    grib_handle* handle = grib_handle_new_from_samples(nullptr, "GRIB2");
-    grib_set_long(handle, "tablesVersion", 32);
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_LAMBERT_AZIMUTHAL_EQUAL_AREA;
+    auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB2");
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL;
+    spec.Ni        = 2;
+    spec.Nj        = 2;
 
-    grib_handle* finalh = grib_util_set_spec(
+    spec.longitudeOfFirstGridPointInDegrees = -1.;
+
+    // packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_GRID_SIMPLE;
+    // packing_spec.bitsPerValue = 16;
+    // packing_spec.accuracy = GRIB_UTIL_ACCURACY_USE_PROVIDED_BITS_PER_VALUES;
+    // packing_spec.packing  = GRIB_UTIL_PACKING_USE_PROVIDED;
+
+    grib_handle* finalh = codes_grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
         values, outlen, &err);
     ECCODES_ASSERT(err == 0);
     return finalh;
 }
 
-// HEALPix
+// Lambert azimuthal equal area
 static grib_handle* test2()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
@@ -91,9 +100,35 @@ static grib_handle* test2()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
-    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB1");
-    spec.grid_type      = GRIB_UTIL_GRID_SPEC_HEALPIX;
-    spec.N              = 2;
+    auto* handle = grib_handle_new_from_samples(nullptr, "GRIB2");
+    grib_set_long(handle, "tablesVersion", 32);
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_LAMBERT_AZIMUTHAL_EQUAL_AREA;
+
+    grib_handle* finalh = grib_util_set_spec(
+        handle, &spec, &packing_spec, set_spec_flags,
+        values, outlen, &err);
+    ECCODES_ASSERT(err == 0);
+    return finalh;
+}
+
+// HEALPix
+static grib_handle* test3()
+{
+    fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
+    int set_spec_flags = 0;
+    size_t outlen      = 4;
+
+    auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB1");
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_HEALPIX;
+    spec.N         = 2;
 
     packing_spec.packing_type  = GRIB_UTIL_PACKING_TYPE_GRID_SECOND_ORDER;
     packing_spec.packing       = GRIB_UTIL_PACKING_USE_PROVIDED;
@@ -107,7 +142,7 @@ static grib_handle* test2()
 }
 
 // Spherical harmonics
-static grib_handle* test3()
+static grib_handle* test4()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
     int err                  = 0;
@@ -121,10 +156,10 @@ static grib_handle* test3()
     int set_spec_flags = 0;
     size_t outlen      = 0;
 
-    auto* handle        = grib_handle_new_from_samples(nullptr, "sh_pl_grib2");
-    spec.grid_type      = GRIB_UTIL_GRID_SPEC_SH;
-    spec.truncation     = 20;
-    outlen              = 2;
+    auto* handle    = grib_handle_new_from_samples(nullptr, "sh_pl_grib2");
+    spec.grid_type  = GRIB_UTIL_GRID_SPEC_SH;
+    spec.truncation = 20;
+    outlen          = 2;
 
     packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_SPECTRAL_SIMPLE;
     packing_spec.bitsPerValue = 16;
@@ -139,7 +174,7 @@ static grib_handle* test3()
 }
 
 // Polar stereo
-static grib_handle* test4()
+static grib_handle* test5()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
     int err                  = 0;
@@ -171,33 +206,6 @@ static grib_handle* test4()
 }
 
 // Regular Gaussian
-static grib_handle* test5()
-{
-    fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
-    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
-    int set_spec_flags = 0;
-    size_t outlen      = 0;
-
-    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB2");
-    spec.grid_type      = GRIB_UTIL_GRID_SPEC_REGULAR_GG;
-    spec.Ni = spec.Nj = 2;
-    outlen            = 4;
-
-    grib_handle* finalh = grib_util_set_spec(
-        handle, &spec, &packing_spec, set_spec_flags,
-        values, outlen, &err);
-    ECCODES_ASSERT(err == 0);
-    return finalh;
-}
-
-// Reduced LL
 static grib_handle* test6()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
@@ -212,10 +220,37 @@ static grib_handle* test6()
     int set_spec_flags = 0;
     size_t outlen      = 0;
 
-    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB2");
-    spec.grid_type      = GRIB_UTIL_GRID_SPEC_REDUCED_LL;
-    spec.Nj             = 2;
-    outlen              = 4;
+    auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB2");
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_REGULAR_GG;
+    spec.Ni = spec.Nj = 2;
+    outlen            = 4;
+
+    grib_handle* finalh = grib_util_set_spec(
+        handle, &spec, &packing_spec, set_spec_flags,
+        values, outlen, &err);
+    ECCODES_ASSERT(err == 0);
+    return finalh;
+}
+
+// Reduced LL
+static grib_handle* test7()
+{
+    fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
+    int set_spec_flags = 0;
+    size_t outlen      = 0;
+
+    auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB2");
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_REDUCED_LL;
+    spec.Nj        = 2;
+    outlen         = 4;
 
     grib_handle* finalh = grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
@@ -225,7 +260,7 @@ static grib_handle* test6()
 }
 
 // Unstructured
-static grib_handle* test7()
+static grib_handle* test8()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
     int err                  = 0;
@@ -239,8 +274,8 @@ static grib_handle* test7()
     int set_spec_flags = 0;
     size_t outlen      = 4;
 
-    auto* handle        = grib_handle_new_from_samples(nullptr, "GRIB2");
-    spec.grid_type      = GRIB_UTIL_GRID_SPEC_UNSTRUCTURED;
+    auto* handle   = grib_handle_new_from_samples(nullptr, "GRIB2");
+    spec.grid_type = GRIB_UTIL_GRID_SPEC_UNSTRUCTURED;
 
     grib_handle* finalh = grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
@@ -253,7 +288,7 @@ int main()
 {
     using test_func = grib_handle* (*)();
 
-    for (auto func : { test0, test1, test2, test3, test4, test5, test6, test7 }) {
+    for (auto func : { test0, test1, test2, test3, test4, test5, test6, test7, test8 }) {
         auto* result = func();
         ECCODES_ASSERT(result != nullptr);
         dump_it(result);

--- a/tests/grib_util_set_spec2.cc
+++ b/tests/grib_util_set_spec2.cc
@@ -13,8 +13,7 @@
 
 static void dump_it(grib_handle* h)
 {
-    int dump_flags = GRIB_DUMP_FLAG_CODED | GRIB_DUMP_FLAG_OCTET | GRIB_DUMP_FLAG_VALUES | GRIB_DUMP_FLAG_READ_ONLY;
-    grib_dump_content(h, stderr, "wmo", dump_flags, nullptr);
+    grib_dump_content(h, stderr, "wmo", 0, nullptr);
 }
 
 // Lambert conformal conic (edition=1)
@@ -63,6 +62,8 @@ static grib_handle* test1()
     spec.Ni        = 2;
     spec.Nj        = 2;
 
+    // Note: For Lambert: In GRIB1 the longitude can be -ve but not in GRIB2.
+    // So codes_grib_util_set_spec should cater for this case
     spec.longitudeOfFirstGridPointInDegrees = -1.;
 
     // packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_GRID_SIMPLE;
@@ -168,6 +169,7 @@ static grib_handle* test5()
     // grib_set_long(handle, "tablesVersion", 32);
     spec.grid_type = GRIB_UTIL_GRID_SPEC_POLAR_STEREOGRAPHIC;
     outlen         = 4;
+    spec.longitudeOfFirstGridPointInDegrees = -1.;
 
     packing_spec.extra_settings_count         = 1;
     packing_spec.extra_settings[0].type       = GRIB_TYPE_LONG;
@@ -250,8 +252,7 @@ static grib_handle* test8()
 
 int main()
 {
-    using test_func = grib_handle* (*)();
-
+    //using test_func = grib_handle* (*)();
     for (auto func : { test0, test1, test2, test3, test4, test5, test6, test7, test8 }) {
         auto* result = func();
         ECCODES_ASSERT(result != nullptr);

--- a/tests/grib_util_set_spec2.cc
+++ b/tests/grib_util_set_spec2.cc
@@ -21,17 +21,21 @@ static void dump_it(grib_handle* h)
 static grib_handle* test0()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 4;
+    size_t outlen      = 4;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB1");
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL;
-    spec.Ni = 2;
-    spec.Nj = 2;
+    spec.grid_type      = GRIB_UTIL_GRID_SPEC_LAMBERT_CONFORMAL;
+    spec.Ni             = 2;
+    spec.Nj             = 2;
 
     // packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_GRID_SIMPLE;
     // packing_spec.bitsPerValue = 16;
@@ -49,12 +53,16 @@ static grib_handle* test0()
 static grib_handle* test1()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 4;
+    size_t outlen      = 4;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
     grib_set_long(handle, "tablesVersion", 32);
@@ -71,19 +79,23 @@ static grib_handle* test1()
 static grib_handle* test2()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 4;
+    size_t outlen      = 4;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB1");
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_HEALPIX;
-    spec.N = 2;
+    spec.grid_type      = GRIB_UTIL_GRID_SPEC_HEALPIX;
+    spec.N              = 2;
 
-    packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_GRID_SECOND_ORDER;
-    packing_spec.packing  = GRIB_UTIL_PACKING_USE_PROVIDED;
+    packing_spec.packing_type  = GRIB_UTIL_PACKING_TYPE_GRID_SECOND_ORDER;
+    packing_spec.packing       = GRIB_UTIL_PACKING_USE_PROVIDED;
     packing_spec.editionNumber = 2;
 
     grib_handle* finalh = grib_util_set_spec(
@@ -97,22 +109,26 @@ static grib_handle* test2()
 static grib_handle* test3()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2 };
     int set_spec_flags = 0;
-    size_t outlen = 0;
+    size_t outlen      = 0;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "sh_pl_grib2");
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_SH;
-    spec.truncation = 20;
-    outlen = 2;
+    spec.grid_type      = GRIB_UTIL_GRID_SPEC_SH;
+    spec.truncation     = 20;
+    outlen              = 2;
 
     packing_spec.packing_type = GRIB_UTIL_PACKING_TYPE_SPECTRAL_SIMPLE;
     packing_spec.bitsPerValue = 16;
-    packing_spec.accuracy = GRIB_UTIL_ACCURACY_USE_PROVIDED_BITS_PER_VALUES;
-    packing_spec.packing  = GRIB_UTIL_PACKING_USE_PROVIDED;
+    packing_spec.accuracy     = GRIB_UTIL_ACCURACY_USE_PROVIDED_BITS_PER_VALUES;
+    packing_spec.packing      = GRIB_UTIL_PACKING_USE_PROVIDED;
 
     grib_handle* finalh = grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
@@ -125,21 +141,25 @@ static grib_handle* test3()
 static grib_handle* test4()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 0;
+    size_t outlen      = 0;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
-    //grib_set_long(handle, "tablesVersion", 32);
+    // grib_set_long(handle, "tablesVersion", 32);
     spec.grid_type = GRIB_UTIL_GRID_SPEC_POLAR_STEREOGRAPHIC;
-    outlen = 4;
+    outlen         = 4;
 
-    packing_spec.extra_settings_count = 1;
-    packing_spec.extra_settings[0].type = GRIB_TYPE_LONG;
-    packing_spec.extra_settings[0].name = "tablesVersion";
+    packing_spec.extra_settings_count         = 1;
+    packing_spec.extra_settings[0].type       = GRIB_TYPE_LONG;
+    packing_spec.extra_settings[0].name       = "tablesVersion";
     packing_spec.extra_settings[0].long_value = 32;
 
     grib_handle* finalh = grib_util_set_spec(
@@ -153,17 +173,21 @@ static grib_handle* test4()
 static grib_handle* test5()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 0;
+    size_t outlen      = 0;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_REGULAR_GG;
+    spec.grid_type      = GRIB_UTIL_GRID_SPEC_REGULAR_GG;
     spec.Ni = spec.Nj = 2;
-    outlen = 4;
+    outlen            = 4;
 
     grib_handle* finalh = grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
@@ -176,17 +200,21 @@ static grib_handle* test5()
 static grib_handle* test6()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 0;
+    size_t outlen      = 0;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_REDUCED_LL;
-    spec.Nj = 2;
-    outlen = 4;
+    spec.grid_type      = GRIB_UTIL_GRID_SPEC_REDUCED_LL;
+    spec.Nj             = 2;
+    outlen              = 4;
 
     grib_handle* finalh = grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
@@ -199,15 +227,19 @@ static grib_handle* test6()
 static grib_handle* test7()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err = 0;
-    grib_util_grid_spec spec = {0,};
-    grib_util_packing_spec packing_spec = {0,};
-    double values[4] = {1.1, 2.2, 3.3, 0.4};
+    int err                  = 0;
+    grib_util_grid_spec spec = {
+        0,
+    };
+    grib_util_packing_spec packing_spec = {
+        0,
+    };
+    double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
-    size_t outlen = 4;
+    size_t outlen      = 4;
 
     grib_handle* handle = grib_handle_new_from_samples(0, "GRIB2");
-    spec.grid_type = GRIB_UTIL_GRID_SPEC_UNSTRUCTURED;
+    spec.grid_type      = GRIB_UTIL_GRID_SPEC_UNSTRUCTURED;
 
     grib_handle* finalh = grib_util_set_spec(
         handle, &spec, &packing_spec, set_spec_flags,
@@ -219,11 +251,11 @@ static grib_handle* test7()
 int main()
 {
     typedef grib_handle* (*test_func)(void);
-    test_func funcs[] = {test0, test1, test2, test3, test4, test5, test6, test7};
+    test_func funcs[] = { test0, test1, test2, test3, test4, test5, test6, test7 };
 
-    //grib_handle* (*p[8]) (void) = {test0, test1, test2, test3, test4, test5, test6, test7};
+    // grib_handle* (*p[8]) (void) = {test0, test1, test2, test3, test4, test5, test6, test7};
 
-    const size_t num_tests = sizeof(funcs)/sizeof(funcs[0]);
+    const size_t num_tests = sizeof(funcs) / sizeof(funcs[0]);
     for (size_t i = 0; i < num_tests; i++) {
         grib_handle* result = funcs[i]();
         ECCODES_ASSERT(result);

--- a/tests/grib_util_set_spec2.cc
+++ b/tests/grib_util_set_spec2.cc
@@ -21,13 +21,9 @@ static void dump_it(grib_handle* h)
 static grib_handle* test0()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 4;
@@ -55,13 +51,9 @@ static grib_handle* test0()
 static grib_handle* test1()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 4;
@@ -89,13 +81,9 @@ static grib_handle* test1()
 static grib_handle* test2()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 4;
@@ -115,13 +103,9 @@ static grib_handle* test2()
 static grib_handle* test3()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 4;
@@ -145,13 +129,9 @@ static grib_handle* test3()
 static grib_handle* test4()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2 };
     int set_spec_flags = 0;
     size_t outlen      = 0;
@@ -177,13 +157,9 @@ static grib_handle* test4()
 static grib_handle* test5()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 0;
@@ -209,13 +185,9 @@ static grib_handle* test5()
 static grib_handle* test6()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 0;
@@ -236,13 +208,9 @@ static grib_handle* test6()
 static grib_handle* test7()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 0;
@@ -263,13 +231,9 @@ static grib_handle* test7()
 static grib_handle* test8()
 {
     fprintf(stderr, "Doing test %s\n-----------------\n", __func__);
-    int err                  = 0;
-    grib_util_grid_spec spec = {
-        0,
-    };
-    grib_util_packing_spec packing_spec = {
-        0,
-    };
+    int err = 0;
+    grib_util_grid_spec spec = {0,};
+    grib_util_packing_spec packing_spec = {0,};
     double values[4]   = { 1.1, 2.2, 3.3, 0.4 };
     int set_spec_flags = 0;
     size_t outlen      = 4;


### PR DESCRIPTION
I'm trying to encode a lambert conformal conic grid (gridType=lambert) in eccodes, and generally, I can without an issue for GRIB edition=1.
 
But it seems to fail for GRIB edition=2, on the account that I'm trying to encode a negative value for longitudeOfFirstGridPoint (and likely, for the last grid point too). Note that this has always worked before, for grids other than gridType=lambert (regular_ll, reduced_gg, the classics). 
 
Internally, it looks like so:
 
mars - DEBUG  - 20250312.115307 - ###################################################################################
mars - DEBUG  - 20250312.115307 - Save[packing=simple,output=GribMemoryOutput[]]
mars - DEBUG  - 20250312.115307 - ###################################################################################
mars - DEBUG  - 20250312.115307 - RegularGrid::validate checked 950,000 values, iterator counts 950,000 (Domain[north=37.8659,west=-8.354,south=16.5435,east=19.4922,isGlobal=0]).
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.grid_type = 11
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.Ni = 1000
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.Nj = 950
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.iDirectionIncrementInDegrees = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.jDirectionIncrementInDegrees = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.longitudeOfFirstGridPointInDegrees = -8.354
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.longitudeOfLastGridPointInDegrees = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.latitudeOfFirstGridPointInDegrees = 37.333
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.latitudeOfLastGridPointInDegrees = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.uvRelativeToGrid = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.latitudeOfSouthernPoleInDegrees = -90
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.longitudeOfSouthernPoleInDegrees = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.iScansNegatively = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.jScansPositively = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.N = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.bitmapPresent = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.missingValue = -1.79769313486e+308
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.pl_size = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.truncation = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.orientationOfTheGridInDegrees = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.DyInMetres = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.grid.DxInMetres = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.packing_type = 5
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.packing = 1
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.boustrophedonic = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.editionNumber = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.accuracy = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.bitsPerValue = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.decimalScaleFactor = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.computeLaplacianOperator = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.truncateLaplacian = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.laplacianOperator = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.deleteLocalDefinition = 0
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings_count = 5
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].name = DxInMetres
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].double_value = 2500
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].name = DyInMetres
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].double_value = 2500
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].name = Latin1InDegrees
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].double_value = 45.8
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].name = Latin2InDegrees
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].double_value = 45.8
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].name = LoVInDegrees
mars - DEBUG  - 20250312.115307 -   GRIB encoding: info.packing.extra_settings[j].double_value = 2
mars - ERROR  - 20250312.115307 - Key "longitudeOfFirstGridPoint": Trying to encode a negative value of -8354000 for key of type unsigned [ecCodes]
mars - ERROR  - 20250312.115307 - Unable to set longitudeOfFirstGridPoint=-8354000 as long (Encoding invalid) [ecCodes]
mars - ERROR  - 20250312.115307 - Accessor longitudeOfFirstGridPointInDegrees: cannot pack value for longitudeOfFirstGridPoint (Encoding invalid)
[ecCodes]
mars - ERROR  - 20250312.115307 - Key "longitudeOfFirstGridPoint": Trying to encode a negative value of -8354000 for key of type unsigned [ecCodes]
mars - ERROR  - 20250312.115307 - Unable to set longitudeOfFirstGridPoint=-8354000 as long (Encoding invalid) [ecCodes]
mars - ERROR  - 20250312.115307 - Accessor longitudeOfFirstGridPointInDegrees: cannot pack value for longitudeOfFirstGridPoint (Encoding invalid)
[ecCodes]
mars - ERROR  - 20250312.115307 - grib_set_values[3] longitudeOfFirstGridPointInDegrees (type=double) failed: Encoding invalid (message 1) [ecCodes]
grib_util_set_spec: Cannot set key values: Encoding invalid
longitudeOfFirstGridPointInDegrees Encoding invalid