### PR TITLE
Allow Jasper encode/decode to run in parallel

### DIFF
--- a/src/eccodes/grib_jasper_encoding.cc
+++ b/src/eccodes/grib_jasper_encoding.cc
@@ -20,21 +20,56 @@
 #include "jasper/jasper.h"
 #define MAXOPTSSIZE 1024
 
+// The number of active jasper initialisation actions which have not been cleaned up
+static int ecc_jasper_active_inits = 0;
+
+#if GRIB_PTHREADS
+static pthread_once_t once    = PTHREAD_ONCE_INIT;
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static void init()
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&mutex, &attr);
+    pthread_mutexattr_destroy(&attr);
+}
+#elif GRIB_OMP_THREADS
+static int once = 0;
+static omp_nest_lock_t mutex;
+static void init()
+{
+    GRIB_OMP_CRITICAL(lock_grib_jasper_c)
+    {
+        if (once == 0) {
+            omp_init_nest_lock(&mutex);
+            once = 1;
+        }
+    }
+}
+#endif
+
+
 static int ecc_jasper_initialise()
 {
 #if JASPER_VERSION_MAJOR >= 3
     int jaserr = 0;
-    jas_conf_clear();
-    jas_conf_set_max_mem_usage(jas_get_total_mem_size());
-
-    #if defined GRIB_PTHREADS || defined GRIB_OMP_THREADS
+    if (ecc_jasper_active_inits == 0) {
+        jas_conf_clear();
+        jas_conf_set_max_mem_usage(jas_get_total_mem_size());
+ 
+        #if defined GRIB_PTHREADS || defined GRIB_OMP_THREADS
         jas_conf_set_multithread(1);
-    #endif
-
-    jaserr = jas_init_library();
-    if (jaserr) return jaserr;
+        #endif
+        jaserr = jas_init_library();
+        if (jaserr) return jaserr;
+        // Jasper library has been init, so add to the count
+        ecc_jasper_active_inits += 1;
+    }
     jaserr = jas_init_thread();
     if (jaserr) return jaserr;
+    // Jasper thread has been init, so add to the count
+    ecc_jasper_active_inits += 1;
 #endif
     return 0;
 }
@@ -63,7 +98,13 @@ static void ecc_jasper_cleanup()
 {
 #if JASPER_VERSION_MAJOR >= 3
     jas_cleanup_thread();
-    jas_cleanup_library();
+    // Cleaned up a thread, so remove from the count
+    ecc_jasper_active_inits -= 1;
+    if (ecc_jasper_active_inits == 1) {
+        jas_cleanup_library();
+        // Library has been cleaned up, so remove from the count
+        ecc_jasper_active_inits -= 1;
+    }
 #endif
 }
 
@@ -78,7 +119,10 @@ int grib_jasper_decode(grib_context* c, unsigned char* buf, const size_t* buflen
     int i, j, k;
     int jaserr = 0; /* 0 means success */
 
+    GRIB_MUTEX_INIT_ONCE(&once, &init);
+    GRIB_MUTEX_LOCK(&mutex);
     jaserr = ecc_jasper_initialise();
+    GRIB_MUTEX_UNLOCK(&mutex);
     if (jaserr) {
         grib_context_log(c, GRIB_LOG_ERROR, "grib_jasper_decode: Failed to initialize JasPer library. JasPer error %d", jaserr);
         code = GRIB_DECODING_ERROR;
@@ -135,7 +179,10 @@ cleanup:
         jas_image_destroy(image);
     if (jpeg)
         jas_stream_close(jpeg);
+    GRIB_MUTEX_INIT_ONCE(&once, &init);
+    GRIB_MUTEX_LOCK(&mutex);
     ecc_jasper_cleanup();
+    GRIB_MUTEX_UNLOCK(&mutex);
 
     return code;
 }
@@ -215,7 +262,15 @@ int grib_jasper_encode(grib_context* c, j2k_encode_helper* helper)
         }
     }
 
