### PR TITLE
Improve encode performance for bitsPerValue when not a multiple of 8

### DIFF
--- a/src/eccodes/grib_bits_any_endian_omp.cc
+++ b/src/eccodes/grib_bits_any_endian_omp.cc
@@ -175,18 +175,73 @@ int grib_encode_double_array(size_t n_vals, const double* val, long bits_per_val
     unsigned char* encoded     = p;
     double x;
     if (bits_per_value % 8) {
-        for (i = 0; i < n_vals; i++) {
-            x            = (((val[i] * d) - reference_value) * divisor) + 0.5;
-            unsigned_val = (unsigned long)x;
-            grib_encode_unsigned_longb(encoded, unsigned_val, off, bits_per_value);
+        /* Non-byte-aligned case: bits_per_value is not a multiple of 8 (e.g. 10, 12, 14-bit).
+         *
+         * Accumulator-based encoding, adapted from wgrib2's add_many_bitstream().
+         *
+         * Use a shift-register accumulator (reg/rbits) that collects
+         * bits across value boundaries and flushes one full byte at a time.  For a
+         * 10-bit field the inner while-loop fires at most twice per value (writing
+         * 1-2 bytes), reducing work to ~1-2 byte writes per value regardless of
+         * bits_per_value.  This matches the throughput of the byte-aligned branch
+         * below and avoids the per-bit call overhead entirely.
+         *
+         * Note: bit-packing is a sequential operation (each value's bits depend on
+         * the accumulator state left by the previous value) so no OpenMP parallelism
+         * can be applied to this branch.
+         *
+         * Invariant: reg holds rbits valid bits in its least-significant positions.
+         * rbits is always in [0, 7] between loop iterations. */
+        unsigned long reg = 0;    /* bit accumulator; low rbits are valid */
+        int rbits = 0;            /* number of valid bits currently in reg */
+        const unsigned long jmask = (1UL << bits_per_value) - 1; /* mask for one packed value */
+
+        /* *off is a bit offset from p[].  Advance encoded to the byte that
+         * contains bit *off, then recover the already-written high bits of that
+         * partial byte into reg so we do not overwrite them. */
+        encoded += (*off >> 3);        /* byte index: bit-offset / 8 */
+        rbits = (int)(*off & 7);       /* bits already used in the current byte */
+        if (rbits) {
+            /* Preserve the rbits most-significant bits already written to *encoded.
+             * Shift them into the low end of reg so subsequent OR operations align. */
+            reg = (unsigned long)(*encoded) >> (8 - rbits);
         }
+
+        for (i = 0; i < n_vals; i++) {
+            /* Scale the floating-point value to a packed integer. */
+            x            = (((val[i] * d) - reference_value) * divisor) + 0.5;
+            unsigned_val = (unsigned long)x & jmask; /* clamp to bits_per_value bits */
+
+            /* Shift the new value into the accumulator. */
+            rbits += bits_per_value;
+            reg = (reg << bits_per_value) | unsigned_val;
+
+            /* Flush all complete bytes.  After the loop rbits is in [0, 7]. */
+            while (rbits >= 8) {
+                rbits -= 8;
+                *encoded++ = (unsigned char)((reg >> rbits) & 0xFF);
+            }
+        }
+
+        /* Flush the remaining partial byte, if any.  The valid bits are in the
+         * most-significant positions; pad the trailing bits with zeros. */
+        if (rbits) {
+            *encoded = (unsigned char)((reg << (8 - rbits)) & 0xFF);
+        }
+
+        /* Advance the caller's bit offset by the total number of bits written. */
+        *off += (long)n_vals * bits_per_value;
     }
     else {
+        /* Byte-aligned case: bits_per_value is a multiple of 8 (8, 16, 24, 32-bit).
+         * Each value occupies an integral number of bytes, so we can write them
+         * one byte at a time using simple right-shifts with no accumulator needed. */
         for (i = 0; i < n_vals; i++) {
             int blen     = 0;
             blen         = bits_per_value;
             x            = ((((val[i] * d) - reference_value) * divisor) + 0.5);
             unsigned_val = (unsigned long)x;
+            /* Write the most-significant byte first (big-endian), then the next, etc. */
             while (blen >= 8) {
                 blen -= 8;
                 *encoded = (unsigned_val >> blen);

--- a/src/eccodes/grib_bits_any_endian_simple.cc
+++ b/src/eccodes/grib_bits_any_endian_simple.cc
@@ -201,18 +201,69 @@ int grib_encode_double_array(size_t n_vals, const double* val, long bits_per_val
     unsigned char* encoded     = p;
     double x;
     if (bits_per_value % 8) {
-        for (i = 0; i < n_vals; i++) {
-            x            = (((val[i] * d) - reference_value) * divisor) + 0.5;
-            unsigned_val = (unsigned long)x;
-            grib_encode_unsigned_longb(encoded, unsigned_val, off, bits_per_value);
+        /* Non-byte-aligned case: bits_per_value is not a multiple of 8 (e.g. 10, 12, 14-bit).
+         *
+         * Accumulator-based encoding, adapted from wgrib2's add_many_bitstream().
+         *
+         * Use a shift-register accumulator (reg/rbits) that collects
+         * bits across value boundaries and flushes one full byte at a time.  For a
+         * 10-bit field the inner while-loop fires at most twice per value (writing
+         * 1-2 bytes), reducing work to ~1-2 byte writes per value regardless of
+         * bits_per_value.  This matches the throughput of the byte-aligned branch
+         * below and avoids the per-bit call overhead entirely.
+         *
+         * Invariant: reg holds rbits valid bits in its least-significant positions.
+         * rbits is always in [0, 7] between loop iterations. */
+        unsigned long reg = 0;    /* bit accumulator; low rbits are valid */
+        int rbits = 0;            /* number of valid bits currently in reg */
+        const unsigned long jmask = (1UL << bits_per_value) - 1; /* mask for one packed value */
+
+        /* *off is a bit offset from p[].  Advance encoded to the byte that
+         * contains bit *off, then recover the already-written high bits of that
+         * partial byte into reg so we do not overwrite them. */
+        encoded += (*off >> 3);        /* byte index: bit-offset / 8 */
+        rbits = (int)(*off & 7);       /* bits already used in the current byte */
+        if (rbits) {
+            /* Preserve the rbits most-significant bits already written to *encoded.
+             * Shift them into the low end of reg so subsequent OR operations align. */
+            reg = (unsigned long)(*encoded) >> (8 - rbits);
         }
+
+        for (i = 0; i < n_vals; i++) {
+            /* Scale the floating-point value to a packed integer. */
+            x            = (((val[i] * d) - reference_value) * divisor) + 0.5;
+            unsigned_val = (unsigned long)x & jmask; /* clamp to bits_per_value bits */
+
+            /* Shift the new value into the accumulator. */
+            rbits += bits_per_value;
+            reg = (reg << bits_per_value) | unsigned_val;
+
+            /* Flush all complete bytes.  After the loop rbits is in [0, 7]. */
+            while (rbits >= 8) {
+                rbits -= 8;
+                *encoded++ = (unsigned char)((reg >> rbits) & 0xFF);
+            }
+        }
+
+        /* Flush the remaining partial byte, if any.  The valid bits are in the
+         * most-significant positions; pad the trailing bits with zeros. */
+        if (rbits) {
+            *encoded = (unsigned char)((reg << (8 - rbits)) & 0xFF);
+        }
+
+        /* Advance the caller's bit offset by the total number of bits written. */
+        *off += (long)n_vals * bits_per_value;
     }
     else {
+        /* Byte-aligned case: bits_per_value is a multiple of 8 (8, 16, 24, 32-bit).
+         * Each value occupies an integral number of bytes, so we can write them
+         * one byte at a time using simple right-shifts with no accumulator needed. */
         for (i = 0; i < n_vals; i++) {
             int blen     = 0;
             blen         = bits_per_value;
             x            = ((((val[i] * d) - reference_value) * divisor) + 0.5);
             unsigned_val = (unsigned long)x;
+            /* Write the most-significant byte first (big-endian), then the next, etc. */
             while (blen >= 8) {
                 blen -= 8;
                 *encoded = (unsigned_val >> blen);


### PR DESCRIPTION
### Description

This change moves to an accumulator-based encoding approach, adapted from wgrib2's add_many_bitstream(). The original approach called grib_encode_unsigned_longb() once per value, which writes one bit at a time in a loop: O(bits_per_value) function calls per value.  For a 10-bit field with 1 M values that is ~10 M individual bit-set calls, each touching the same byte multiple times.

Instead, we use a shift-register accumulator (reg/rbits) that collects bits across value boundaries and flushes one full byte at a time.  For a 10-bit field the inner while-loop fires at most twice per value (writing 1-2 bytes), reducing work to ~1-2 byte writes per value regardless of bits_per_value.  This matches the throughput of the byte-aligned branch below and avoids the per-bit call overhead entirely.

I have tested this using a combination of data

1. ECMWF data with mixed grib1 and grib2 format and a range of existing bits per value, some with bitmaps and some without. 1100 messages existed in the dataset
2. A message with constant values (5.5) 
3. A message with a linear ramp of data increasing across longitudes from -249.3 to 249.3
4. A message with a linear ramp of data increasing across latitudes from -99 to 99
5. A message with a random range of values from approx -2.4e7 to 2.4e7
6. A range of bitsPerValue=1 to bitsPerValue=32

Performance gains for 1100 messages shows remarkable speedup. Some examples are below.

bitsPerValue | 2.46.0 | Patched
-- | -- | --
1 | 3.62 | 3.87
2 | 4.24 | 2.29
3 | 4.94 | 2.36
4 | 5.73 | 2.46
5 | 6.48 | 2.51
6 | 7.4 | 2.56
7 | 8.56 | 3.26
8 | 2.38 | 2.37
9 | 11.17 | 2.7
10 | 12.54 | 2.74
11 | 13.79 | 2.78
12 | 15.17 | 2.81
13 | 16.98 | 3.27
14 | 17.96 | 3.34
15 | 19.14 | 3.38
16 | 3.49 | 3.33
17 | 22.18 | 4.52
18 | 22.76 | 4.57
19 | 23.53 | 4.62
20 | 24.61 | 4.65
21 | 25.4 | 4.95
22 | 25.88 | 4.98
23 | 26.78 | 4.99
24 | 5.12 | 5.01
25 | 28.29 | 5.09
26 | 29.03 | 5.18
27 | 29.77 | 5.28
28 | 30.68 | 5.32
29 | 31.53 | 5.48
30 | 32.32 | 5.44
31 | 33.1 | 7.72
32 | 5.72 | 7.12

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
