### PR TITLE
ECC-2238: Case-agnostic copying of Fortran module files

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -76,15 +76,6 @@ if( HAVE_FORTRAN )
                                          $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
                          PRIVATE_LIBS    eccodes ${ECCODES_PTHREADS_LIBRARIES} )
 
-    if( DEFINED ecbuild_VERSION AND NOT ${ecbuild_VERSION} VERSION_LESS 3.1 )
-        # Installed module directory is not in the PUBLIC INCLUDES!
-        target_include_directories( eccodes_f90 PUBLIC $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}> )
-
-        # NOTE: When eccodes accepts ecbuild 3.0 as minimum requirement,
-        # this should instead be written inside the ecbuild_add_library macro with:
-        #    PUBLIC_INCLUDES $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
-    endif()
-
     set(_eccodes_mod_candidates eccodes.mod ECCODES.mod grib_api.mod GRIB_API.mod)
 
     file( GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/eccodes_f90_copy_mod.cmake


### PR DESCRIPTION
### Description

CCE 18 and 19 have incurred a bug with the `-ef` option, preventing it's use. As a consequence, we have to build without this option when using these compilers, which leads to upper-case .mod file names (GRIB_API.mod and ECCODES.mod). This makes the copy of these mod files more flexible to support both cases.

I still need to test that this works reliably also with other compilers and in the install step, thus keeping this in draft state for now.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 