### PR TITLE
ECC-2272: Add FT2026 levtypes to pre-mtg2 and CAMS mars levtype concepts

### DIFF
--- a/definitions/grib2/marsLevtypeConcept.chemsplit.def
+++ b/definitions/grib2/marsLevtypeConcept.chemsplit.def
@@ -11,6 +11,16 @@
 'sfc' = {typeOfFirstFixedSurface=19; typeOfSecondFixedSurface=255;}
 'o2d' = {discipline=10; typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
 'sfc' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'sfc' = {typeOfFirstFixedSurface=28;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=29;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=28;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=29; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=36;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=37;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=255;}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=100;}
 'sfc' = {typeOfFirstFixedSurface=1; typeOfSecondFixedSurface=100;

--- a/definitions/grib2/marsLevtypeConcept.lte33.def
+++ b/definitions/grib2/marsLevtypeConcept.lte33.def
@@ -11,6 +11,16 @@
 'sfc' = {typeOfFirstFixedSurface=19; typeOfSecondFixedSurface=255;}
 'o2d' = {discipline=10; typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
 'sfc' = {typeOfFirstFixedSurface=20; typeOfSecondFixedSurface=255;}
+'sfc' = {typeOfFirstFixedSurface=28;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=29;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=28;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=29; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=36;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
+'sfc' = {typeOfFirstFixedSurface=37;    scaleFactorOfFirstFixedSurface=missing();  scaledValueOfFirstFixedSurface=missing();
+         typeOfSecondFixedSurface=255; scaleFactorOfSecondFixedSurface=missing(); scaledValueOfSecondFixedSurface=missing();}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=255;}
 'pl'  = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=100;}
 'sfc' = {typeOfFirstFixedSurface=1; typeOfSecondFixedSurface=100;


### PR DESCRIPTION
### Description
With FT2026-1, new table 4.5 level types were introduced. typeOflevel and marsLevtype for MTG2 switch value 1 were defined.
mars levtypes for the other switch values 0 and 2 are also needed. This PR is to add the missing entries to marsLevtypeConcept.lte33.def and marsLevtypeConcept.chemsplit.def. marsLevtypeConcept.def has the entries already.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
