### PR TITLE
ECC-2287: obscutoff read-only

### DIFF
--- a/definitions/mars/xwda.def
+++ b/definitions/mars/xwda.def
@@ -1,6 +1,6 @@
 alias mars.anoffset = offsetToEndOf4DvarWindow;
 
-transient maxobscutoff = max(0, hoursAfterDataCutoff - offsetToEndOf4DvarWindow);
+transient maxobscutoff = max(0, hoursAfterDataCutoff - offsetToEndOf4DvarWindow) : hidden;
 
-meta obscutoff time(maxobscutoff,minutesAfterDataCutoff,zero);
+meta obscutoff time(maxobscutoff,minutesAfterDataCutoff,zero) : no_copy,read_only;
 alias mars.obscutoff = obscutoff;


### PR DESCRIPTION
### Description
For the eXtended Window Data Assimilation - XWDA, a MARS keyword obscutoff was introduced. This keyword is derived from low-level keys and is modified to be always greater or equal than 0. This key is currently settable, but it need to be read-only and also copying need to prevented because it provokes problems when a reset is triggered in ecCodes.

This PR is to make obscutoff read-only and no_copy. Please merge it to 2.48.0 and cherry-pick to hotfix/2.47.2.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
