### PR TITLE
script to create chem defs from db and db created defs

### DIFF
--- a/definitions/create_chemdefs.py
+++ b/definitions/create_chemdefs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import os
+import sys
+import subprocess
+import mysql.connector
+## Create a connection object
+## IP address of the MySQL database server
+Host = os.environ['PARAM_DB_HOST']
+## User name of the database server
+User = os.environ['PARAM_DB_USER']
+## Password for the database user
+Password = os.environ['PARAM_DB_PASS']
+## opens directly the database param
+database = "param"
+
+conn  = mysql.connector.connect(host=Host, user=User, password=Password, database=database)
+
+# Create a cursor object
+cur  = conn.cursor()
+
+# WMO definitions
+#os.system('mkdir -p grib2')
+centre = 0
+query = f"select chem.id as chemId,shortName as chemShortName,chem.name as chemName,chem.formula as chemFormula,group_concat(concat(attribute.name,'=',coalesce(chem_attributes.attribute_value,'missing()')) order by attribute.o) as attributes from chem join chem_attributes on chem_attributes.chem_id=chem.id join attribute on attribute.id=chem_attributes.attribute_id where chem.centre_id={centre} group by chem.id;"
+#cur.execute(query)
+#df = cur.fetchall()
+df = pd.read_sql(query, con=conn)
+f1 = open("grib2/chemId.def", "w")
+f2 = open("grib2/chemName.def", "w")
+f3 = open("grib2/chemShortName.def", "w")
+f4 = open("grib2/chemFormula.def", "w")
+for i in range(len(df)):
+    attr_i = df.iloc[i]['attributes'].split(',')
+    chemName = df.iloc[i]['chemName']
+    chemId = df.iloc[i]['chemId']
+    chemShortName = df.iloc[i]['chemShortName']
+    chemFormula = df.iloc[i]['chemFormula']
+    print(chemId,chemName)
+#    os.system('echo "#' + str(chemName) + '"')
+    f1.write(f"#{chemName}\n")
+    f2.write(f"#{chemName}\n")
+    f3.write(f"#{chemName}\n")
+    f4.write(f"#{chemName}\n")
+#    os.system("echo \"" + "'" + str(chemId) + "'\" = {")
+    f1.write("'" + f"{chemId}" + "' " +  "=" + " {" + "\n")
+    f2.write("'" + f"{chemName}" + "' " +  "=" + " {" + "\n")
+    f3.write("'" + f"{chemShortName}" + "' " +  "=" + " {" + "\n")
+    f4.write("'" + f"{chemFormula}" + "' " +  "=" + " {" + "\n")
+#    os.system(f"echo \#{chemName}")
+    # we loop over the attributes
+    for j in range(len(attr_i)):
+        aid = attr_i[j].split('=')[0]
+        ava = attr_i[j].split('=')[1]
+#        os.system('echo "\t' + str(aid) + ' = ' + str(ava) + ' ;"')
+        f1.write(f"\t{aid} = {ava} ;\n")
+        f2.write(f"\t{aid} = {ava} ;\n")
+        f3.write(f"\t{aid} = {ava} ;\n")
+        f4.write(f"\t{aid} = {ava} ;\n")
+#    os.system('echo "\t"' + "}")
+    f1.write(f"\t" + '}\n')
+    f2.write(f"\t" + '}\n')
+    f3.write(f"\t" + '}\n')
+    f4.write(f"\t" + '}\n')
+f1.close()
+f2.close()
+f3.close()
+f4.close()
+
+# ECMWF definitions
+#os.system('mkdir -p grib2/localConcepts/')
+#os.system('mkdir -p grib2/localConcepts/ecmf/')
+centre = 98
+query = f"select chem.id as chemId,shortName as chemShortName,chem.name as chemName,chem.formula as chemFormula,group_concat(concat(attribute.name,'=',coalesce(chem_attributes.attribute_value,'missing()')) order by attribute.o) as attributes from chem join chem_attributes on chem_attributes.chem_id=chem.id join attribute on attribute.id=chem_attributes.attribute_id where chem.centre_id={centre} group by chem.id;"
+#cur.execute(query)
+#df = cur.fetchall()
+df = pd.read_sql(query, con=conn)
+f1 = open("grib2/localConcepts/ecmf/chemId.def", "w")
+f2 = open("grib2/localConcepts/ecmf/chemName.def", "w")
+f3 = open("grib2/localConcepts/ecmf/chemShortName.def", "w")
+f4 = open("grib2/localConcepts/ecmf/chemFormula.def", "w")
+for i in range(len(df)):
+    attr_i = df.iloc[i]['attributes'].split(',')
+    chemName = df.iloc[i]['chemName']
+    chemId = df.iloc[i]['chemId']
+    chemShortName = df.iloc[i]['chemShortName']
+    chemFormula = df.iloc[i]['chemFormula']
+    print(chemId,chemName)
+#    os.system('echo "#' + str(chemName) + '"')
+    f1.write(f"#{chemName}\n")
+    f2.write(f"#{chemName}\n")
+    f3.write(f"#{chemName}\n")
+    f4.write(f"#{chemName}\n")
+#    os.system("echo \"" + "'" + str(chemId) + "'\" = {")
+    f1.write("'" + f"{chemId}" + "' " +  "=" + " {" + "\n")
+    f2.write("'" + f"{chemName}" + "' " +  "=" + " {" + "\n")
+    f3.write("'" + f"{chemShortName}" + "' " +  "=" + " {" + "\n")
+    f4.write("'" + f"{chemFormula}" + "' " +  "=" + " {" + "\n")
+#    os.system(f"echo \#{chemName}")
+    # we loop over the attributes
+    for j in range(len(attr_i)):
+        aid = attr_i[j].split('=')[0]
+        ava = attr_i[j].split('=')[1]
+#        os.system('echo "\t' + str(aid) + ' = ' + str(ava) + ' ;"')
+        f1.write(f"\t{aid} = {ava} ;\n")
+        f2.write(f"\t{aid} = {ava} ;\n")
+        f3.write(f"\t{aid} = {ava} ;\n")
+        f4.write(f"\t{aid} = {ava} ;\n")
+#    os.system('echo "\t"' + "}")
+    f1.write(f"\t" + '}\n')
+    f2.write(f"\t" + '}\n')
+    f3.write(f"\t" + '}\n')
+    f4.write(f"\t" + '}\n')
+f1.close()
+f2.close()
+f3.close()
+f4.close()
+
+conn.close()

