### PR TITLE
ECC-2268: grib_compare -r does not reorder data correctly

### DIFF
--- a/definitions/grib2/section.0.def
+++ b/definitions/grib2/section.0.def
@@ -4,11 +4,13 @@ position offsetSection0;
 constant section0Length=16;
 ascii[4]     identifier    = "GRIB" : read_only;
 unsigned[2]  reserved      = missing() : can_be_missing,hidden,read_only,edition_specific;
+
+position startOfHeaders;  # Must come before discipline. See ECC-2268
+
 codetable[1] discipline    ('0.0.table',masterDir,localDir) : dump;
 unsigned[1]  editionNumber = 2 : edition_specific,dump;
 
 alias ls.edition = editionNumber;
 section_length[8] totalLength;
-position startOfHeaders;
 
 meta section0Pointer section_pointer(offsetSection0,section0Length,0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -340,6 +340,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-2137
         grib_ecc-2188
         grib_ecc-2230
+        grib_ecc-2268
         grib_modelName
         grib_sub_hourly
         grib_set_bytes

--- a/tests/grib_ecc-2268.sh
+++ b/tests/grib_ecc-2268.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+# ---------------------------------------------------------
+# This is the test for JIRA issue ECC-2268
+# grib_compare -r does not reorder data correctly
+# ---------------------------------------------------------
+
+REDIRECT=/dev/null
+
+label=`basename $0 | sed -e 's/\.sh/_test/'`
+
+tempGrib_34=temp.$label.34.grib
+tempGrib_134=temp.$label.134.grib
+tempGrib_34_134=temp.$label.34_134.grib
+tempGrib_134_34=temp.$label.134_34.grib
+
+sample_grib2=$ECCODES_SAMPLES_PATH/GRIB2.tmpl
+
+${tools_dir}/grib_set -s paramId=34  $sample_grib2 $tempGrib_34
+${tools_dir}/grib_set -s paramId=134 $sample_grib2 $tempGrib_134
+cat $tempGrib_34  $tempGrib_134 > $tempGrib_34_134
+cat $tempGrib_134 $tempGrib_34  > $tempGrib_134_34
+
+${tools_dir}/grib_compare -r $tempGrib_34_134 $tempGrib_134_34
+
+md5_34=$(  ${tools_dir}/grib_get -p md5Headers $tempGrib_34  )
+md5_134=$( ${tools_dir}/grib_get -p md5Headers $tempGrib_134 )
+if [ "$md5_34" == "$md5_134" ]; then
+    echo "Error: md5Headers should be different for paramId=34 and paramId=134"
+    echo "md5Headers for paramId=34:  $md5_34"
+    echo "md5Headers for paramId=134: $md5_134"
+    exit 1
+fi
+
+# Clean up
+rm -f $tempGrib_34 $tempGrib_134 $tempGrib_34_134 $tempGrib_134_34
+


### PR DESCRIPTION
### Description
See https://jira.ecmwf.int/browse/ECC-2268

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
