### PR TITLE
ECC-2290: include minor version in hydro configuration concepts

### DIFF
--- a/definitions/grib2/localConcepts/hydro/configurationConcept.ecland.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.ecland.def
@@ -1,5 +1,5 @@
 #1-39 keep the numbers for ecland europe
-'v1' = { generatingProcessIdentifier = 1 ; }
+'v1.0' = { generatingProcessIdentifier = 1 ; }
 
 #40-79 keep the numbers for ecland global
-'v1' = { generatingProcessIdentifier = 40 ; }
+'v1.0' = { generatingProcessIdentifier = 40 ; }

--- a/definitions/grib2/localConcepts/hydro/configurationConcept.hype.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.hype.def
@@ -5,4 +5,4 @@
 'v1-grid' = { generatingProcessIdentifier = 40; }
 
 #80-119 keep the numbers for c3s ww hype
-'v1' = { generatingProcessIdentifier = 80; }
+'v1.0' = { generatingProcessIdentifier = 80; }

--- a/definitions/grib2/localConcepts/hydro/configurationConcept.jules.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.jules.def
@@ -1,5 +1,5 @@
 #1-39 keep the numbers for JULES europe
-'v1' = { generatingProcessIdentifier = 1; }
+'v1.0' = { generatingProcessIdentifier = 1; }
 
 #40-79 keep the numbers for JULES global
-'v1' = { generatingProcessIdentifier = 40; }
+'v1.0' = { generatingProcessIdentifier = 40; }

--- a/definitions/grib2/localConcepts/hydro/configurationConcept.lisflood.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.lisflood.def
@@ -1,10 +1,10 @@
 #1-39 keep the numbers for Efas
-'v2' = { generatingProcessIdentifier = 1; }
-'v3' = { generatingProcessIdentifier = 2; }
+'v2.0' = { generatingProcessIdentifier = 1; }
+'v3.0' = { generatingProcessIdentifier = 2; }
 'v3.5' = { generatingProcessIdentifier = 3 ; }
-'v4' = { generatingProcessIdentifier = 4; }
-'v5' = { generatingProcessIdentifier = 5; }
-'v6' = { generatingProcessIdentifier = 6; }
+'v4.0' = { generatingProcessIdentifier = 4; }
+'v5.0' = { generatingProcessIdentifier = 5; }
+'v6.0' = { generatingProcessIdentifier = 6; }
 
 #40-79 keep the numbers for Glofas
 'v3.1' = { generatingProcessIdentifier = 40; }
@@ -12,7 +12,7 @@
 'v5.0' = { generatingProcessIdentifier = 42; }
 
 #80-119 keep the numbers for c3s europe
-'v1' = { generatingProcessIdentifier = 80; }
+'v1.0' = { generatingProcessIdentifier = 80; }
 
 #120-159 keep the numbers for c3s global
-'v1' = { generatingProcessIdentifier = 120; }
+'v1.0' = { generatingProcessIdentifier = 120; }

--- a/definitions/grib2/localConcepts/hydro/configurationConcept.mhm.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.mhm.def
@@ -1,5 +1,5 @@
 #1-39 keep the numbers for mHM europe
-'v1' = { generatingProcessIdentifier = 1; }
+'v1.0' = { generatingProcessIdentifier = 1; }
 
 #40-79 keep the numbers for mHM global
-'v1' = { generatingProcessIdentifier = 40; }
+'v1.0' = { generatingProcessIdentifier = 40; }

--- a/definitions/grib2/localConcepts/hydro/configurationConcept.pcr-globwb.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.pcr-globwb.def
@@ -1,5 +1,5 @@
 #1-39 keep the numbers for PCR-GLOBWB europe
-'v1' = { generatingProcessIdentifier = 1; }
+'v1.0' = { generatingProcessIdentifier = 1; }
 
 #40-79 keep the numbers for PCR-GLOBWB global
-'v1' = { generatingProcessIdentifier = 40; }
+'v1.0' = { generatingProcessIdentifier = 40; }

--- a/definitions/grib2/localConcepts/hydro/configurationConcept.vic-wur.def
+++ b/definitions/grib2/localConcepts/hydro/configurationConcept.vic-wur.def
@@ -1,5 +1,5 @@
 #1-39 keep the numbers for c3s VIC-WUR europe
-'v1' = { generatingProcessIdentifier = 1; }
+'v1.0' = { generatingProcessIdentifier = 1; }
 
 #40-79 keep the numbers for c3s VIC-WUR global
-'v1' = { generatingProcessIdentifier = 40; }
+'v1.0' = { generatingProcessIdentifier = 40; }

--- a/tests/grib_ecc-2221.sh
+++ b/tests/grib_ecc-2221.sh
@@ -35,7 +35,7 @@ cat >$tempFilt<<EOF
     write;
 EOF
 ${tools_dir}/grib_filter -o $tempGrib $tempFilt $sample_grib2
-grib_check_key_equals $tempGrib model,configuration,forcing,timespan "lisflood v5 ecmf-ifs 6h"
+grib_check_key_equals $tempGrib model,configuration,forcing,timespan "lisflood v5.0 ecmf-ifs 6h"
 
 # Clean up
 rm -f $tempGrib $tempFilt


### PR DESCRIPTION
### Description
This PR is to align the version numbers defined for the different hydrological models. Some version numbers in the configuration concepts contain only major versions, others major and minor versions together.
All configurations are adapted to have major.minor version.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
