### PR TITLE
ECC-2269: missing paramtypes added to paramtypeConcept

### DIFF
--- a/definitions/grib2/paramtypeConcept.def
+++ b/definitions/grib2/paramtypeConcept.def
@@ -11,6 +11,7 @@
 'base' = {productDefinitionTemplateNumber=0;}
 'base' = {productDefinitionTemplateNumber=1;}
 'base' = {productDefinitionTemplateNumber=2;}
+'satellite' = {productDefinitionTemplateNumber=2; grib2LocalSectionNumber=37;}
 'base' = {productDefinitionTemplateNumber=3;}
 'base' = {productDefinitionTemplateNumber=4;}
 'base' = {productDefinitionTemplateNumber=5;}
@@ -21,6 +22,7 @@
 'base' = {productDefinitionTemplateNumber=10;}
 'base' = {productDefinitionTemplateNumber=11;}
 'base' = {productDefinitionTemplateNumber=12;}
+'satellite' = {productDefinitionTemplateNumber=2; grib2LocalSectionNumber=37;}
 'base' = {productDefinitionTemplateNumber=13;}
 'base' = {productDefinitionTemplateNumber=14;}
 'base' = {productDefinitionTemplateNumber=15;}
@@ -193,6 +195,23 @@
 'chemical' = {productDefinitionTemplateNumber=153;}
 'base' = {productDefinitionTemplateNumber=154;}
 'base' = {productDefinitionTemplateNumber=155;}
+'optical' = {productDefinitionTemplateNumber=156; MTG2Switch=1;}
+'chemical_optical' = {productDefinitionTemplateNumber=156; MTG2Switch=2;}
+'optical' = {productDefinitionTemplateNumber=157; MTG2Switch=1;}
+'chemical_optical' = {productDefinitionTemplateNumber=157; MTG2Switch=2;}
+'optical' = {productDefinitionTemplateNumber=158; MTG2Switch=1;}
+'chemical_optical' = {productDefinitionTemplateNumber=158; MTG2Switch=2;}
+'optical' = {productDefinitionTemplateNumber=159; MTG2Switch=1;}
+'chemical_optical' = {productDefinitionTemplateNumber=159; MTG2Switch=2;}
+'wave' = {productDefinitionTemplateNumber=160; MTG2Switch=1;}
+'wave' = {productDefinitionTemplateNumber=160; MTG2Switch=2;}
+'wave' = {productDefinitionTemplateNumber=161; MTG2Switch=1;}
+'wave' = {productDefinitionTemplateNumber=161; MTG2Switch=2;}
+# 162 - 165
+'base' = {productDefinitionTemplateNumber=166; MTG2Switch=1;}
+'chemical' = {productDefinitionTemplateNumber=166; MTG2Switch=2;}
+'base' = {productDefinitionTemplateNumber=167; MTG2Switch=1;}
+'chemical' = {productDefinitionTemplateNumber=167; MTG2Switch=2;}
 'base' = {productDefinitionTemplateNumber=254;}
 'base' = {productDefinitionTemplateNumber=311;}
 'base' = {productDefinitionTemplateNumber=1000;}


### PR DESCRIPTION
### Description
This PR is to add to the paramtype concept the paramtype satellite for the cases where a derived forecast template is used together with the grib2 local section 37. This means that the data have the MARS key channel which is the criteria for the paramtype satellite. Some section 4 templates from the WMO FT2026-1 were recently added. They needed also a paramtype definition. Please merge to develop and cherry-pick to hotfix/2.47.1.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