--- a/definitions/grib2/chemFormula.def
+++ b/definitions/grib2/chemFormula.def
@@ -506,7 +506,7 @@
 'ISOPDO2' = {
 	constituentType = 10057 ;
 	}
-#Sulphur hexafluoride 
+#Sulphur hexafluoride
 'SF6' = {
 	constituentType = 45 ;
 	}
@@ -560,57 +560,57 @@
 	}
 #Sea salt aerosol (0.03 - 0.5 um)
 'aer_seasalt_003_05' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (0.5 - 5 um)
 'aer_seasalt_05_5' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (5 - 20 um)
 'aer_seasalt_5_20' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 6 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62008 ;
 	}
 #Dust aerosol (0.03 - 0.55 um)
 'aer_dust_003_055' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 8 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 55 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.55 - 0.9 um)
 'aer_dust_055_09' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 55 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 55 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 9 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.9 - 20 um)
 'aer_dust_09_20' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 9 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
 	}
 #Hydrophilic organic matter aerosol
 'aer_hicorgmat' = {
@@ -634,21 +634,21 @@
 	}
 #Nitrate fine mode aerosol (<= 2.5 um)
 'aer_nitrfine' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 5 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Nitrate coarse mode aerosol (>2.5 um)
 'aer_nitrcoars' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 3 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 3 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Ammonium aerosol
 'aer_nh4' = {
@@ -672,83 +672,83 @@
 	}
 #Dust aerosol (0.9 - 2.5 um)
 'aer_dust_09_2p5' = {
-        scaleFactorOfSecondSize = 7 ;
-        scaledValueOfFirstSize = 9 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 25 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 25 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (2.5 - 5.0 um)
 'aer_dust_2p5_5' = {
-        scaleFactorOfSecondSize = 6 ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 5 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 5 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (5.0 - 10.0 um)
 'aer_dust_5_10' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 5 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 1 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 1 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (10.0 - 20.0 um)
 'aer_dust_10_20' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 2 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
+	}
 #Particulate matter <= 1 um
 'PM1' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 2.5 um
 'PM2.5' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 10 um
 'PM10' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
-#Volcanic ash
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
+#Volcanic Ash
 'volash' = {
 	constituentType = 62025 ;
 	}
 #Black carbon organic aerosol
 'aer_blackcarb' = {
-        constituentType = 62009 ;
-        }
+	constituentType = 62009 ;
+	}
 #Organic matter aerosol
 'aer_orgmat' = {
-        constituentType = 62010 ;
-        }
+	constituentType = 62010 ;
+	}
 #Dust aerosol
 'aer_dust' = {
-        constituentType = 62001 ;
-        }
+	constituentType = 62001 ;
+	}
 #Sea salt aerosol
 'aer_seasalt' = {
 	constituentType = 62008 ;

--- a/definitions/grib2/chemId.def
+++ b/definitions/grib2/chemId.def
@@ -506,7 +506,7 @@
 '230' = {
 	constituentType = 10057 ;
 	}
-#Sulphur hexafluoride 
+#Sulphur hexafluoride
 '232' = {
 	constituentType = 45 ;
 	}
@@ -560,57 +560,57 @@
 	}
 #Sea salt aerosol (0.03 - 0.5 um)
 '901' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (0.5 - 5 um)
 '902' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (5 - 20 um)
 '903' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 6 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62008 ;
 	}
 #Dust aerosol (0.03 - 0.55 um)
 '904' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 8 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 55 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.55 - 0.9 um)
 '905' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 55 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 55 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 9 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.9 - 20 um)
 '906' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 9 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
 	}
 #Hydrophilic organic matter aerosol
 '907' = {
@@ -634,21 +634,21 @@
 	}
 #Nitrate fine mode aerosol (<= 2.5 um)
 '912' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 5 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Nitrate coarse mode aerosol (>2.5 um)
 '913' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 3 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 3 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Ammonium aerosol
 '914' = {
@@ -672,83 +672,83 @@
 	}
 #Dust aerosol (0.9 - 2.5 um)
 '925' = {
-        scaleFactorOfSecondSize = 7 ;
-        scaledValueOfFirstSize = 9 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 25 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 25 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (2.5 - 5.0 um)
 '926' = {
-        scaleFactorOfSecondSize = 6 ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 5 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 5 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (5.0 - 10.0 um)
 '927' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 5 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 1 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 1 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (10.0 - 20.0 um)
 '928' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 2 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
+	}
 #Particulate matter <= 1 um
 '929' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 2.5 um
 '930' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 10 um
 '931' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
-#Volcanic ash
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
+#Volcanic Ash
 '932' = {
 	constituentType = 62025 ;
 	}
 #Black carbon organic aerosol
 '933' = {
-        constituentType = 62009 ;
-        }
+	constituentType = 62009 ;
+	}
 #Organic matter aerosol
 '934' = {
-        constituentType = 62010 ;
-        }
+	constituentType = 62010 ;
+	}
 #Dust aerosol
 '935' = {
-        constituentType = 62001 ;
-        }
+	constituentType = 62001 ;
+	}
 #Sea salt aerosol
 '936' = {
 	constituentType = 62008 ;

--- a/definitions/grib2/chemName.def
+++ b/definitions/grib2/chemName.def
@@ -506,8 +506,8 @@
 'Isoprene peroxy type D' = {
 	constituentType = 10057 ;
 	}
-#Sulphur hexafluoride 
-'Sulphur hexafluoride ' = {
+#Sulphur hexafluoride
+'Sulphur hexafluoride' = {
 	constituentType = 45 ;
 	}
 #Sulphur dioxide
@@ -560,57 +560,57 @@
 	}
 #Sea salt aerosol (0.03 - 0.5 um)
 'Sea salt aerosol (0.03 - 0.5 um)' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (0.5 - 5 um)
 'Sea salt aerosol (0.5 - 5 um)' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (5 - 20 um)
 'Sea salt aerosol (5 - 20 um)' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 6 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62008 ;
 	}
 #Dust aerosol (0.03 - 0.55 um)
 'Dust aerosol (0.03 - 0.55 um)' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 8 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 55 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.55 - 0.9 um)
 'Dust aerosol (0.55 - 0.9 um)' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 55 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 55 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 9 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.9 - 20 um)
 'Dust aerosol (0.9 - 20 um)' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 9 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
 	}
 #Hydrophilic organic matter aerosol
 'Hydrophilic organic matter aerosol' = {
@@ -634,21 +634,21 @@
 	}
 #Nitrate fine mode aerosol (<= 2.5 um)
 'Nitrate fine mode aerosol (<= 2.5 um)' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 5 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Nitrate coarse mode aerosol (>2.5 um)
 'Nitrate coarse mode aerosol (>2.5 um)' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 3 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 3 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Ammonium aerosol
 'Ammonium aerosol' = {
@@ -672,83 +672,83 @@
 	}
 #Dust aerosol (0.9 - 2.5 um)
 'Dust aerosol (0.9 - 2.5 um)' = {
-        scaleFactorOfSecondSize = 7 ;
-        scaledValueOfFirstSize = 9 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 25 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 25 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (2.5 - 5.0 um)
 'Dust aerosol (2.5 - 5.0 um)' = {
-        scaleFactorOfSecondSize = 6 ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 5 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 5 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (5.0 - 10.0 um)
 'Dust aerosol (5.0 - 10.0 um)' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 5 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 1 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 1 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (10.0 - 20.0 um)
 'Dust aerosol (10.0 - 20.0 um)' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 2 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
+	}
 #Particulate matter <= 1 um
 'Particulate matter <= 1 um' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 2.5 um
 'Particulate matter <= 2.5 um' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 10 um
 'Particulate matter <= 10 um' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
-#Volcanic ash
-'Volcanic ash' = {
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
+#Volcanic Ash
+'Volcanic Ash' = {
 	constituentType = 62025 ;
 	}
 #Black carbon organic aerosol
 'Black carbon organic aerosol' = {
-        constituentType = 62009 ;
-        }
+	constituentType = 62009 ;
+	}
 #Organic matter aerosol
 'Organic matter aerosol' = {
-        constituentType = 62010 ;
-        }
+	constituentType = 62010 ;
+	}
 #Dust aerosol
 'Dust aerosol' = {
-        constituentType = 62001 ;
-        }
+	constituentType = 62001 ;
+	}
 #Sea salt aerosol
 'Sea salt aerosol' = {
 	constituentType = 62008 ;

--- a/definitions/grib2/chemShortName.def
+++ b/definitions/grib2/chemShortName.def
@@ -506,7 +506,7 @@
 'ISOPDO2' = {
 	constituentType = 10057 ;
 	}
-#Sulphur hexafluoride 
+#Sulphur hexafluoride
 'SF6' = {
 	constituentType = 45 ;
 	}
@@ -560,57 +560,57 @@
 	}
 #Sea salt aerosol (0.03 - 0.5 um)
 'aer_seasalt_003_05' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (0.5 - 5 um)
 'aer_seasalt_05_5' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 5 ;
