### PR TITLE
Systematic use of code numbers and is_one_of were applicable in times…

### DIFF
--- a/definitions/grib2/localConcepts/ecmf/timespanConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/timespanConcept.def
@@ -1,27 +1,39 @@
 ## Statistical window concept for ECMWF
 # either instantaneous data or processing is specified by mars stream
+###############
+# 1043 | mnth #
+# 1092 | swmm #
+# 1122 | eefo #
+# 1221 | msmm #
+# 1224 | mmsa #
+# 1257 | sttd #
+# 1258 | stte #
+###############
 # this is for one loop grib2 data
-'none'  = {stream=1092; numberOfTimeRanges=1;}
-'none'  = {stream=1043; numberOfTimeRanges=1;}
-'none'  = {stream=1224; numberOfTimeRanges=1;}
-'none'  = {stream=1221; numberOfTimeRanges=1;}
-'none'  = {stream=1257; numberOfTimeRanges=1; indicatorOfUnitForTimeRange=1;}
-'none'  = {stream=1257; numberOfTimeRanges=1; indicatorOfUnitForTimeRange=2;}
-'none'  = {stream=1257; numberOfTimeRanges=1; indicatorOfUnitForTimeRange=3;}
-'none'  = {stream=1258; numberOfTimeRanges=1; indicatorOfUnitForTimeRange=1;}
-'none'  = {stream=1258; numberOfTimeRanges=1; indicatorOfUnitForTimeRange=2;}
-'none'  = {stream=1258; numberOfTimeRanges=1; indicatorOfUnitForTimeRange=3;}
-# special rules for weekly extended-range (sub-seasonal) products
-'none'  = {marsStream=1122; type='fcmax';   numberOfTimeRanges=1;}
-'none'  = {marsStream=1122; type='fcmin';   numberOfTimeRanges=1;}
-'none'  = {marsStream=1122; type='fcmean';  numberOfTimeRanges=1;}
-'none'  = {marsStream=1122; type='fcstdev'; numberOfTimeRanges=1;}
-'none'  = {marsStream=1122; type='taem';    numberOfTimeRanges=1;}
-'none'  = {marsStream=1122; type='taes';    numberOfTimeRanges=1;}
+'none'  = {stream=1092; numberOfTimeRanges=1; true=is_one_of(indicatorOfUnitForTimeRange,1,2,3);}
+'none'  = {stream=1043; numberOfTimeRanges=1; true=is_one_of(indicatorOfUnitForTimeRange,1,2,3);}
+'none'  = {stream=1224; numberOfTimeRanges=1; true=is_one_of(indicatorOfUnitForTimeRange,1,2,3);}
+'none'  = {stream=1221; numberOfTimeRanges=1; true=is_one_of(indicatorOfUnitForTimeRange,1,2,3);}
+'none'  = {stream=1257; numberOfTimeRanges=1; true=is_one_of(indicatorOfUnitForTimeRange,1,2,3);}
+'none'  = {stream=1258; numberOfTimeRanges=1; true=is_one_of(indicatorOfUnitForTimeRange,1,2,3);}
+# special rules for weekly extended-range (sub-seasonal) products, types
+################
+# 47 | taem    #
+# 48 | taes    #
+# 80 | fcmean  #
+# 81 | fcmax   #
+# 82 | fcmin   #
+# 83 | fcstdev #
+################
+#'none'  = {marsStream=1122; numberOfTimeRanges=1; true=is_one_of(marsType,47,48,80,81,82,83);}
+'none'  = {marsStream=1122; numberOfTimeRanges=1; true=is_one_of(type,'fcmean','fcmax','fcmin','fcstdev','taem','taes');}
 ## accumulations
 # 24 hourly time unit
 '24h'  = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=24; class=1; stream=1035; type=30;}
 # special rule for accumulations in streams efhs / eehs, type cd
+###########
+# 32 | cd #
+###########
 '24h'  = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=24;  class=1; stream=1040; type=32;}
 '72h'  = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=72;  class=1; stream=1040; type=32;}
 '120h' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=120; class=1; stream=1040; type=32;}