-    ecc_jasper_initialise();
+    GRIB_MUTEX_INIT_ONCE(&once, &init);
+    GRIB_MUTEX_LOCK(&mutex);
+    jaserr = ecc_jasper_initialise();
+    GRIB_MUTEX_UNLOCK(&mutex);
+    if (jaserr) {
+        grib_context_log(c, GRIB_LOG_ERROR, "grib_jasper_encode: Failed to initialize JasPer library. JasPer error %d", jaserr);
+        code = GRIB_ENCODING_ERROR;
+        goto cleanup;
+    }
 
     opts[0] = 0;
 
@@ -269,7 +324,10 @@ cleanup:
         jas_stream_close(istream);
     if (jpcstream)
         jas_stream_close(jpcstream);
+    GRIB_MUTEX_INIT_ONCE(&once, &init);
+    GRIB_MUTEX_LOCK(&mutex);
     ecc_jasper_cleanup();
+    GRIB_MUTEX_UNLOCK(&mutex);
     return code;
 }
 

--- a/tests/grib_encode_pthreads2.sh
+++ b/tests/grib_encode_pthreads2.sh
@@ -71,8 +71,7 @@ GRIB2_INPUTS="
   ${data_dir}/test_file.grib2
   ${data_dir}/sample.grib2"
 
-# There is a problem with multi-threading and Jasper versions > 2
-if [ $HAVE_JPEG -eq 1 -a $HAVE_LIBJASPER -eq 0 ]; then
+if [ $HAVE_JPEG -eq 1 ]; then
     echo "Adding extra files (HAVE_JPEG=1)"
     GRIB2_INPUTS="${data_dir}/jpeg.grib2 ${data_dir}/reduced_gaussian_surface_jpeg.grib2 "$GRIB2_INPUTS
 fi


### PR DESCRIPTION
This MR relates to SID-110476 in the ECMWF Jira.

A couple of years ago it looks like ECMWF discovered that parallel JPEG encode using Jasper didn't work - 
https://github.com/ecmwf/eccodes/commit/a950ca130cf1d122e2685c1057bc5b67d088d0bd

However, there was a way to make it thread safe, as it was only the initialisation and cleanup that had issues - or perhaps Jasper has improved since then. I do not have a way to test with old versions of Jasper to confirm, but I would also be surprised if someone is using the HEAD of eccodes and very old versions of Jasper.

I personally used the little program below for testing, but then noticed today that there was a test built into eccodes that should handle it too.

```c
#include <omp.h>
#include <stdio.h>
#include <stdlib.h>

#include "eccodes.h"

int main(int argc, char** argv)
{
    int i;
    size_t len = 0;

    const char* sample_filename = "gg_sfc_grib2";
    codes_handle *h = NULL;
    codes_handle *h1 = NULL;
    codes_handle *h2 = NULL;
    codes_handle *h3 = NULL;
    codes_handle *h4 = NULL;

    /* create new handle from message in sample file */
    h = codes_grib_handle_new_from_samples(0, sample_filename);
    if (h == NULL) {
        printf("Error: unable to create handle from sample file %s\n", sample_filename);
        exit(1);
    }

    // Create 4 clones of the original GRIB handle
    h1 = codes_handle_clone(h);
    h2 = codes_handle_clone(h);
    h3 = codes_handle_clone(h);
    h4 = codes_handle_clone(h);

    printf("DEBUG: L%d in file '%s'\n", __LINE__, __FILE__);
    codes_set_string(h1, "packingType", "grid_jpeg", &len);
    printf("DEBUG: L%d in file '%s'\n", __LINE__, __FILE__);
    #pragma omp parallel for private(i)
    for (i=1; i<4; ++i) {
    printf("DEBUG: L%d in file '%s' for thread %d\n", __LINE__, __FILE__, omp_get_thread_num());
        switch (i) {
            case 0:
                codes_set_string(h1, "packingType", "grid_jpeg", &len);
                break;
            case 1:
                codes_set_string(h2, "packingType", "grid_jpeg", &len);
                break;
            case 2:
                codes_set_string(h3, "packingType", "grid_jpeg", &len);
                break;
            case 3:
                codes_set_string(h4, "packingType", "grid_jpeg", &len);
                break;
            default:
                break;
        }
    }

    return 0;
}
```

