### PR TITLE
ECC-2212: Feature/flight level

### DIFF
--- a/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
@@ -6,5 +6,5 @@
 'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=5;}
 'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=6;}
 'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=7;}
-'fl'  = {typeOfFirstFixedSurface=193;}
+'fl'   = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'sfc'  = {typeOfFirstFixedSurface=254;}

--- a/definitions/grib2/localConcepts/ecmf/typeOfLevelConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/typeOfLevelConcept.def
@@ -1,2 +1,3 @@
 # Concept typeOfLevel
+'flightLevel' = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'abstractLevel' = {typeOfFirstFixedSurface=254;}

--- a/definitions/grib2/tables/local/ecmf/1/4.5.table
+++ b/definitions/grib2/tables/local/ecmf/1/4.5.table
@@ -1,3 +1,3 @@
 173 173 Top surface of snow, over ice, on sea, lake or river
-193 193 Flight level
+193 193 Flight level (ft)
 254 254 Abstract level with no vertical localization or meaning

--- a/definitions/grib2/typeOfLevelConcept.def
+++ b/definitions/grib2/typeOfLevelConcept.def
@@ -192,6 +192,4 @@
 'abstractSingleLevel' = {typeOfFirstFixedSurface=191; scaleFactorOfFirstFixedSurface=missing(); scaledValueOfFirstFixedSurface=missing(); }
 'abstractMultipleLevels' = {typeOfFirstFixedSurface=191;}
 
-'flightLevel' = {typeOfFirstFixedSurface=193;}
-
 'unknown'        = {dummyc=1;}


### PR DESCRIPTION
### Description
ECC-2212: This PR contains a new typeOfLevel with a local table reference for flight levels and a new mars levtype fl.
These changes were discussed in the ADR-002 process and the extension of the mars language regarding the flight levels are already part of the latest metkit release.

Please merge this branch into develop.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 