### PR TITLE
Feature/50r1 wavelength

### DIFF
--- a/definitions/grib2/templates/template.4.108.def
+++ b/definitions/grib2/templates/template.4.108.def
@@ -8,3 +8,7 @@ include "grib2/templates/template.4.generating_process.def"
 include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.point_in_time.def"
 include "grib2/templates/template.4.horizontal.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.109.def
+++ b/definitions/grib2/templates/template.4.109.def
@@ -9,3 +9,7 @@ include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.point_in_time.def"
 include "grib2/templates/template.4.horizontal.def"
 include "grib2/templates/template.4.eps.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.110.def
+++ b/definitions/grib2/templates/template.4.110.def
@@ -8,3 +8,7 @@ include "grib2/templates/template.4.generating_process.def"
 include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.horizontal.def"
 include "grib2/templates/template.4.statistical.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.111.def
+++ b/definitions/grib2/templates/template.4.111.def
@@ -9,3 +9,7 @@ include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.horizontal.def"
 include "grib2/templates/template.4.eps.def"
 include "grib2/templates/template.4.statistical.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.48.def
+++ b/definitions/grib2/templates/template.4.48.def
@@ -10,3 +10,7 @@ include "grib2/templates/template.4.generating_process.def"
 include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.point_in_time.def"
 include "grib2/templates/template.4.horizontal.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.49.def
+++ b/definitions/grib2/templates/template.4.49.def
@@ -11,3 +11,7 @@ include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.point_in_time.def"
 include "grib2/templates/template.4.horizontal.def"
 include "grib2/templates/template.4.eps.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.80.def
+++ b/definitions/grib2/templates/template.4.80.def
@@ -11,3 +11,7 @@ include "grib2/templates/template.4.generating_process.def"
 include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.point_in_time.def"
 include "grib2/templates/template.4.horizontal.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.81.def
+++ b/definitions/grib2/templates/template.4.81.def
@@ -12,3 +12,7 @@ include "grib2/templates/template.4.forecast_time.def"
 include "grib2/templates/template.4.point_in_time.def"
 include "grib2/templates/template.4.horizontal.def"
 include "grib2/templates/template.4.eps.def"
+
+# MARS includes
+
+include "mars/mars.wavelength.def"

--- a/definitions/grib2/templates/template.4.optical.def
+++ b/definitions/grib2/templates/template.4.optical.def
@@ -18,17 +18,11 @@ constant billion = 1000000000 : hidden;
 meta firstWavelengthInNanometres  multdouble(firstWavelength, billion) : read_only;
 meta secondWavelengthInNanometres multdouble(secondWavelength, billion) : read_only;
 
-# All post-MTG2 data (MTG2Switch != 0) will have the wavelength key
-if (MTG2Switch != 0) {
- # typeOfWavelengthInterval (table 4.91 specifies if first / second / first+second limit(s) are to be defined)
- if ( typeOfWavelengthInterval == 0 || typeOfWavelengthInterval == 3 || typeOfWavelengthInterval == 5 || typeOfWavelengthInterval == 8 || typeOfWavelengthInterval == 11 ){
-  alias mars.wavelength = firstWavelengthInNanometres ;
- }
- if ( typeOfWavelengthInterval == 1 || typeOfWavelengthInterval == 4 || typeOfWavelengthInterval == 6 || typeOfWavelengthInterval == 9 ){
-  alias mars.wavelength = secondWavelengthInNanometres ;
- }
- if ( typeOfWavelengthInterval == 2 || typeOfWavelengthInterval == 7 || typeOfWavelengthInterval == 10 ){
-  meta wavelengthRange sprintf("%s-%s",firstWavelengthInNanometres,secondWavelengthInNanometres) ;
-  alias mars.wavelength = wavelengthRange ;
- }
-}
+# MARS include
+# mars.wavelength is aliased for MTG2Switch > 0
+# this was done originally here, but the MTG2SwitchConcept uses the generatingProcessIdenfiert
+# to implement an exception for 50r1
+# as template.4.optical.def is evaluated before template.4.generating_process.def"
+# the aliasing has to happen later, this is why in the optical templates the following is included:
+#
+# include "mars/mars.wavelength.def"

