### PR TITLE
ECC-2197: unalias level from mars namespace for abstractSingleLevel

### DIFF
--- a/definitions/mars/grib.elda.an.def
+++ b/definitions/mars/grib.elda.an.def
@@ -1,2 +1,7 @@
 alias mars.anoffset=offsetToEndOf4DvarWindow;
 alias mars.number=perturbationNumber;
+
+if (typeOfLevel is "abstractSingleLevel"){
+ unalias mars.levelist;
+}
+

--- a/definitions/mars/grib.elda.fc.def
+++ b/definitions/mars/grib.elda.fc.def
@@ -1,2 +1,7 @@
 alias mars.anoffset=offsetToEndOf4DvarWindow;
 alias mars.number=perturbationNumber;
+
+if (typeOfLevel is "abstractSingleLevel"){
+ unalias mars.levelist;
+}
+


### PR DESCRIPTION
### Description
ECC-2197: For SPP, a random pattern is used on each model level, but currently the random pattern is the same for each level, but multiplied by a level dependent factor.

An extension of this approach would be to have for each model level a separate random pattern.

These two applications are implemented in the typeOfLevel concept in ecCodes via the abstractSingleLevel and abstractMultipleLevels.

abstractSingleLevel is used for the single random pattern, so in MARS we do not need a level for it. abstractMultipleLevels needs instead a level in the mars namespace.

Therefore this PR unaliases the mars.levelist for stream elda type an and fc:
if (typeOfLevel is "abstractSingleLevel")
{  unalias mars.levelist; }

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 