### PR TITLE
ECC-2280: Don't link libaec when ENABLE_AEC=OFF

### DIFF
--- a/src/eccodes/CMakeLists.txt
+++ b/src/eccodes/CMakeLists.txt
@@ -447,7 +447,7 @@ ecbuild_add_library(
        ${ECCODES_EXTRA_LIBRARIES}
        ${CMAKE_THREAD_LIBS_INIT}
        ${PNG_LIBRARIES}
-       $<$<BOOL:${libaec_FOUND}>:libaec::aec>
+       $<$<BOOL:${ENABLE_AEC}>:libaec::aec>
     PUBLIC_LIBS 
         ${CMATH_LIBRARIES}
         ${THREADS_LIBRARIES}


### PR DESCRIPTION
### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