+	constituentType = 62008 ;
 	}
 #Sea salt aerosol (5 - 20 um)
 'aer_seasalt_5_20' = {
-	constituentType = 62008 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 6 ;
-	scaledValueOfFirstSize = 5 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62008 ;
 	}
 #Dust aerosol (0.03 - 0.55 um)
 'aer_dust_003_055' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 3 ;
 	scaleFactorOfSecondSize = 8 ;
+	scaledValueOfFirstSize = 3 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 55 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.55 - 0.9 um)
 'aer_dust_055_09' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 8 ;
-	scaledValueOfFirstSize = 55 ;
 	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 55 ;
+	scaleFactorOfFirstSize = 8 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 9 ;
+	constituentType = 62001 ;
 	}
 #Dust aerosol (0.9 - 20 um)
 'aer_dust_09_20' = {
-	constituentType = 62001 ;
-	typeOfSizeInterval = 7 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 9 ;
 	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
 	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
 	}
 #Hydrophilic organic matter aerosol
 'aer_hicorgmat' = {
@@ -634,21 +634,21 @@
 	}
 #Nitrate fine mode aerosol (<= 2.5 um)
 'aer_nitrfine' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 5 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Nitrate coarse mode aerosol (>2.5 um)
 'aer_nitrcoars' = {
-	constituentType = 62004 ;
-	typeOfSizeInterval = 3 ;
-	scaleFactorOfFirstSize = 7 ;
-	scaledValueOfFirstSize = 25 ;
 	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 3 ;
 	scaledValueOfSecondSize = missing() ;
+	constituentType = 62004 ;
 	}
 #Ammonium aerosol
 'aer_nh4' = {
@@ -672,83 +672,83 @@
 	}
 #Dust aerosol (0.9 - 2.5 um)
 'aer_dust_09_2p5' = {
-        scaleFactorOfSecondSize = 7 ;
-        scaledValueOfFirstSize = 9 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 25 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 7 ;
+	scaledValueOfFirstSize = 9 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 25 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (2.5 - 5.0 um)
 'aer_dust_2p5_5' = {
-        scaleFactorOfSecondSize = 6 ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 5 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 6 ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 5 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (5.0 - 10.0 um)
 'aer_dust_5_10' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 5 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 1 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 5 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 1 ;
+	constituentType = 62001 ;
+	}
 #Dust aerosol (10.0 - 20.0 um)
 'aer_dust_10_20' = {
-        scaleFactorOfSecondSize = 5 ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 7 ;
-        scaledValueOfSecondSize = 2 ;
-        constituentType = 62001 ;
-        }
+	scaleFactorOfSecondSize = 5 ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 7 ;
+	scaledValueOfSecondSize = 2 ;
+	constituentType = 62001 ;
+	}
 #Particulate matter <= 1 um
 'aer_pm_1' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 6 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 6 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 2.5 um
 'aer_pm_2p5' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 25 ;
