### PR TITLE
ECC-2205: derived forecast templates for chemical constituents and wave period …

### DIFF
--- a/definitions/grib2/templates/template.4.160.def
+++ b/definitions/grib2/templates/template.4.160.def
@@ -1,0 +1,11 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.160, Derived forecasts based on all ensemble members at a horizontal level or in a horizontal layer at a point in time for waves selected by period range
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.wave_period_range.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.point_in_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.lderived.def"

--- a/definitions/grib2/templates/template.4.161.def
+++ b/definitions/grib2/templates/template.4.161.def
@@ -1,0 +1,11 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.161, Derived forecasts based on all ensemble members at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval for waves selected by period range
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.wave_period_range.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.lderived.def"
+include "grib2/templates/template.4.statistical.def"

--- a/definitions/grib2/templates/template.4.166.def
+++ b/definitions/grib2/templates/template.4.166.def
@@ -1,0 +1,11 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.166, Derived forecasts based on all ensemble members at a horizontal level or in a horizontal layer at a point in time for atmospheric chemical constituents
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.chemical.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.point_in_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.lderived.def"

--- a/definitions/grib2/templates/template.4.167.def
+++ b/definitions/grib2/templates/template.4.167.def
@@ -1,0 +1,11 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.167, Derived forecasts based on all ensemble members at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval for atmospheric chemical constituents
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.chemical.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.lderived.def"
+include "grib2/templates/template.4.statistical.def"


### PR DESCRIPTION
…dependent parameters

### Description
ECC-2205: This PR includes 4 templates validated in the FT2026-1 WMO Fast-track to encode derived forecast products like ensemble mean for parameters with a constituentType and for Significant wave heights within a specific wave period.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 