### PR TITLE
Py wheel: explicit dependency order

### DIFF
--- a/python_wrapper/buildconfig
+++ b/python_wrapper/buildconfig
@@ -20,8 +20,10 @@ CMAKE_PARAMS4="-DENABLE_ECCODES_THREADS=1 -DENABLE_MEMFS=1"
 CMAKE_PARAMS="$CMAKE_PARAMS1 $CMAKE_PARAMS2 $CMAKE_PARAMS3 $CMAKE_PARAMS4"
 
 PYPROJECT_DIR="python_wrapper"
-# TODO add eckit once the dependency is in place
 # NOTE fckit is present because it bundles intel fortran libs in, which eccodes fortran also needs. There is no code
 # dependency. We could have instead bundled fortran libs in here as well, but that would result in bloated wheels and
 # perhaps conflicts -- thus we opt for a hack (temporary anyway as eventually fortran will fade out)
-DEPENDENCIES='["fckitlib"]'
+# NOTE we have eckit dependency here already, but it's not actually used during compilation -- the reason is that
+# the dependency resolution during install cannot well resolve transitive dependencies yet, and fckit does depend on
+# eckit
+DEPENDENCIES='["eckitlib", "fckitlib"]'


### PR DESCRIPTION
Adding eckit as a wheel dependency, to overcome dependency resolution issues

Note this does *not* add code dependency for eccodes on eckit