-        scaleFactorOfFirstSize = 7 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 25 ;
+	scaleFactorOfFirstSize = 7 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
 #Particulate matter <= 10 um
 'aer_pm_10' = {
-        scaleFactorOfSecondSize = missing() ;
-        scaledValueOfFirstSize = 1 ;
-        scaleFactorOfFirstSize = 5 ;
-        typeOfSizeInterval = 5 ;
-        scaledValueOfSecondSize = missing() ;
-        constituentType = 62026 ;
-        }
-#Volcanic ash
+	scaleFactorOfSecondSize = missing() ;
+	scaledValueOfFirstSize = 1 ;
+	scaleFactorOfFirstSize = 5 ;
+	typeOfSizeInterval = 5 ;
+	scaledValueOfSecondSize = missing() ;
+	constituentType = 62026 ;
+	}
+#Volcanic Ash
 'volash' = {
 	constituentType = 62025 ;
 	}
 #Black carbon organic aerosol
 'aer_blackcarb' = {
-        constituentType = 62009 ;
-        }
+	constituentType = 62009 ;
+	}
 #Organic matter aerosol
 'aer_orgmat' = {
-        constituentType = 62010 ;
-        }
+	constituentType = 62010 ;
+	}
 #Dust aerosol
 'aer_dust' = {
-        constituentType = 62001 ;
-        }
+	constituentType = 62001 ;
+	}
 #Sea salt aerosol
 'aer_seasalt' = {
 	constituentType = 62008 ;

--- a/definitions/grib2/localConcepts/ecmf/chemFormula.def
+++ b/definitions/grib2/localConcepts/ecmf/chemFormula.def
@@ -1,155 +1,155 @@
 #Methane (chemistry)
 'CH4_c' = {
-	constituentType = 2 ;
 	localTablesVersion = 1 ;
+	constituentType = 2 ;
 	}
 #Volcanic sulphur dioxide
 'SO2_v' = {
-        constituentType = 65507 ;
-        localTablesVersion = 1 ;
-        }
+	localTablesVersion = 1 ;
+	constituentType = 65507 ;
+	}
 #Stratospheric ozone
 'O3S' = {
-	constituentType = 65524 ;
 	localTablesVersion = 1 ;
+	constituentType = 65524 ;
 	}
 #PAR budget corrector
 'rxpar' = {
-	constituentType = 65520 ;
 	localTablesVersion = 1 ;
+	constituentType = 65520 ;
 	}
 #NO to NO2 operator
 'xo2' = {
-	constituentType = 65521 ;
 	localTablesVersion = 1 ;
+	constituentType = 65521 ;
 	}
 #NO to alkyl nitrate operator
 'xo2n' = {
-	constituentType = 65522 ;
 	localTablesVersion = 1 ;
+	constituentType = 65522 ;
 	}
 #Polar stratospheric cloud
 'psc' = {
-	constituentType = 65516 ;
 	localTablesVersion = 1 ;
+	constituentType = 65516 ;
 	}
 #Methacrolein MVK
 'ISPD' = {
-	constituentType = 65523 ;
 	localTablesVersion = 1 ;
+	constituentType = 65523 ;
 	}
 #Acetone product
 'aco2' = {
-	constituentType = 65515 ;
 	localTablesVersion = 1 ;
+	constituentType = 65515 ;
 	}
 #HYPROPO2
 'hypropo2' = {
-	constituentType = 65519 ;
 	localTablesVersion = 1 ;
+	constituentType = 65519 ;
 	}
 #Nitrogen oxides Transp
 'noxa' = {
-	constituentType = 65514 ;
 	localTablesVersion = 1 ;
+	constituentType = 65514 ;
 	}
 #Carbon dioxide (chemistry)
 'CO2_c' = {
-	constituentType = 3 ;
 	localTablesVersion = 1 ;
+	constituentType = 3 ;
 	}
 #Nitrous oxide (chemistry)
 'N2O_c' = {
-	constituentType = 6 ;
 	localTablesVersion = 1 ;
+	constituentType = 6 ;
 	}
 #Water vapour (chemistry)
 'H2O_c' = {
-	constituentType = 1 ;
 	localTablesVersion = 1 ;
+	constituentType = 1 ;
 	}
 #Toluene and less reactive aromatics
 'tol' = {
-	constituentType = 65529 ;
 	localTablesVersion = 1 ;
+	constituentType = 65529 ;
 	}
 #Xylene and more reactive aromatics
 'xyl' = {
-	constituentType = 65530 ;
 	localTablesVersion = 1 ;
+	constituentType = 65530 ;
 	}
 #Lumped alkenes
 'BIGENE' = {
+	localTablesVersion = 1 ;
 	constituentType = 60010 ;
-	localTablesVersion = 2 ;
 	}
 #Lumped alkanes
 'BIGALK' = {
+	localTablesVersion = 1 ;
 	constituentType = 60009 ;
-	localTablesVersion = 2 ;
 	}
 #Hydrogen atom
 'h_c' = {
-	constituentType = 65513 ;
 	localTablesVersion = 1 ;
+	constituentType = 65513 ;
 	}
 #Condensable gas type 1
 'sog1' = {
-	constituentType = 65526 ;
 	localTablesVersion = 1 ;
+	constituentType = 65526 ;
 	}
 #Condensable gas type 2a
 'sog2a' = {
-	constituentType = 65527 ;
 	localTablesVersion = 1 ;
+	constituentType = 65527 ;
 	}
 #Condensable gas type 2b
 'sog2b' = {
-	constituentType = 65528 ;
 	localTablesVersion = 1 ;
+	constituentType = 65528 ;
 	}
 #Asymmetric chlorine dioxide radical
 'cloo' = {
-	constituentType = 65518 ;
 	localTablesVersion = 1 ;
+	constituentType = 65518 ;
 	}
 #GEMS ozone
 'gO3' = {
-	constituentType = 0 ;
 	localTablesVersion = 1 ;
+	constituentType = 0 ;
 	}
 #Stratospheric aerosol
 'strataer' = {
-	constituentType = 65517 ;
 	localTablesVersion = 1 ;
+	constituentType = 65517 ;
 	}
 #Biogenic secondary organic aerosol precursor
 'aer_biosecorg_pre' = {
-	constituentType = 65511 ;
 	localTablesVersion = 1 ;
+	constituentType = 65511 ;
 	}
 #Anthropogenic secondary organic aerosol precursor
 'aer_antsecorg_pre' = {
-	constituentType = 65512 ;
 	localTablesVersion = 1 ;
+	constituentType = 65512 ;
 	}
 #SO2 precursor
 'aer_so2_pre' = {
-	constituentType = 65510 ;
 	localTablesVersion = 1 ;
+	constituentType = 65510 ;
 	}
 #Aerosol small mode
 'aer_sm' = {
-	constituentType = 65508 ;
 	localTablesVersion = 1 ;
+	constituentType = 65508 ;
 	}
 #Aerosol large mode
 'aer_lm' = {
-	constituentType = 65509 ;
 	localTablesVersion = 1 ;
+	constituentType = 65509 ;
 	}
