### PR TITLE
ECC-2281: remove unalias of time from ldas statistics namespace

### DIFF
--- a/definitions/mars/grib.ldsb.an.def
+++ b/definitions/mars/grib.ldsb.an.def
@@ -3,7 +3,6 @@ alias mars.step = startStep;
 alias monthlyVerificationTime = zero;
 alias monthlyVerificationDate = dataDate;
 
-unalias mars.time;
 unalias mars.step;
 
 meta ldas_configuration sprintf("%s-%s", modelVersion, targetFcstSystem ) : no_copy;

--- a/definitions/mars/grib.ldsb.fc.def
+++ b/definitions/mars/grib.ldsb.fc.def
@@ -9,7 +9,6 @@ meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
 meta verificationMonth         evaluate( (verificationDate/100)%100 );
 meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
 
-unalias mars.time;
 unalias mars.step;
 
 meta ldas_configuration sprintf("%s-%s", modelVersion, targetFcstSystem ) : no_copy;

--- a/definitions/mars/grib.ldst.an.def
+++ b/definitions/mars/grib.ldst.an.def
@@ -3,7 +3,6 @@ alias mars.step = startStep;
 alias monthlyVerificationTime = zero;
 alias monthlyVerificationDate = dataDate;
 
-unalias mars.time;
 unalias mars.step;
 
 meta ldas_configuration sprintf("%s-%s", modelVersion, targetFcstSystem ) : no_copy;

--- a/definitions/mars/grib.ldst.fc.def
+++ b/definitions/mars/grib.ldst.fc.def
@@ -9,7 +9,6 @@ meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
 meta verificationMonth         evaluate( (verificationDate/100)%100 );
 meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
 
-unalias mars.time;
 unalias mars.step;
 
 meta ldas_configuration sprintf("%s-%s", modelVersion, targetFcstSystem ) : no_copy;


### PR DESCRIPTION
### Description
For LDAS statistics, the time MARS keyword needs to be in the MARS namespace as synoptic statistics will be calculated. Therefore the unalias mars.time has to be removed from the ldst and ldsb files.

Please include this change into hotfix/2.47.2 and 2.48.0.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