--- a/definitions/mars/mars.wavelength.def
+++ b/definitions/mars/mars.wavelength.def
@@ -1,0 +1,15 @@
+# All post-MTG2 data (MTG2Switch != 0) will have the wavelength key
+if (MTG2Switch != 0) {
+ # typeOfWavelengthInterval (table 4.91 specifies if first / second / first+second limit(s) are to be defined)
+ if ( typeOfWavelengthInterval == 0 || typeOfWavelengthInterval == 3 || typeOfWavelengthInterval == 5 || typeOfWavelengthInterval == 8 || typeOfWavelengthInterval == 11 ){
+  alias mars.wavelength = firstWavelengthInNanometres ;
+ }
+ if ( typeOfWavelengthInterval == 1 || typeOfWavelengthInterval == 4 || typeOfWavelengthInterval == 6 || typeOfWavelengthInterval == 9 ){
+  alias mars.wavelength = secondWavelengthInNanometres ;
+ }
+ if ( typeOfWavelengthInterval == 2 || typeOfWavelengthInterval == 7 || typeOfWavelengthInterval == 10 ){
+  meta wavelengthRange sprintf("%s-%s",firstWavelengthInNanometres,secondWavelengthInNanometres) ;
+  alias mars.wavelength = wavelengthRange ;
+ }
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-1708
         grib_ecc-1766
         grib_ecc-1829
+        grib_ecc-2140
         bufr_ecc-1028
         bufr_ecc-1195
         bufr_ecc-1259

--- a/tests/grib_ecc-2140.sh
+++ b/tests/grib_ecc-2140.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+# ---------------------------------------------------------
+# This is the test for JIRA issue ECC-XXXX
+# < Add issue summary here >
+# ---------------------------------------------------------
+
+REDIRECT=/dev/null
+
+label="grib_ecc-2140_test"  # Change prod to bufr or grib etc
+tempGrib=temp.$label.grib
+
+sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
+
+# pre-mtg2
+${tools_dir}/grib_set -s tablesVersion=32,setLocalDefinition=1,class=cr,generatingProcessIdentifier=158,productDefinitionTemplateNumber=48,typeOfWavelengthInterval=11,scaledValueOfFirstWavelength=500,scaleFactorOfFirstWavelength=9 $sample_grib2 $tempGrib
+[ $( ${tools_dir}/grib_get -f -p mars.wavelength $tempGrib ) = "not_found" ]
+
+# 50r1
+${tools_dir}/grib_set -s tablesVersion=35,setLocalDefinition=1,class=cr,generatingProcessIdentifier=161,productDefinitionTemplateNumber=48,typeOfWavelengthInterval=11,scaledValueOfFirstWavelength=500,scaleFactorOfFirstWavelength=9 $sample_grib2 $tempGrib
+[ $( ${tools_dir}/grib_get -f -p mars.wavelength $tempGrib ) = "not_found" ]
+
+# 50r2
+${tools_dir}/grib_set -s tablesVersion=35,setLocalDefinition=1,class=cr,generatingProcessIdentifier=162,productDefinitionTemplateNumber=48,typeOfWavelengthInterval=11,scaledValueOfFirstWavelength=500,scaleFactorOfFirstWavelength=9 $sample_grib2 $tempGrib
+[ $( ${tools_dir}/grib_get -f -p mars.wavelength $tempGrib ) = 500 ]
+
+# Clean up
+rm -f $tempGrib


### PR DESCRIPTION
### Description
With ecCodes 2.42 a so called MTG2Switch was introduced. This switch controls which parameter definitions are read and which mars keys are aliased into the mars namespace.
3 different values are currently implemented, 0 for pre-mtg2, 1 for post-mtg2 and 2 for post-mtg2 with chemIds. ERA6 / EAC5 with IFS 49r2 will be post-mtg2 while 50r1 remains pre-mtg2. While the main mechanism for the switch is the tablesVersion, a MTG2SwitchConcept was introduced to make 50r1 an exception.
In post-mtg2, an additional mars key wavelength is used for optical parameters using one of the PDTs 48, 49, 80, 81, 108, 109, 110, 111. This aliasing was done in template.4.optical.def as this is common to all of these section 4 templates.
Depending on the defined threshold of the tablesVersion, the wavelength key is added or not and works as expected, but this doesn't work for 50r1 as this needs generatingProcessIdentifier = 161 and the key generatingProcessIdentifier is defined after the template.4.optical.def:
include "grib2/templates/template.4.optical.def"
include "grib2/templates/template.4.generating_process.def"

Therefore the logic in template.4.optical.def was removed, added into a separate file in the definitions/mars and included at the end of all PDTs which also include the template.4.optical.def.

Please merge the branch into develop.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 