Compiled with `icc -qopenmp -I$CONDA_PREFIX/include -L$CONDA_PREFIX/lib -Wl,-rpath=$CONDA_PREFIX/lib -l eccodes main.c  && ./a.out` or ` gcc -fopenmp -I$CONDA_PREFIX/include -L$CONDA_PREFIX/lib -Wl,-rpath=$CONDA_PREFIX/lib -l eccodes main.c  && ./a.out`.

With no changes to eccodes, the outputs are

```
DEBUG: L40 in file 'main.c'
DEBUG: L42 in file 'main.c'
DEBUG: L45 in file 'main.c' for thread 2
DEBUG: L45 in file 'main.c' for thread 0
DEBUG: L45 in file 'main.c' for thread 1
a.out: /home/conda/feedstock_root/build_artifacts/jasper_1743025794692/work/src/libjasper/base/jas_init.c:505: jas_init_library: Assertion `!jas_global.initialized' failed.
Aborted (core dumped)
```

After my patch, the outputs were (with some debug prints in eccodes added to track the movement). First with eccodes built using OMP instead of pthreads. From the below around the library init and library cleanup lines, you can see they are called when there are no active threads. As the active thread count is only incremented and decremented when in a lock, it should be safe.

```
DEBUG: L40 in file 'main.c'
In ecc_jasper_init, outisde if block at line 55 and active threads 0
In ecc_jasper_init, doing the library at line 63 and active threads 0
In ecc_jasper_cleanup, outside if at line 98 and active threads 1
In ecc_jasper_cleanup, doing lib cleanup at line 101 with active threads 0
DEBUG: L42 in file 'main.c'
DEBUG: L45 in file 'main.c' for thread 0
DEBUG: L45 in file 'main.c' for thread 1
DEBUG: L45 in file 'main.c' for thread 2
In ecc_jasper_init, outisde if block at line 55 and active threads 0
In ecc_jasper_init, doing the library at line 63 and active threads 0
In ecc_jasper_init, outisde if block at line 55 and active threads 1
In ecc_jasper_init, outisde if block at line 55 and active threads 2
In ecc_jasper_cleanup, outside if at line 98 and active threads 3
In ecc_jasper_cleanup, outside if at line 98 and active threads 2
In ecc_jasper_cleanup, outside if at line 98 and active threads 1
In ecc_jasper_cleanup, doing lib cleanup at line 101 with active threads 0
```

As an extra test, using a patched build of pthreads eccodes instead of an OMP threads build, we get this output:

```
DEBUG: L40 in file 'main.c'
In ecc_jasper_init, outisde if block at line 55 and active threads 0
In ecc_jasper_init, doing the library at line 63 and active threads 0
In ecc_jasper_cleanup, outside if at line 98 and active threads 1
In ecc_jasper_cleanup, doing lib cleanup at line 101 with active threads 0
DEBUG: L42 in file 'main.c'
DEBUG: L45 in file 'main.c' for thread 1
DEBUG: L45 in file 'main.c' for thread 2
DEBUG: L45 in file 'main.c' for thread 0
In ecc_jasper_init, outisde if block at line 55 and active threads 0
In ecc_jasper_init, doing the library at line 63 and active threads 0
In ecc_jasper_init, outisde if block at line 55 and active threads 1
In ecc_jasper_init, outisde if block at line 55 and active threads 2
In ecc_jasper_cleanup, outside if at line 98 and active threads 3
In ecc_jasper_cleanup, outside if at line 98 and active threads 2
In ecc_jasper_cleanup, outside if at line 98 and active threads 1
In ecc_jasper_cleanup, doing lib cleanup at line 101 with active threads 0
```