### PR TITLE
Incorrect missing value handling when converting geopotential height (gh) to geopotential (z) in GRIB files

### DIFF
--- a/src/eccodes/accessor/DataG22OrderPacking.cc
+++ b/src/eccodes/accessor/DataG22OrderPacking.cc
@@ -48,16 +48,6 @@ void DataG22OrderPacking::init(const long v, grib_arguments* args)
 
 #define ONES (~(int)0)
 
-// #define UNDEFINED 9.999e20
-// #define UNDEFINED_LOW 9.9989e20
-// #define UNDEFINED_HIGH 9.9991e20
-#define UNDEFINED        9999.0
-#define UNDEFINED_LOW    9998.9
-#define UNDEFINED_HIGH   9999.1
-#define UNDEFINED_VAL(x) ((x) >= UNDEFINED_LOW && (x) <= UNDEFINED_HIGH)
-#define DEFINED_VAL(x)   ((x) < UNDEFINED_LOW || (x) > UNDEFINED_HIGH)
-#define UNDEFINED_ANGLE  999.0
-
 struct bitstream_context
 {
     unsigned char* bitstream;
@@ -192,7 +182,7 @@ static double Int_Power(double x, int y)
     return value;
 }
 
-static int min_max_array(double* data, unsigned int n, double* min, double* max)
+static int min_max_array(double* data, unsigned int n, double* min, double* max, double missingValue)
 {
     unsigned int first;
     double mn, mx;
@@ -203,7 +193,7 @@ static int min_max_array(double* data, unsigned int n, double* min, double* max)
     }
 
     for (first = 0; first < n; first++) {
-        if (DEFINED_VAL(data[first])) break;
+        if (data[first] != missingValue) break;
     }
     if (first >= n) {
         *min = *max = 0.0;
@@ -218,7 +208,7 @@ static int min_max_array(double* data, unsigned int n, double* min, double* max)
         min_val = max_val = data[first];
 
         for (unsigned int i = first + 1; i < n; i++) {
-            if (DEFINED_VAL(data[i])) {
+            if (data[i] != missingValue) {
                 min_val = (min_val > data[i]) ? data[i] : min_val;
                 max_val = (max_val < data[i]) ? data[i] : max_val;
             }
@@ -818,6 +808,10 @@ int DataG22OrderPacking::pack_double(const double* val, size_t* len)
         bits_per_value = 23;
     }
 
+    double missingValue = 0;
+    if ((err = grib_get_double_internal(gh, "missingValue", &missingValue)) != GRIB_SUCCESS)
+        return err;
+
     if ((err = grib_get_long_internal(gh, decimal_scale_factor_, &decimal_scale_factor)) != GRIB_SUCCESS)
         return err;
 
@@ -878,7 +872,7 @@ int DataG22OrderPacking::pack_double(const double* val, size_t* len)
     wanted_bits = bits_per_value;
 
     for (i = 0; i < *len; i++) {
-        if (DEFINED_VAL(val[i])) {
+        if (val[i] != missingValue) {
             ndef = ndef + 1;
         }
     }
@@ -958,7 +952,7 @@ int DataG22OrderPacking::pack_double(const double* val, size_t* len)
         grib_context_log(context_, GRIB_LOG_ERROR, "%s packing: unable to allocate %zu bytes", accessor_type().c_str(), nndata * sizeof(int));
         return GRIB_OUT_OF_MEMORY;
     }
-    if (min_max_array(data, ndata, &mn, &mx) != GRIB_SUCCESS) {
+    if (min_max_array(data, ndata, &mn, &mx, missingValue) != GRIB_SUCCESS) {
         grib_context_log(context_, GRIB_LOG_ERROR, "%s packing: failed to get min max of data", accessor_type().c_str());
         return GRIB_ENCODING_ERROR;
     }
@@ -992,7 +986,7 @@ int DataG22OrderPacking::pack_double(const double* val, size_t* len)
             max_val *= dec_factor;
             if (has_undef) {
                 for (i = 0; i < nndata; i++) {
-                    if (DEFINED_VAL(data[i])) data[i] *= dec_factor;
+                    if (data[i] != missingValue) data[i] *= dec_factor;
                 }
             }
             else {
@@ -1016,7 +1010,7 @@ int DataG22OrderPacking::pack_double(const double* val, size_t* len)
         scale = ldexp(1.0, -binary_scale);
         if (has_undef) {
             for (i = 0; i < nndata; i++) {
-                if (DEFINED_VAL(data[i])) {
+                if (data[i] != missingValue) {
                     v[i] = floor((data[i] - ref) * scale + 0.5);
                     v[i] = v[i] >= 0 ? v[i] : 0;
                 }
@@ -1035,7 +1029,7 @@ int DataG22OrderPacking::pack_double(const double* val, size_t* len)
         // scale = 1.0;
         if (has_undef) {
             for (i = 0; i < nndata; i++) {
-                if (DEFINED_VAL(data[i])) {
+                if (data[i] != missingValue) {
                     v[i] = floor(data[i] - ref + 0.5);
                     v[i] = v[i] >= 0 ? v[i] : 0;
                 }


### PR DESCRIPTION
### Description
Do not use a hardcoded missing value range (9998.9 to 9999.1). Use the missingValue key itself.
Users can then change the default missingValue to whatever they choose.
See issue #397

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
