### PR TITLE
ECC-2204: Support of static linking of libaec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ ecbuild_add_option( FEATURE NETCDF
     NO_TPL )
 
 ecbuild_add_option( FEATURE USE_SHARED_LIB_AEC
-    DESCRIPTION "Link statically against libaec"
+    DESCRIPTION "Link against shared libaec library (dynamic linking)"
     DEFAULT ON )
 
 if ( ENABLE_USE_SHARED_LIB_AEC )


### PR DESCRIPTION
### Description
This PR introduces a new CMake option, USE_SHARED_LIB_AEC, that allows you to select between static and shared linking for libaec.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 