### PR TITLE
ECC-2263: typeOfLevel abstractLevel with missing scaled values and scale factors

### DIFF
--- a/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/marsLevtypeConcept.def
@@ -7,4 +7,4 @@
 'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=6;}
 'o2d'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;gridDefinitionTemplateNumber=101;numberOfGridUsed=7;}
 'fl'   = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
-'sfc'  = {typeOfFirstFixedSurface=254;}
+'sfc'  = {typeOfFirstFixedSurface=254; typeOfSecondFixedSurface=255;}

--- a/definitions/grib2/localConcepts/ecmf/typeOfLevelConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/typeOfLevelConcept.def
@@ -1,3 +1,5 @@
 # Concept typeOfLevel
 'flightLevel' = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'abstractLevel' = {typeOfFirstFixedSurface=254; scaleFactorOfFirstFixedSurface=missing(); scaledValueOfFirstFixedSurface=missing();
+                   typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'abstractLevel' = {typeOfFirstFixedSurface=254;}

--- a/definitions/grib2/localConcepts/ecmf/typeOfLevelConcept.def
+++ b/definitions/grib2/localConcepts/ecmf/typeOfLevelConcept.def
@@ -2,4 +2,4 @@
 'flightLevel' = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'abstractLevel' = {typeOfFirstFixedSurface=254; scaleFactorOfFirstFixedSurface=missing(); scaledValueOfFirstFixedSurface=missing();
                    typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
-'abstractLevel' = {typeOfFirstFixedSurface=254;}
+'abstractLevel' = {typeOfFirstFixedSurface=254; typeOfSecondFixedSurface=255;}


### PR DESCRIPTION
### Description
The typeOfLevel abstractLevel with the local ECMWF code 254 for the typeOfFirstFixedSurface should have the corresponding scaled values and scale factors set to missing and the typeOfSecondFixedSurface also as missing.

For other typeOfLevel for which these keys make only sense as being missing, the typeOfLevel contains two concepts. The first entry for a grib_set which explicitly sets the keys to missing and a 2nd entry which allows also the decoding of messages where these keys were set to a value instead of set to missing.

'abstractLevel' = {typeOfFirstFixedSurface=254; scaleFactorOfFirstFixedSurface=missing(); scaledValueOfFirstFixedSurface=missing();typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing();scaledValueOfSecondFixedSurface=missing();}

This entry was added in front of the current abstractLevel entry in the definitions/grib2/localConcepts/ecmf/typeOfLevel.def.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