-#Volcanic sulphate
+#Volcanic Sulphate
 'SO4_v' = {
+	localTablesVersion = 1 ;
 	constituentType = 65506 ;
-        localTablesVersion = 1 ;
-        }
+	}

--- a/definitions/grib2/localConcepts/ecmf/chemId.def
+++ b/definitions/grib2/localConcepts/ecmf/chemId.def
@@ -1,155 +1,155 @@
 #Methane (chemistry)
 '4' = {
-	constituentType = 2 ;
 	localTablesVersion = 1 ;
+	constituentType = 2 ;
 	}
 #Volcanic sulphur dioxide
 '8' = {
-        constituentType = 65507 ;
-        localTablesVersion = 1 ;
-        }
+	localTablesVersion = 1 ;
+	constituentType = 65507 ;
+	}
 #Stratospheric ozone
 '24' = {
-	constituentType = 65524 ;
 	localTablesVersion = 1 ;
+	constituentType = 65524 ;
 	}
 #PAR budget corrector
 '37' = {
-	constituentType = 65520 ;
 	localTablesVersion = 1 ;
+	constituentType = 65520 ;
 	}
 #NO to NO2 operator
 '38' = {
-	constituentType = 65521 ;
 	localTablesVersion = 1 ;
+	constituentType = 65521 ;
 	}
 #NO to alkyl nitrate operator
 '39' = {
-	constituentType = 65522 ;
 	localTablesVersion = 1 ;
+	constituentType = 65522 ;
 	}
 #Polar stratospheric cloud
 '41' = {
-	constituentType = 65516 ;
 	localTablesVersion = 1 ;
+	constituentType = 65516 ;
 	}
 #Methacrolein MVK
 '50' = {
-	constituentType = 65523 ;
 	localTablesVersion = 1 ;
+	constituentType = 65523 ;
 	}
 #Acetone product
 '53' = {
-	constituentType = 65515 ;
 	localTablesVersion = 1 ;
+	constituentType = 65515 ;
 	}
 #HYPROPO2
 '55' = {
-	constituentType = 65519 ;
 	localTablesVersion = 1 ;
+	constituentType = 65519 ;
 	}
 #Nitrogen oxides Transp
 '56' = {
-	constituentType = 65514 ;
 	localTablesVersion = 1 ;
+	constituentType = 65514 ;
 	}
 #Carbon dioxide (chemistry)
 '57' = {
-	constituentType = 3 ;
 	localTablesVersion = 1 ;
+	constituentType = 3 ;
 	}
 #Nitrous oxide (chemistry)
 '58' = {
-	constituentType = 6 ;
 	localTablesVersion = 1 ;
+	constituentType = 6 ;
 	}
 #Water vapour (chemistry)
 '59' = {
-	constituentType = 1 ;
 	localTablesVersion = 1 ;
+	constituentType = 1 ;
 	}
 #Toluene and less reactive aromatics
 '99' = {
-	constituentType = 65529 ;
 	localTablesVersion = 1 ;
+	constituentType = 65529 ;
 	}
 #Xylene and more reactive aromatics
 '100' = {
-	constituentType = 65530 ;
 	localTablesVersion = 1 ;
+	constituentType = 65530 ;
 	}
 #Lumped alkenes
 '124' = {
+	localTablesVersion = 1 ;
 	constituentType = 60010 ;
-	localTablesVersion = 2 ;
 	}
 #Lumped alkanes
 '126' = {
+	localTablesVersion = 1 ;
 	constituentType = 60009 ;
-	localTablesVersion = 2 ;
 	}
 #Hydrogen atom
 '177' = {
-	constituentType = 65513 ;
 	localTablesVersion = 1 ;
+	constituentType = 65513 ;
 	}
 #Condensable gas type 1
 '186' = {
-	constituentType = 65526 ;
 	localTablesVersion = 1 ;
+	constituentType = 65526 ;
 	}
 #Condensable gas type 2a
 '187' = {
-	constituentType = 65527 ;
 	localTablesVersion = 1 ;
+	constituentType = 65527 ;
 	}
 #Condensable gas type 2b
 '188' = {
-	constituentType = 65528 ;
 	localTablesVersion = 1 ;
+	constituentType = 65528 ;
 	}
 #Asymmetric chlorine dioxide radical
 '198' = {
-	constituentType = 65518 ;
 	localTablesVersion = 1 ;
+	constituentType = 65518 ;
 	}
 #GEMS ozone
 '231' = {
-	constituentType = 0 ;
 	localTablesVersion = 1 ;
+	constituentType = 0 ;
 	}
 #Stratospheric aerosol
 '917' = {
-	constituentType = 65517 ;
 	localTablesVersion = 1 ;
+	constituentType = 65517 ;
 	}
 #Biogenic secondary organic aerosol precursor
 '919' = {
-	constituentType = 65511 ;
 	localTablesVersion = 1 ;
+	constituentType = 65511 ;
 	}
 #Anthropogenic secondary organic aerosol precursor
 '920' = {
-	constituentType = 65512 ;
 	localTablesVersion = 1 ;
+	constituentType = 65512 ;
 	}
 #SO2 precursor
 '921' = {
-	constituentType = 65510 ;
 	localTablesVersion = 1 ;
+	constituentType = 65510 ;
 	}
 #Aerosol small mode
 '923' = {
-	constituentType = 65508 ;
 	localTablesVersion = 1 ;
+	constituentType = 65508 ;
 	}
 #Aerosol large mode
 '924' = {
-	constituentType = 65509 ;
 	localTablesVersion = 1 ;
+	constituentType = 65509 ;
 	}
