### PR TITLE
Resolve naming conflict with MARS

### DIFF
--- a/src/eccodes/grib_api_internal.h
+++ b/src/eccodes/grib_api_internal.h
@@ -921,17 +921,17 @@ struct grib_math
     int arity;
 };
 
-typedef double (*mathproc)(void);
-typedef int (*funcproc)(grib_math*, mathproc);
+typedef double (*grib_mathproc)(void);
+typedef int (*grib_funcproc)(grib_math*, grib_mathproc);
 
-typedef struct func
+typedef struct grib_func
 {
     char* name;
-    funcproc addr;
-    mathproc proc;
+    grib_funcproc addr;
+    grib_mathproc proc;
     int arity;
     char* info;
-} func;
+} grib_func;
 
 /* action file */
 struct grib_action_file


### PR DESCRIPTION
### Description
This pull request refactors function pointer type and struct names in the `grib_math` logic to improve code clarity and consistency. The main updates involve renaming types and struct members to use a `grib_` prefix.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
