### PR TITLE
DGOV-566: Add aifs-single-mse-v1.1 to model version

### DIFF
--- a/definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-single-mse.def
+++ b/definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-single-mse.def
@@ -1,3 +1,5 @@
 'v0.2.0' = { generatingProcessIdentifier = 1; }
 'v0.2.1' = { generatingProcessIdentifier = 2; }
 'v1.0' = { generatingProcessIdentifier = 3; }
+'v1.1' = { generatingProcessIdentifier = 4; }
+'v2.0' = { generatingProcessIdentifier = 5; }

--- a/definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-single.def
+++ b/definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-single.def
@@ -2,3 +2,4 @@
 'aifs-single-mse-v0.2.1' = { generatingProcessIdentifier = 2; }
 'aifs-single-mse-v1.0' = { generatingProcessIdentifier = 3; }
 'aifs-single-mse-v1.1' = { generatingProcessIdentifier = 4; }
+'aifs-single-mse-v2.0' = { generatingProcessIdentifier = 5; }


### PR DESCRIPTION
Please merge feature/AIFS-version into develop. In only contains an addition to definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-single.def
for the version of the next AIFS single release, see DGOV-566 ( https://jira.ecmwf.int/browse/DGOV-566 )
