### PR TITLE
ECC-2259: Pass only unstructured grids to eckit

### DIFF
--- a/src/eccodes/geo/iterator/Iterator.cc
+++ b/src/eccodes/geo/iterator/Iterator.cc
@@ -163,20 +163,10 @@ static grib_iterator* grib_iterator_new_(const grib_handle* ch, unsigned long fl
     size_t gtlen = sizeof(gridType);
     err = grib_get_string(ch, "gridType", gridType, &gtlen);
     if (!err &&
-        STR_EQUAL(gridType, "unstructured_grid") ||
-        STR_EQUAL(gridType, "healpix") ||
-        STR_EQUAL(gridType, "regular_ll"))
+        (STR_EQUAL(gridType, "unstructured_grid") ||
+         STR_EQUAL(gridType, "healpix")))
     {
         do_process_with_eckit = true;
-
-        if (STR_EQUAL(gridType, "regular_ll")) {
-            long numberOfDataPoints = 0;
-            if (grib_get_long(ch, "numberOfDataPoints", &numberOfDataPoints) == GRIB_SUCCESS &&
-                numberOfDataPoints == 1)
-            {
-                do_process_with_eckit = false;
-            }
-        }
     }
 
     const int eckit_geo = ch->context->eckit_geo;  // check environment variable


### PR DESCRIPTION
### Description
This pull request updates the logic for selecting which grid types are processed with eckit in the `grib_iterator_new_` function. The main change is to only process `unstructured_grid` and `healpix` grid types with eckit, and to remove special handling for the `regular_ll` grid type.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 