### PR TITLE
ECCC-2275: chemId for pollen and spores from FT2026-1

### DIFF
--- a/definitions/grib2/chemFormula.def
+++ b/definitions/grib2/chemFormula.def
@@ -606,6 +606,14 @@
 'C8H18' = {
 	constituentType = 10068 ;
 	}
+#Lumped pollen
+'bio_pol' = {
+	constituentType = 62298 ;
+	}
+#Lumped fungal spores
+'bio_spo' = {
+	constituentType = 62299 ;
+	}
 #Calcite
 'CaCO3' = {
 	constituentType = 62400 ;

--- a/definitions/grib2/chemId.def
+++ b/definitions/grib2/chemId.def
@@ -606,6 +606,14 @@
 '447' = {
 	constituentType = 10068 ;
 	}
+#Lumped pollen
+'800' = {
+	constituentType = 62298 ;
+	}
+#Lumped fungal spores
+'801' = {
+	constituentType = 62299 ;
+	}
 #Calcite
 '802' = {
 	constituentType = 62400 ;

--- a/definitions/grib2/chemName.def
+++ b/definitions/grib2/chemName.def
@@ -606,6 +606,14 @@
 'Octane' = {
 	constituentType = 10068 ;
 	}
+#Lumped pollen
+'Lumped pollen' = {
+	constituentType = 62298 ;
+	}
+#Lumped fungal spores
+'Lumped fungal spores' = {
+	constituentType = 62299 ;
+	}
 #Calcite
 'Calcite' = {
 	constituentType = 62400 ;

--- a/definitions/grib2/chemShortName.def
+++ b/definitions/grib2/chemShortName.def
@@ -606,6 +606,14 @@
 'C8H18' = {
 	constituentType = 10068 ;
 	}
+#Lumped pollen
+'bio_pol' = {
+	constituentType = 62298 ;
+	}
+#Lumped fungal spores
+'bio_spo' = {
+	constituentType = 62299 ;
+	}
 #Calcite
 'dst_calc' = {
 	constituentType = 62400 ;


### PR DESCRIPTION
### Description

This pull request adds support for two new biological aerosol types—lumped pollen and lumped fungal spores—across several GRIB2 definition files. The main changes involve registering these new constituents with unique identifiers and constituent types to ensure they are recognised consistently in the system.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
