### PR TITLE
ECC-2295: U/V for ERA5 monthly statistics

### DIFF
--- a/definitions/grib2/localConcepts/era/name.lte33.def
+++ b/definitions/grib2/localConcepts/era/name.lte33.def
@@ -109,6 +109,20 @@
 	 parameterNumber = 0 ;
 	 typeOfStatisticalProcessing = 0 ;
 	}
+#U component of wind
+'U component of wind' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 2 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
+#V component of wind
+'V component of wind' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 3 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
 #Specific humidity
 'Specific humidity' = {
 	 discipline = 0 ;

--- a/definitions/grib2/localConcepts/era/paramId.lte33.def
+++ b/definitions/grib2/localConcepts/era/paramId.lte33.def
@@ -109,6 +109,20 @@
 	 parameterNumber = 0 ;
 	 typeOfStatisticalProcessing = 0 ;
 	}
+#U component of wind
+'131' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 2 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
+#V component of wind
+'132' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 3 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
 #Specific humidity
 '133' = {
 	 discipline = 0 ;

--- a/definitions/grib2/localConcepts/era/shortName.lte33.def
+++ b/definitions/grib2/localConcepts/era/shortName.lte33.def
@@ -109,6 +109,20 @@
 	 parameterNumber = 0 ;
 	 typeOfStatisticalProcessing = 0 ;
 	}
+#U component of wind
+'u' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 2 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
+#V component of wind
+'v' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 3 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
 #Specific humidity
 'q' = {
 	 discipline = 0 ;

--- a/definitions/grib2/localConcepts/era/units.lte33.def
+++ b/definitions/grib2/localConcepts/era/units.lte33.def
@@ -109,6 +109,20 @@
 	 parameterNumber = 0 ;
 	 typeOfStatisticalProcessing = 0 ;
 	}
+#U component of wind
+'m s**-1' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 2 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
+#V component of wind
+'m s**-1' = {
+	 discipline = 0 ;
+	 parameterCategory = 2 ;
+	 parameterNumber = 3 ;
+	 typeOfStatisticalProcessing = 0 ;
+	}
 #Specific humidity
 'kg kg**-1' = {
 	 discipline = 0 ;


### PR DESCRIPTION
### Description
paramIds 131 / 132 added to ERA pseudo-centre to make ERA5 data behave like in earlier ecCodes versions.
Without this change, paramIds switch from 131 to 235131 and 132 to 235132.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
