### PR TITLE
ECC-2264: endStep with typeOfTimeIncrement 1 for ecPoint

### DIFF
--- a/definitions/mars/grib.oper.ppm.def
+++ b/definitions/mars/grib.oper.ppm.def
@@ -1,0 +1,14 @@
+if (edition == 2) {
+  if (MTG2Switch < 1) {
+    alias mars.step = stepRange;
+  } else {
+    alias mars.step = endStep;
+    alias mars.timespan = timespan;
+  }
+}
+# We need this because 'postProcessing' is defined later
+#meta ecpt_method sprintf("%s", postProcessing) : no_copy;
+#alias mars.method = ecpt_method;
+
+meta marsQuantile sprintf("%d:%d",quantileValue,totalNumberOfQuantiles);
+alias mars.quantile = marsQuantile;

--- a/src/eccodes/accessor/G2EndStep.cc
+++ b/src/eccodes/accessor/G2EndStep.cc
@@ -71,6 +71,22 @@ static bool is_special_expver(const grib_handle* h)
     return false;
 }
 
+static bool is_special_type(const grib_handle* h)
+{
+    char strMarsType[50] = {0,};
+    size_t slen = 50;
+    int ret = grib_get_string(h, "mars.type", strMarsType, &slen);
+    if (ret == GRIB_SUCCESS &&
+        (STR_EQUAL(strMarsType, "pfc")  ||  // pfc = Point values
+         STR_EQUAL(strMarsType, "ppm")  ||  // ppm = Point value metrics
+         STR_EQUAL(strMarsType, "gwt")  ||  // gwt = Weather types
+         STR_EQUAL(strMarsType, "gbf")))    // gbf = Bias-corrected gridbox
+    {
+        return true;  // Special case for ecPoint MARS types used in ERA5 with typeOfTimeIncrement=1
+    }
+    return false;
+}
+
 static int convert_time_range_long_(
     grib_handle* h,
     long stepUnits,                   /* step_units */
@@ -179,7 +195,7 @@ int G2EndStep::unpack_one_time_range_double_(double* val, size_t* len)
         /* See GRIB-488 & ECC-1734 */
         /* Note: For this case, lengthOfTimeRange is not related to step and should not be used to calculate step */
         add_time_range = 0;
-        if (is_special_expver(h)) {
+        if (is_special_expver(h) || is_special_type(h)) {
             add_time_range = 1;
         }
     }

--- a/src/eccodes/accessor/G2EndStep.cc
+++ b/src/eccodes/accessor/G2EndStep.cc
@@ -141,7 +141,7 @@ int G2EndStep::unpack_one_time_range_long_(long* val, size_t* len)
         /* See GRIB-488 & ECC-1734 */
         /* Note: For this case, lengthOfTimeRange is not related to step and should not be used to calculate step */
         add_time_range = 0;
-        if (is_special_expver(h)) {
+        if (is_special_expver(h) || is_special_type(h)) {
             add_time_range = 1;
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -190,6 +190,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-2242
         grib_ecc-2248
         grib_ecc-2254
+        grib_ecc-2264
     )
 
     # These tests require data downloads

--- a/tests/grib_ecc-2264.sh
+++ b/tests/grib_ecc-2264.sh
@@ -11,8 +11,8 @@
 . ./include.ctest.sh
 
 # ---------------------------------------------------------
-# This is the test for JIRA issue ECC-XXXX
-# < Add issue summary here >
+# This is the test for JIRA issue ECC-2264
+# Validate that step and endStep are encoded correctly for GRIB statistical processing and ecPoint-type cases
 # ---------------------------------------------------------
 
 REDIRECT=/dev/null

--- a/tests/grib_ecc-2264.sh
+++ b/tests/grib_ecc-2264.sh
@@ -39,7 +39,7 @@ set typeOfTimeIncrement=2;
 write;
 EOF
 ${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
-grib_check_key_equals $tempGrib step "0-24"
+grib_check_key_equals $tempGrib step,endStep "0-24 24"
 
 # here we also expect step=0-24 and endStep 24
 # should be fixed for ecPoint types only
@@ -57,7 +57,7 @@ set typeOfTimeIncrement=1;
 write;
 EOF
 ${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
-grib_check_key_equals $tempGrib step "0-24"
+grib_check_key_equals $tempGrib step,endStep "0-24 24"
 
 # ERA5 gbf
 cat >$tempFilt<<EOF
@@ -72,7 +72,7 @@ set typeOfTimeIncrement=1;
 write;
 EOF
 ${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
-grib_check_key_equals $tempGrib step "0-24"
+grib_check_key_equals $tempGrib step,endStep "0-24 24"
 
 # ERA5 pfc
 cat >$tempFilt<<EOF
@@ -87,7 +87,7 @@ set typeOfTimeIncrement=1;
 write;
 EOF
 ${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
-grib_check_key_equals $tempGrib step "0-24"
+grib_check_key_equals $tempGrib step,endStep "0-24 24"
 
 # ERA5 ppm
 cat >$tempFilt<<EOF
@@ -102,7 +102,7 @@ set typeOfTimeIncrement=1;
 write;
 EOF
 ${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
-grib_check_key_equals $tempGrib step "0-24"
+grib_check_key_equals $tempGrib step,endStep "0-24 24"
 
 # ERA5 fc
 cat >$tempFilt<<EOF

--- a/tests/grib_ecc-2264.sh
+++ b/tests/grib_ecc-2264.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+# ---------------------------------------------------------
+# This is the test for JIRA issue ECC-XXXX
+# < Add issue summary here >
+# ---------------------------------------------------------
+
+REDIRECT=/dev/null
+
+label=`basename $0 | sed -e 's/\.sh/_test/'`
+
+tempGrib=temp.$label.grib
+tempFilt=temp.$label.filt
+
+sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
+
+# here we expect step=0-24 and endStep 24
+# 50r1
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=36;
+set class='od';
+set type='gwt';
+set generatingProcessIdentifier=161;
+set productDefinitionTemplateNumber=8;
+set typeOfStatisticalProcessing=1;
+set lengthOfTimeRange=24;
+set typeOfTimeIncrement=2;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib step "0-24"
+
+# here we also expect step=0-24 and endStep 24
+# should be fixed for ecPoint types only
+
+# ERA5 gwt
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=35;
+set class='ea';
+set type='gwt';
+set productDefinitionTemplateNumber=8;
+set typeOfStatisticalProcessing=1;
+set lengthOfTimeRange=24;
+set typeOfTimeIncrement=1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib step "0-24"
+
+# ERA5 gbf
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=35;
+set class='ea';
+set type='gbf';
+set productDefinitionTemplateNumber=8;
+set typeOfStatisticalProcessing=1;
+set lengthOfTimeRange=24;
+set typeOfTimeIncrement=1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib step "0-24"
+
+# ERA5 pfc
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=35;
+set class='ea';
+set type='pfc';
+set productDefinitionTemplateNumber=8;
+set typeOfStatisticalProcessing=1;
+set lengthOfTimeRange=24;
+set typeOfTimeIncrement=1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib step "0-24"
+
+# ERA5 ppm
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=35;
+set class='ea';
+set type='ppm';
+set productDefinitionTemplateNumber=8;
+set typeOfStatisticalProcessing=1;
+set lengthOfTimeRange=24;
+set typeOfTimeIncrement=1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib step "0-24"
+
+# ERA5 fc
+cat >$tempFilt<<EOF
+set setLocalDefinition=1;
+set tablesVersion=35;
+set class='ea';
+set type='fc';
+set productDefinitionTemplateNumber=8;
+set typeOfStatisticalProcessing=1;
+set lengthOfTimeRange=24;
+set typeOfTimeIncrement=1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib step "0"
+
+# Clean up
+rm -f $tempGrib $tempFilt


### PR DESCRIPTION
### Description
In ERA5 ecPoint data, typeOfTimeIncrement is set to 1 as the 24 hour accumulations are combined from several forecasts.
The G2EndStep accessor deactivates the endStep calculation if typeOfTimeIncrement=1. The is already an exception for a special expver in the source code. In the same way, this PR is to add an exception for the ecPoint mars types used for ERA5.
These type are currently used only for ERA5, and if used later for other purposes, they will be Post-MTG2.
For Post-MTG2 data, the MTG2Switch mechanism allows for the endStep calculation also for typeOfTimeIncrement=1.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
