### PR TITLE
ECC-2217: templates 4.156-4.159, no no_copy wave period templates, timespan for…

### DIFF
--- a/definitions/grib2/templates/template.4.156.def
+++ b/definitions/grib2/templates/template.4.156.def
@@ -1,0 +1,12 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.156, Average, accumulation, extreme values or other statistically processed values at a horizontal layer in a continuous or non-continuous time interval for optical properties of aerosol
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.aerosol.def"
+include "grib2/templates/template.4.aerosol_size.def"
+include "grib2/templates/template.4.optical.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.statistical.def"

--- a/definitions/grib2/templates/template.4.157.def
+++ b/definitions/grib2/templates/template.4.157.def
@@ -1,0 +1,13 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.157, Individual ensemble forecast  control and perturbed  at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval for optical properties of aerosol
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.aerosol.def"
+include "grib2/templates/template.4.aerosol_size.def"
+include "grib2/templates/template.4.optical.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.leps.def"
+include "grib2/templates/template.4.statistical.def"

--- a/definitions/grib2/templates/template.4.158.def
+++ b/definitions/grib2/templates/template.4.158.def
@@ -1,0 +1,13 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.158, Average, accumulation, extreme values or other statistically processed values at a continuous or non-continuous time interval for optical properties of aerosol with source or sink
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.aerosol.def"
+include "grib2/templates/template.4.source.def"
+include "grib2/templates/template.4.aerosol_size.def"
+include "grib2/templates/template.4.optical.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.statistical.def"

--- a/definitions/grib2/templates/template.4.159.def
+++ b/definitions/grib2/templates/template.4.159.def
@@ -1,0 +1,14 @@
+# (C) Copyright 2005- ECMWF.
+
+# TEMPLATE 4.159, Individual ensemble forecast  control and perturbed  at a horizontal level or in a horizontal layer in a continuous or non-continuous time interval for optical properties of aerosol with source or sink
+
+include "grib2/templates/template.4.parameter.def"
+include "grib2/templates/template.4.aerosol.def"
+include "grib2/templates/template.4.source.def"
+include "grib2/templates/template.4.aerosol_size.def"
+include "grib2/templates/template.4.optical.def"
+include "grib2/templates/template.4.generating_process.def"
+include "grib2/templates/template.4.forecast_time.def"
+include "grib2/templates/template.4.horizontal.def"
+include "grib2/templates/template.4.leps.def"
+include "grib2/templates/template.4.statistical.def"

--- a/definitions/grib2/templates/template.4.wave_period_range.def
+++ b/definitions/grib2/templates/template.4.wave_period_range.def
@@ -2,7 +2,7 @@
 # Template for wave parameters defined on a certain period range
 
 #  Type of period interval
-codetable[1] typeOfWavePeriodInterval ('4.91.table',masterDir,localDir) = 255 : dump,no_copy,edition_specific,string_type;
+codetable[1] typeOfWavePeriodInterval ('4.91.table',masterDir,localDir) = 255 : dump,edition_specific,string_type;
 
 signed[1] scaleFactorOfLowerWavePeriodLimit = missing() : can_be_missing,dump;
 unsigned[4] scaledValueOfLowerWavePeriodLimit = missing() : can_be_missing,dump;

--- a/definitions/grib2/timespanConcept.def
+++ b/definitions/grib2/timespanConcept.def
@@ -77,6 +77,8 @@
  'none' = {productDefinitionTemplateNumber=150;}
  'none' = {productDefinitionTemplateNumber=152;}
  'none'	= {productDefinitionTemplateNumber=154;}
+ 'none' = {productDefinitionTemplateNumber=160;}
+ 'none' = {productDefinitionTemplateNumber=166;}
  'none' = {productDefinitionTemplateNumber=254;}
  'none' = {productDefinitionTemplateNumber=1000;}
  'none' = {productDefinitionTemplateNumber=1002;}


### PR DESCRIPTION
### Description
ECC-2217: This branch contains new section 4 templates (4.156-159) from FT2026-1. It also fixes missing timespan entries for the templates 4.160 and 4.166 added with ECC-2205. The four templates added to this branch are all time-statistical templates, so they do not need a timespan entry as timespan is derived for those from the keys describing the temporal processing. 

Also a no_copy entry for the key typeOfWavePeriodInterval in the template.4.wave_period_range.def sub-template is removed.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 