### PR TITLE
Fix memory leak issue when reset file in multi support mode

### DIFF
--- a/src/eccodes/grib_handle.cc
+++ b/src/eccodes/grib_handle.cc
@@ -1815,10 +1815,23 @@ void grib_multi_support_reset_file(grib_context* c, FILE* f)
 {
     if (!c) c = grib_context_get_default();
     grib_multi_support* gm = c->multi_support;
+    grib_multi_support* prev = NULL;
     while (gm) {
         if (gm->file == f) {
             gm->file = NULL;
+            if (gm->message)
+                grib_context_free(c, gm->message);
+            grib_multi_support* old_gm = gm;
+            gm = gm->next;
+            if (prev) {
+                prev->next = gm;
+            } else {
+                c->multi_support = gm;
+            }
+            grib_context_free(c, old_gm);
+            continue;
         }
+        prev = gm;
         gm = gm->next;
     }
 }


### PR DESCRIPTION
### Description
In multi support, when reset file will only set file point as NULL, but not release the memory allocated to message.
This pr will release the message and gm memory and rebuild gm link array on grib context.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 