### PR TITLE
ECC-2184: additional stat types for accumulations

### DIFF
--- a/definitions/grib2/stattypeConcept.def
+++ b/definitions/grib2/stattypeConcept.def
@@ -198,6 +198,11 @@
 ## Daily STATTYPES with 1 or 2 time loops ##
 ############################################
 # Mean - 24 hours
+'daac' = {true = is_one_of(numberOfTimeRanges,1,2) ;
+          true = (element(lengthOfTimeRange,0) == 24) ;
+          true = (element(indicatorOfUnitForTimeRange,0) == 1) ;
+          true = (element(typeOfStatisticalProcessing,0) == 1) ; }
+# Mean - 24 hours
 'daav' = {true = is_one_of(numberOfTimeRanges,1,2) ;
           true = (element(lengthOfTimeRange,0) == 24) ;
           true = (element(indicatorOfUnitForTimeRange,0) == 1) ;

--- a/definitions/grib2/timespanConcept.def
+++ b/definitions/grib2/timespanConcept.def
@@ -91,8 +91,10 @@
  # hourly rolling accumulations and we don't want to have the first in a different bucket
  ## since start accumulation must have forecastTime=0
  # specific rules are in the centre's own definitions
- # fromstart for minutes / hourly / day
- 'fromstart'    = {typeOfStatisticalProcessing=1; forecastTime=0; true=is_one_of(indicatorOfUnitForTimeRange,0,1,2);}
+ # minutes / hours / day / seconds
+ 'fromstart'    = {typeOfStatisticalProcessing=1; forecastTime=0; true=is_one_of(indicatorOfUnitForTimeRange,0,1,2,13); numberOfTimeRanges=1;}
+ 'none' = {typeOfStatisticalProcessing=1; forecastTime=0; stattype="daac"; numberOfTimeRanges=1;}
+ '1h' = {typeOfStatisticalProcessing=1; forecastTime=0; stattype="daac"; numberOfTimeRanges=2; indicatorOfUnitForTimeRange=1; lengthOfTimeRange = 1;}
  ### end Accumulations ###
  #
  ### mean/min/max/stdev ###


### PR DESCRIPTION
### Description
This PR includes additional stattypes for the ERA6 statistics as they were tested on the MTG2sc infrastructure.
They were originally added to the feature/mtg2_merge branch to make them available for the tests, and they are now needed in the 2.44.2 hotfix to make them available in marser.

See https://jira.ecmwf.int/browse/ECC-2184

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 