### PR TITLE
ECC-2200: aifs-ens-crps-v2 added

### DIFF
--- a/definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-ens.def
+++ b/definitions/grib2/localConcepts/ecmf/modelVersionConcept.aifs-ens.def
@@ -1,1 +1,3 @@
 'aifs-ens-crps-v1' = { generatingProcessIdentifier = 1; }
+'aifs-ens-crps-v2' = { generatingProcessIdentifier = 2; }
+


### PR DESCRIPTION
### Description
ECC-2200: For AIFS-ens, the following version is needed: aifs-ens-crps-v2

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 