@@ -30,6 +42,6 @@
 '240h' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=240; class=1; stream=1040; type=32;}
 '360h' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=360; class=1; stream=1040; type=32;}
 ## 7 days rolling accumulation
-'7 days' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=168; type=32;}
+'7 days' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange=168; marsType=32;}
  ## 7 days rolling accumulation
- '7 days' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 168; type='cd';}
+'7 days' = {typeOfStatisticalProcessing=1; indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 168; marsType=32;}

--- a/definitions/grib2/timespanConcept.def
+++ b/definitions/grib2/timespanConcept.def
@@ -91,12 +91,8 @@
  # hourly rolling accumulations and we don't want to have the first in a different bucket
  ## since start accumulation must have forecastTime=0
  # specific rules are in the centre's own definitions
- # hourly
- 'fromstart'    = {typeOfStatisticalProcessing=1; forecastTime=0; indicatorOfUnitForTimeRange=1;}
- # minutes
- 'fromstart'    = {typeOfStatisticalProcessing=1; forecastTime=0; indicatorOfUnitForTimeRange=0;}
- # 24 hourly time unit
- 'fromstart'    = {typeOfStatisticalProcessing=1; forecastTime=0; indicatorOfUnitForTimeRange=2;}
+ # fromstart for minutes / hourly / day
+ 'fromstart'    = {typeOfStatisticalProcessing=1; forecastTime=0; true=is_one_of(indicatorOfUnitForTimeRange,0,1,2);}
  ### end Accumulations ###
  #
  ### mean/min/max/stdev ###
@@ -118,14 +114,8 @@
  '240h'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 240;}
  '360h'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 360;}
 #'7 days'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 168;}
-# 28 days
- 'month'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 672;}
-# 29 days
- 'month'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 696;}
-# 30 days
- 'month'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 720;}
-# 31 days
- 'month'   = {indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 744;}
+# 28/29/30/31 days
+ 'month'   = {indicatorOfUnitForTimeRange=1; true=is_one_of(lengthOfTimeRange,672,696,720,744);}
 # time unit month
  'month'   = {indicatorOfUnitForTimeRange=3; lengthOfTimeRange = 1;}
 ### end mean/min/max/stdev ###

--- a/tests/grib_timeSpanConcept.sh
+++ b/tests/grib_timeSpanConcept.sh
@@ -45,5 +45,71 @@ EOF
   done
 fi
 
+# now we test for the seasonal products
+# for those we have monthyl statistics, but timespan should be none in case of a single time loop
+for STREAM in 1043 1092 1221 1224 ; do
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set stream=$STREAM;
+set tablesVersion=34;
+set productDefinitionTemplateNumber=8;
+set numberOfTimeRanges=1;
+set lengthOfTimeRange=744;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib timeSpan "none"
+done
+
+# sub-seasonal, one time loop -> timeSpan = none
+for TYPE in 47 48 80 81 82 83 ; do
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set stream=1122;
+set type=$TYPE;
+set tablesVersion=34;
+set productDefinitionTemplateNumber=8;
+set numberOfTimeRanges=1;
+set lengthOfTimeRange=168;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib timeSpan "none"
+done
+
+# fromstart
+for IUTR in 0 1 2 ; do
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=34;
+set productDefinitionTemplateNumber=8;
+set indicatorOfUnitForTimeRange=$IUTR;
+set numberOfTimeRanges=1;
+set typeOfStatisticalProcessing=1;
+set forecastTime=0;
+set lengthOfTimeRange=1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib timeSpan "fromstart"
+done
+
+# month
+for LTR in 672 696 720 744 ; do
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=34;
+set productDefinitionTemplateNumber=8;
+set indicatorOfUnitForTimeRange=1;
+set numberOfTimeRanges=1;
+set typeOfStatisticalProcessing=0;
+set lengthOfTimeRange=$LTR;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib timeSpan "month"
+done
+
+
 # Clean up
 rm -f $tempGrib


### PR DESCRIPTION
…pan concept

### Description


### Contributor Declaration
This branch contains a clean-up of the timespanConcept.defs regarding the use of code numbers instead of strings for the mars keys and merging several concepts into a single one by using the is_one_of function.
Please merge it into develop.

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 