### PR TITLE
ECC-2254: GRIB: Add DestinE local section with tilescheme key

### DIFF
--- a/definitions/grib2/destineLocalVersion.table
+++ b/definitions/grib2/destineLocalVersion.table
@@ -1,1 +1,2 @@
 1 1 MARS labeling
+2 2 Land surface tile data with tilescheme key

--- a/definitions/grib2/destine_tilescheme.table
+++ b/definitions/grib2/destine_tilescheme.table
@@ -1,0 +1,4 @@
+0 unknown unknown
+1 simple Simple tile scheme configuration with most-grouped tiles
+2 granular Granular tile scheme configuration with most-separated tile groupings
+65535 65535 Missing

--- a/definitions/grib2/local.destine.2.def
+++ b/definitions/grib2/local.destine.2.def
@@ -1,0 +1,12 @@
+# DestinE MARS layout
+# Local definition 2: Land surface tile data with tilescheme key
+
+# Base keywords for all datasets
+include "grib2/local.destine.base.def"
+
+# Keywords based on dataset
+template_nofail datasetTemplate "grib2/local.destine.[dataset:s].def";
+
+# Add tilescheme key
+codetable[2] tilescheme "grib2/destine_tilescheme.table" : dump;
+alias mars.tilescheme = tilescheme;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,6 +189,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-2240
         grib_ecc-2242
         grib_ecc-2248
+        grib_ecc-2254
     )
 
     # These tests require data downloads

--- a/tests/grib_ecc-2254.sh
+++ b/tests/grib_ecc-2254.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+# ECC-2254: Destination Earth tile metadata support
+
+label="grib_destine_tilescheme_test"
+temp_grib_a=temp.$label.a.grib
+temp_grib_b=temp.$label.b.grib
+destine_sample=temp.$label.destine.grib
+sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
+
+tablesVersionLatest=$( ${tools_dir}/grib_get -p tablesVersionLatest $sample_grib2 )
+
+# Setup Destine pseudo-centre GRIB message
+# !!!!!!
+# This ensures the dataset key is created which is needed for subsequent logic based on its value
+# !!!!!!
+# First latest tables version and add local section with MARS labeling
+${tools_dir}/grib_set -s tablesVersion=$tablesVersionLatest,setLocalDefinition=1,grib2LocalSectionNumber=1 $sample_grib2 $temp_grib_a
+
+# Then change to processed data = 12 --> DestinE and destineLocalVersion=2 --> DestinE tile metadata
+${tools_dir}/grib_set -s productionStatusOfProcessedData=12,class=d1,destineLocalVersion=2 $temp_grib_a $destine_sample
+
+# Check DestinE base related keys are present and correct
+grib_check_key_exists $destine_sample destineLocalVersion,dataset,marsClass,marsType,marsStream,experimentVersionNumber
+grib_check_key_equals $destine_sample "marsClass,dataset,destineLocalVersion" "d1 0 2"
+
+# Check setting dataset to on-demand-extremes-dt (4). Check keys are present and equal defaults
+${tools_dir}/grib_set -s dataset=4 $destine_sample $temp_grib_a
+
+grib_check_key_exists $temp_grib_a dataset,georef,model,tilescheme
+grib_check_key_equals $temp_grib_a "dataset,dataset:s,georef,mars.georef,model,mars.model,tilescheme,mars.tilescheme" "4 on-demand-extremes-dt s0000000 s0000000 IFS IFS 0 0"
+
+# Clean up
+rm -f $temp_grib_a $temp_grib_b $destine_sample

--- a/tests/grib_ecc-2254.sh
+++ b/tests/grib_ecc-2254.sh
@@ -14,7 +14,6 @@
 
 label="grib_destine_tilescheme_test"
 temp_grib_a=temp.$label.a.grib
-temp_grib_b=temp.$label.b.grib
 destine_sample=temp.$label.destine.grib
 sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
 
@@ -40,5 +39,12 @@ ${tools_dir}/grib_set -s dataset=4 $destine_sample $temp_grib_a
 grib_check_key_exists $temp_grib_a dataset,georef,model,tilescheme
 grib_check_key_equals $temp_grib_a "dataset,dataset:s,georef,mars.georef,model,mars.model,tilescheme,mars.tilescheme" "4 on-demand-extremes-dt s0000000 s0000000 IFS IFS 0 0"
 
+# Check an example where a few additional things are set in on-demand-extremes-dt
+${tools_dir}/grib_set -s dataset=4,productDefinitionTemplateNumber=113,tile=SEAO,tileattribute=AGG,tilescheme=simple $destine_sample $temp_grib_a
+
+grib_check_key_exists $temp_grib_a tile,tileattribute,tilescheme
+grib_check_key_equals $temp_grib_a "tile,mars.tile,tileattribute,mars.tileattribute,tilescheme:s,mars.tilescheme:s" "SEAO SEAO AGG AGG simple simple"
+
+
 # Clean up
-rm -f $temp_grib_a $temp_grib_b $destine_sample
+rm -f $temp_grib_a $destine_sample


### PR DESCRIPTION
### Description

Following the approval of the addition of the tilescheme key for DestinE data in codex MARS-006:
[MARS-006-Land-Surface-Tile-Data.md](https://github.com/ecmwf/codex/blob/main/MARS%20language/MARS-006-Land-Surface-Tile-Data.md)
I will add this key to a new destine local section with the simple and granular entries.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 