### PR TITLE
stratosphere and troposphere added to typeOfLevel

### DIFF
--- a/definitions/grib2/typeOfLevelConcept.def
+++ b/definitions/grib2/typeOfLevelConcept.def
@@ -10,6 +10,9 @@
 }
 'surface' = {typeOfFirstFixedSurface=1; typeOfSecondFixedSurface=255;}
 
+'troposphere' = {typeOfFirstFixedSurface=1; scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+    typeOfSecondFixedSurface=7; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+
 'entireAtmosphere' = {
     typeOfFirstFixedSurface=1;  scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
     typeOfSecondFixedSurface=8; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();
@@ -40,6 +43,9 @@
     typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();
 }
 'tropopause' = {typeOfFirstFixedSurface=7;   typeOfSecondFixedSurface=255;}
+
+'stratosphere' = {typeOfFirstFixedSurface=7; scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+    typeOfSecondFixedSurface=36; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 
 'nominalTop' = {
     typeOfFirstFixedSurface=8;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();


### PR DESCRIPTION
This PR is related to JIRA ECC-2048 in which new stratospheric and tropospheric parameters are requested.
The branch adds two new typeOfLevel entries for stratosphere and troposphere.
Please merge it into develop.