-#Volcanic sulphate
+#Volcanic Sulphate
 '941' = {
-        constituentType = 65506 ;
-        localTablesVersion = 1 ;
-        }
+	localTablesVersion = 1 ;
+	constituentType = 65506 ;
+	}

--- a/definitions/grib2/localConcepts/ecmf/chemName.def
+++ b/definitions/grib2/localConcepts/ecmf/chemName.def
@@ -1,155 +1,155 @@
 #Methane (chemistry)
 'Methane (chemistry)' = {
-	constituentType = 2 ;
 	localTablesVersion = 1 ;
+	constituentType = 2 ;
 	}
 #Volcanic sulphur dioxide
 'Volcanic sulphur dioxide' = {
-        constituentType = 65507 ;
-        localTablesVersion = 1 ;
-        }
+	localTablesVersion = 1 ;
+	constituentType = 65507 ;
+	}
 #Stratospheric ozone
 'Stratospheric ozone' = {
-	constituentType = 65524 ;
 	localTablesVersion = 1 ;
+	constituentType = 65524 ;
 	}
 #PAR budget corrector
 'PAR budget corrector' = {
-	constituentType = 65520 ;
 	localTablesVersion = 1 ;
+	constituentType = 65520 ;
 	}
 #NO to NO2 operator
 'NO to NO2 operator' = {
-	constituentType = 65521 ;
 	localTablesVersion = 1 ;
+	constituentType = 65521 ;
 	}
 #NO to alkyl nitrate operator
 'NO to alkyl nitrate operator' = {
-	constituentType = 65522 ;
 	localTablesVersion = 1 ;
+	constituentType = 65522 ;
 	}
 #Polar stratospheric cloud
 'Polar stratospheric cloud' = {
-	constituentType = 65516 ;
 	localTablesVersion = 1 ;
+	constituentType = 65516 ;
 	}
 #Methacrolein MVK
 'Methacrolein MVK' = {
-	constituentType = 65523 ;
 	localTablesVersion = 1 ;
+	constituentType = 65523 ;
 	}
 #Acetone product
 'Acetone product' = {
-	constituentType = 65515 ;
 	localTablesVersion = 1 ;
+	constituentType = 65515 ;
 	}
 #HYPROPO2
 'HYPROPO2' = {
-	constituentType = 65519 ;
 	localTablesVersion = 1 ;
+	constituentType = 65519 ;
 	}
 #Nitrogen oxides Transp
 'Nitrogen oxides Transp' = {
-	constituentType = 65514 ;
 	localTablesVersion = 1 ;
+	constituentType = 65514 ;
 	}
 #Carbon dioxide (chemistry)
 'Carbon dioxide (chemistry)' = {
-	constituentType = 3 ;
 	localTablesVersion = 1 ;
+	constituentType = 3 ;
 	}
 #Nitrous oxide (chemistry)
 'Nitrous oxide (chemistry)' = {
-	constituentType = 6 ;
 	localTablesVersion = 1 ;
+	constituentType = 6 ;
 	}
 #Water vapour (chemistry)
 'Water vapour (chemistry)' = {
-	constituentType = 1 ;
 	localTablesVersion = 1 ;
+	constituentType = 1 ;
 	}
 #Toluene and less reactive aromatics
 'Toluene and less reactive aromatics' = {
-	constituentType = 65529 ;
 	localTablesVersion = 1 ;
+	constituentType = 65529 ;
 	}
 #Xylene and more reactive aromatics
 'Xylene and more reactive aromatics' = {
-	constituentType = 65530 ;
 	localTablesVersion = 1 ;
+	constituentType = 65530 ;
 	}
 #Lumped alkenes
 'Lumped alkenes' = {
+	localTablesVersion = 1 ;
 	constituentType = 60010 ;
-	localTablesVersion = 2 ;
 	}
 #Lumped alkanes
 'Lumped alkanes' = {
+	localTablesVersion = 1 ;
 	constituentType = 60009 ;
-	localTablesVersion = 2 ;
 	}
 #Hydrogen atom
 'Hydrogen atom' = {
-	constituentType = 65513 ;
 	localTablesVersion = 1 ;
+	constituentType = 65513 ;
 	}
 #Condensable gas type 1
 'Condensable gas type 1' = {
-	constituentType = 65526 ;
 	localTablesVersion = 1 ;
+	constituentType = 65526 ;
 	}
 #Condensable gas type 2a
 'Condensable gas type 2a' = {
-	constituentType = 65527 ;
 	localTablesVersion = 1 ;
+	constituentType = 65527 ;
 	}
 #Condensable gas type 2b
 'Condensable gas type 2b' = {
-	constituentType = 65528 ;
 	localTablesVersion = 1 ;
+	constituentType = 65528 ;
 	}
 #Asymmetric chlorine dioxide radical
 'Asymmetric chlorine dioxide radical' = {
-	constituentType = 65518 ;
 	localTablesVersion = 1 ;
+	constituentType = 65518 ;
 	}
 #GEMS ozone
 'GEMS ozone' = {
-	constituentType = 0 ;
 	localTablesVersion = 1 ;
+	constituentType = 0 ;
 	}
 #Stratospheric aerosol
 'Stratospheric aerosol' = {
-	constituentType = 65517 ;
 	localTablesVersion = 1 ;
+	constituentType = 65517 ;
 	}
 #Biogenic secondary organic aerosol precursor
 'Biogenic secondary organic aerosol precursor' = {
-	constituentType = 65511 ;
 	localTablesVersion = 1 ;
+	constituentType = 65511 ;
 	}
 #Anthropogenic secondary organic aerosol precursor
 'Anthropogenic secondary organic aerosol precursor' = {
-	constituentType = 65512 ;
 	localTablesVersion = 1 ;
+	constituentType = 65512 ;
 	}
 #SO2 precursor
 'SO2 precursor' = {
-	constituentType = 65510 ;
 	localTablesVersion = 1 ;
+	constituentType = 65510 ;
 	}
 #Aerosol small mode
 'Aerosol small mode' = {
-	constituentType = 65508 ;
 	localTablesVersion = 1 ;
+	constituentType = 65508 ;
 	}
 #Aerosol large mode
 'Aerosol large mode' = {
-	constituentType = 65509 ;
 	localTablesVersion = 1 ;
+	constituentType = 65509 ;
 	}
