### PR TITLE
ECC-2196: o2d / sfc in ERA6 for isothermal parameters

### DIFF
--- a/definitions/grib2/localConcepts/era6/marsLevtypeConcept.def
+++ b/definitions/grib2/localConcepts/era6/marsLevtypeConcept.def
@@ -7,9 +7,8 @@
 'sfc' = {typeOfFirstFixedSurface=8; typeOfSecondFixedSurface=255;}
 'sfc' = {typeOfFirstFixedSurface=17; typeOfSecondFixedSurface=255;}
 'sfc' = {typeOfFirstFixedSurface=18; typeOfSecondFixedSurface=255;}
-'o2d' = {typeOfFirstFixedSurface=20; scaleFactorOfFirstFixedSurface=-2;
-         scaledValueOfFirstFixedSurface=29315; typeOfSecondFixedSurface=255;}
-'o2d' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'o2d' = {discipline=10; typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'sfc' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=255;}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=100;}
 'sfc' = {typeOfFirstFixedSurface=1; typeOfSecondFixedSurface=100;


### PR DESCRIPTION
### Description
ECC-2194: In the ecCodes definitions/grib2/localConcepts/era6/marsLevTypeConcept.def
the following is defined for typeOfFirstFixedSurface=20, isotherms:
'o2d' =
{typeOfFirstFixedSurface=20; scaleFactorOfFirstFixedSurface=-2;          scaledValueOfFirstFixedSurface=29315; typeOfSecondFixedSurface=255;}
'o2d' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
The parameter [Geometric height of 0 degrees C atmospheric isothermal level above ground](https://codes.ecmwf.int/grib/param-db/228024) is an isotherm parameter in the atmosphere which should get levtype=sfc assigned.
Please adapt the marsLevTypeConcept.def in ERA6 to
'o2d' = {discipline=10; typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
'sfc' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
Discipline=10 contains all the ocean parameters. This means that all ocean parameters go into levtype o2d, the rest into sfc.

Please merge to develop to be added to 2.45.1.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 