### PR TITLE
ECC-2289: additional configuration entries for Lisflood

### DIFF
--- a/definitions/grib2/localConcepts/hydro/configurationConcept.lisflood.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.lisflood.def
@@ -4,10 +4,12 @@
 'v3.5' = { generatingProcessIdentifier = 3 ; }
 'v4' = { generatingProcessIdentifier = 4; }
 'v5' = { generatingProcessIdentifier = 5; }
+'v6' = { generatingProcessIdentifier = 6; }
 
 #40-79 keep the numbers for Glofas
 'v3.1' = { generatingProcessIdentifier = 40; }
 'v4.0' = { generatingProcessIdentifier = 41; }
+'v5.0' = { generatingProcessIdentifier = 42; }
 
 #80-119 keep the numbers for c3s europe
 'v1' = { generatingProcessIdentifier = 80; }


### PR DESCRIPTION
### Description
This PR is to extend the list of configurations for the Lisflood hydrological model.

It introduces for EFAS
'v6' = { generatingProcessIdentifier = 6; }
and for GloFAS
'v5.0' = { generatingProcessIdentifier = 42; }

Please merge into develop for ecCodes 2.48.0 and cherry-pick into hotfix/2.47.2.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
