### PR TITLE
ECC-2256: Add ensemble median type

### DIFF
--- a/definitions/mars/type.table
+++ b/definitions/mars/type.table
@@ -76,3 +76,4 @@
 95 est Ensemble statistics
 96 mpp Model physics perturbations
 97 cpf Crossing-point forecast
+98 emdn Ensemble median


### PR DESCRIPTION
### Description

In addition to the pre-existing MARS type values "Ensemble mean" and "Ensemble spread" statistics, another possibility for an ensemble is to compute the "Ensemble median". This will be done by the DE330 on-demand use cases for the air quality multi-model ensemble.
To support this use case, we will add the type:
```
98 emdn Ensemble median
```
We will also add this to the paramdb with group code 4 - Derived probability products.
We will subsequently add this to metkit.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 