### PR TITLE
ECC-2206: Fix PLPresent problem for wave spectra elda - an and fc

### DIFF
--- a/definitions/mars/grib.elda.an.def
+++ b/definitions/mars/grib.elda.an.def
@@ -1,7 +1,7 @@
 alias mars.anoffset=offsetToEndOf4DvarWindow;
 alias mars.number=perturbationNumber;
 
-if (typeOfLevel is "abstractSingleLevel"){
+if (defined(typeOfLevel) and typeOfLevel is "abstractSingleLevel"){
  unalias mars.levelist;
 }
 

--- a/definitions/mars/grib.elda.fc.def
+++ b/definitions/mars/grib.elda.fc.def
@@ -1,7 +1,7 @@
 alias mars.anoffset=offsetToEndOf4DvarWindow;
 alias mars.number=perturbationNumber;
 
-if (typeOfLevel is "abstractSingleLevel"){
+if (defined(typeOfLevel) and typeOfLevel is "abstractSingleLevel"){
  unalias mars.levelist;
 }
 


### PR DESCRIPTION
### Description
ECC-2206: There is a problem with 2.45.1 trying to get the value of PLPresent from GRIB2 data with wave spectra templates 99-102 if they are labelled as stream elda with types an or fc.

Checking if the typeOfLevel is defined before checking its value in definitions/mars/grib.elda.{an,fc}.def solves the issue. if (**defined(typeOfLevel) and** typeOfLevel is "abstractSingleLevel"){

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 