-#Volcanic sulphate
-'Volcanic sulphate' = {
-        constituentType = 65506 ;
-        localTablesVersion = 1 ;
-        }
+#Volcanic Sulphate
+'Volcanic Sulphate' = {
+	localTablesVersion = 1 ;
+	constituentType = 65506 ;
+	}

--- a/definitions/grib2/localConcepts/ecmf/chemShortName.def
+++ b/definitions/grib2/localConcepts/ecmf/chemShortName.def
@@ -1,155 +1,155 @@
 #Methane (chemistry)
 'CH4_c' = {
-	constituentType = 2 ;
 	localTablesVersion = 1 ;
+	constituentType = 2 ;
 	}
 #Volcanic sulphur dioxide
 'SO2_v' = {
-        constituentType = 65507 ;
-        localTablesVersion = 1 ;
-        }
+	localTablesVersion = 1 ;
+	constituentType = 65507 ;
+	}
 #Stratospheric ozone
 'O3S' = {
-	constituentType = 65524 ;
 	localTablesVersion = 1 ;
+	constituentType = 65524 ;
 	}
 #PAR budget corrector
 'rxpar' = {
-	constituentType = 65520 ;
 	localTablesVersion = 1 ;
+	constituentType = 65520 ;
 	}
 #NO to NO2 operator
 'xo2' = {
-	constituentType = 65521 ;
 	localTablesVersion = 1 ;
+	constituentType = 65521 ;
 	}
 #NO to alkyl nitrate operator
 'xo2n' = {
-	constituentType = 65522 ;
 	localTablesVersion = 1 ;
+	constituentType = 65522 ;
 	}
 #Polar stratospheric cloud
 'psc' = {
-	constituentType = 65516 ;
 	localTablesVersion = 1 ;
+	constituentType = 65516 ;
 	}
 #Methacrolein MVK
 'ISPD' = {
-	constituentType = 65523 ;
 	localTablesVersion = 1 ;
+	constituentType = 65523 ;
 	}
 #Acetone product
 'aco2' = {
-	constituentType = 65515 ;
 	localTablesVersion = 1 ;
+	constituentType = 65515 ;
 	}
 #HYPROPO2
 'hypropo2' = {
-	constituentType = 65519 ;
 	localTablesVersion = 1 ;
+	constituentType = 65519 ;
 	}
 #Nitrogen oxides Transp
 'noxa' = {
-	constituentType = 65514 ;
 	localTablesVersion = 1 ;
+	constituentType = 65514 ;
 	}
 #Carbon dioxide (chemistry)
 'CO2_c' = {
-	constituentType = 3 ;
 	localTablesVersion = 1 ;
+	constituentType = 3 ;
 	}
 #Nitrous oxide (chemistry)
 'N2O_c' = {
-	constituentType = 6 ;
 	localTablesVersion = 1 ;
+	constituentType = 6 ;
 	}
 #Water vapour (chemistry)
 'H2O_c' = {
-	constituentType = 1 ;
 	localTablesVersion = 1 ;
+	constituentType = 1 ;
 	}
 #Toluene and less reactive aromatics
 'tol' = {
-	constituentType = 65529 ;
 	localTablesVersion = 1 ;
+	constituentType = 65529 ;
 	}
 #Xylene and more reactive aromatics
 'xyl' = {
-	constituentType = 65530 ;
 	localTablesVersion = 1 ;
+	constituentType = 65530 ;
 	}
 #Lumped alkenes
 'BIGENE' = {
+	localTablesVersion = 1 ;
 	constituentType = 60010 ;
-	localTablesVersion = 2 ;
 	}
 #Lumped alkanes
 'BIGALK' = {
+	localTablesVersion = 1 ;
 	constituentType = 60009 ;
-	localTablesVersion = 2 ;
 	}
 #Hydrogen atom
 'h_c' = {
-	constituentType = 65513 ;
 	localTablesVersion = 1 ;
+	constituentType = 65513 ;
 	}
 #Condensable gas type 1
 'sog1' = {
-	constituentType = 65526 ;
 	localTablesVersion = 1 ;
+	constituentType = 65526 ;
 	}
 #Condensable gas type 2a
 'sog2a' = {
-	constituentType = 65527 ;
 	localTablesVersion = 1 ;
+	constituentType = 65527 ;
 	}
 #Condensable gas type 2b
 'sog2b' = {
-	constituentType = 65528 ;
 	localTablesVersion = 1 ;
+	constituentType = 65528 ;
 	}
 #Asymmetric chlorine dioxide radical
 'cloo' = {
-	constituentType = 65518 ;
 	localTablesVersion = 1 ;
+	constituentType = 65518 ;
 	}
 #GEMS ozone
 'gO3' = {
-	constituentType = 0 ;
 	localTablesVersion = 1 ;
+	constituentType = 0 ;
 	}
 #Stratospheric aerosol
 'strataer' = {
-	constituentType = 65517 ;
 	localTablesVersion = 1 ;
+	constituentType = 65517 ;
 	}
 #Biogenic secondary organic aerosol precursor
 'aer_biosecorg_pre' = {
-	constituentType = 65511 ;
 	localTablesVersion = 1 ;
+	constituentType = 65511 ;
 	}
 #Anthropogenic secondary organic aerosol precursor
 'aer_antsecorg_pre' = {
-	constituentType = 65512 ;
 	localTablesVersion = 1 ;
+	constituentType = 65512 ;
 	}
 #SO2 precursor
 'aer_so2_pre' = {
-	constituentType = 65510 ;
 	localTablesVersion = 1 ;
+	constituentType = 65510 ;
 	}
 #Aerosol small mode
 'aer_sm' = {
-	constituentType = 65508 ;
 	localTablesVersion = 1 ;
+	constituentType = 65508 ;
 	}
 #Aerosol large mode
 'aer_lm' = {
-	constituentType = 65509 ;
 	localTablesVersion = 1 ;
+	constituentType = 65509 ;
 	}
-#Volcanic sulphate
+#Volcanic Sulphate
 'SO4_v' = {
+	localTablesVersion = 1 ;
 	constituentType = 65506 ;
-        localTablesVersion = 1 ;
-        }
+	}


### PR DESCRIPTION
The chemIds were manually added to ecCodes, but they are also stored in the parameter database. This branch includes a script, definitions/create_chemdefs.py, to create the chem definitions in a similar way as the normal parameter definitions. It takes the row o from the attributes table to sort the keys.

The order of the keys in the chem concepts therefore changes for some entries.

Please merge this change into develop.