### PR TITLE
ECC-2279: Feature/xwda coeffindex

### DIFF
--- a/definitions/mars/grib.xwda.eme.def
+++ b/definitions/mars/grib.xwda.eme.def
@@ -1,2 +1,8 @@
+assert(edition == 2);
+assert(grib2LocalSectionNumber == 45);
+
 include "mars/xwda.def";
 alias mars.number=perturbationNumber;
+
+alias mars.number = perturbationNumber;
+alias mars.coeffindex = fourierCoefficientIndex;

--- a/definitions/mars/grib.xwda.eme.def
+++ b/definitions/mars/grib.xwda.eme.def
@@ -2,7 +2,5 @@
 #assert(grib2LocalSectionNumber == 45);
 
 include "mars/xwda.def";
-alias mars.number=perturbationNumber;
-
 alias mars.number = perturbationNumber;
 alias mars.coeffindex = fourierCoefficientIndex;

--- a/definitions/mars/grib.xwda.eme.def
+++ b/definitions/mars/grib.xwda.eme.def
@@ -1,5 +1,5 @@
-assert(edition == 2);
-assert(grib2LocalSectionNumber == 45);
+#assert(edition == 2);
+#assert(grib2LocalSectionNumber == 45);
 
 include "mars/xwda.def";
 alias mars.number=perturbationNumber;

--- a/definitions/mars/grib.xwda.me.def
+++ b/definitions/mars/grib.xwda.me.def
@@ -1,2 +1,5 @@
+assert(edition == 2);
+assert(grib2LocalSectionNumber == 45);
+
 include "mars/xwda.def";
-alias mars.number=perturbationNumber;
+alias mars.coeffindex = fourierCoefficientIndex;

--- a/definitions/mars/grib.xwda.me.def
+++ b/definitions/mars/grib.xwda.me.def
@@ -1,5 +1,5 @@
-assert(edition == 2);
-assert(grib2LocalSectionNumber == 45);
+#assert(edition == 2);
+#assert(grib2LocalSectionNumber == 45);
 
 include "mars/xwda.def";
 alias mars.coeffindex = fourierCoefficientIndex;


### PR DESCRIPTION
### Description
In 50r1, fourier coefficients of the model errors in the types me and eme were introduced.

The current implementation for the stream xwda, type me/eme MARS namespaces follow still the pre-50r1 way of model errors. This PR is to adapt it to use the local GRIB2 section 2 number 45 and alias the coeffindex.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
