### PR TITLE
ECC-2265: forcing key for fire models

### DIFF
--- a/definitions/grib2/local/fire/section4_extras.def
+++ b/definitions/grib2/local/fire/section4_extras.def
@@ -13,8 +13,12 @@ if (modelName isnot "unknown") {
 concept inputModelName(unknown, "inputModelNameConcept.def", conceptsDir2, conceptsLocalDirAll): no_copy, dump;
 concept inputModelVersion(unknown, "inputModelVersionConcept.def", conceptsDir2, conceptsLocalDirAll): no_copy, dump;
 
-if (defined(typeOfPostProcessing) and typeOfPostProcessing != 10){
- meta forcingModel sprintf("%s",inputModelName);
+if (defined(typeOfPostProcessing) and typeOfPostProcessing == 11){
+ if ( inputModelName is "obs" ){
+     meta forcingModel sprintf("%s",inputModelName);
+   } else {
+     meta forcingModel sprintf("%s-%s",centre, inputModelName);
+ }
  alias mars.forcing = forcingModel;
  unalias mars.origin;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -190,6 +190,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-2242
         grib_ecc-2248
         grib_ecc-2254
+        grib_ecc-2265
     )
 
     # These tests require data downloads

--- a/tests/grib_ecc-2265.sh
+++ b/tests/grib_ecc-2265.sh
@@ -11,8 +11,8 @@
 . ./include.ctest.sh
 
 # ---------------------------------------------------------
-# This is the test for JIRA issue ECC-XXXX
-# < Add issue summary here >
+# This is the test for JIRA issue ECC-2265
+# Validate that the forcing key is derived as "ecmf-era5" for this GRIB2 setup
 # ---------------------------------------------------------
 
 REDIRECT=/dev/null

--- a/tests/grib_ecc-2265.sh
+++ b/tests/grib_ecc-2265.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+# ---------------------------------------------------------
+# This is the test for JIRA issue ECC-XXXX
+# < Add issue summary here >
+# ---------------------------------------------------------
+
+REDIRECT=/dev/null
+
+label=`basename $0 | sed -e 's/\.sh/_test/'`
+
+tempGrib=temp.$label.grib
+tempFilt=temp.$label.filt
+
+sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
+
+cat >$tempFilt<<EOF
+set productDefinitionTemplateNumber = 93;
+set inputOriginatingCentre = 98 ;
+set typeOfGeneratingProcess = 2 ;
+set setLocalDefinition=1;
+set grib2LocalSectionNumber = 1 ;
+set marsClass = 39 ;
+set marsType = 9 ;
+set marsStream = 1025 ;
+set experimentVersionNumber = 1;
+set typeOfPostProcessing = 11 ;
+set tablesVersion=35;
+set inputProcessIdentifier=65533;
+set backgroundProcess = 146;
+set generatingProcessIdentifier = 1;
+write;
+EOF
+${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
+grib_check_key_equals $tempGrib forcing "ecmf-era5"
+
+# Clean up
+rm -f $tempGrib $tempFilt


### PR DESCRIPTION
### Description
The mars key forcing was introduced for the hydrological data using centre-inputModelName. For the fire data it was implemented using the inputModelName only. To align it with the hydrological data layout, this PR is to change it also to centre-inputModelName.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
