### PR TITLE
ECC-2272: levtype entries for new ft2026-1 4.5 entries

### DIFF
--- a/definitions/grib2/marsLevtypeConcept.def
+++ b/definitions/grib2/marsLevtypeConcept.def
@@ -11,6 +11,16 @@
 'sfc' = {typeOfFirstFixedSurface=19; typeOfSecondFixedSurface=255;}
 'o2d' = {discipline=10; typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
 'sfc' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'sfc' = {typeOfFirstFixedSurface=28;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=29;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=28;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=29; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=36;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=37;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=255;}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=100;}
 'sfc' = {typeOfFirstFixedSurface=1; typeOfSecondFixedSurface=100;


### PR DESCRIPTION
### Description
MARS levtype entries for recently added 4.5 table entries were missing which will be used in new storm helicity parameters. This PR is to add those.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
