### PR TITLE
ECC-2261: Feature/hydro anoffset

### DIFF
--- a/definitions/mars/grib.enfo.fu.def
+++ b/definitions/mars/grib.enfo.fu.def
@@ -1,5 +1,3 @@
-alias mars.anoffset=anoffset;
-
 if (grib2LocalSectionNumber == 44){
  alias mars.anoffset=offsetToStartOfForecastFillupInHours;
 }

--- a/definitions/mars/grib.enfo.fu.def
+++ b/definitions/mars/grib.enfo.fu.def
@@ -1,3 +1,5 @@
-if (grib2LocalSectionNumber == 44){
- alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+if (edition == 2) {
+ if (grib2LocalSectionNumber == 44){
+  alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+ }
 }

--- a/definitions/mars/grib.mmsf.fc.def
+++ b/definitions/mars/grib.mmsf.fc.def
@@ -13,7 +13,7 @@ if (class is "od" || class is "me" || class is "en" ||
 alias mars.number = perturbationNumber;
 alias mars.method = methodNumber;
 
-if (class isnot "gw") { # ECC-1448
+if (class isnot "gw" && class isnot "ef" && class isnot "gf" && class isnot "eh" && class isnot "gh") { # ECC-1448
     alias mars.origin = centre;
 }
 

--- a/definitions/mars/grib.oper.fu.def
+++ b/definitions/mars/grib.oper.fu.def
@@ -1,5 +1,8 @@
 alias mars.anoffset=anoffset;
 
-if (grib2LocalSectionNumber == 44){
- alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+if (edition == 2) {
+ if (grib2LocalSectionNumber == 44){
+  alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+ }
 }
+


### PR DESCRIPTION
### Description
This PR includes fixes for the hydrological data MARS namespace.

1. For the fill-up data in type fu, a new local section was created. The key which is aliased into the anoffset was renamed. Therefore it has to be aliased to offsetToStartOfForecastFillupInHours instead of anoffset.
2. For the seasonal data,  the mars forcing key is used to specify with which data the hydrological model was driven. The origin key has to be removed therefore.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 