### PR TITLE
ECC-2304: Removed duplicate concept definition and extended tests.

### DIFF
--- a/definitions/grib2/post_meta_data.hook.products_destine.def
+++ b/definitions/grib2/post_meta_data.hook.products_destine.def
@@ -22,10 +22,12 @@ if ( defined(dataset) && dataset is "climate-dt" ) {
 }
 
 # ECC-2222: We want model in on-demand-extremes-dt
+# ECC-2304: Note that the modelName and modelVersion are already defined in section4_extras as in ECMWF data
+#           All that is needed here is to alias them to the MARS and LS namespaces
 if ( defined(dataset) && dataset is "on-demand-extremes-dt" ) {
-    concept modelName(unknown, "modelNameConcept.def", conceptsDir2, conceptsLocalDirAll): no_copy, dump;
+
     if (modelName isnot "unknown") {
-        concept modelVersion(unknown, "modelVersionConcept.[modelName].def", conceptsDir2, conceptsLocalDirAll): no_copy, dump, read_only;
+
         alias ls.model = modelName;
         alias mars.model = modelName;
 

--- a/definitions/grib2/post_meta_data.hook.products_destine.def
+++ b/definitions/grib2/post_meta_data.hook.products_destine.def
@@ -22,8 +22,8 @@ if ( defined(dataset) && dataset is "climate-dt" ) {
 }
 
 # ECC-2222: We want model in on-demand-extremes-dt
-# ECC-2304: Note that the modelName and modelVersion are already defined in section4_extras as in ECMWF data
-#           All that is needed here is to alias them to the MARS and LS namespaces
+# ECC-2304: Note that modelName/modelVersion concepts are already defined in section4_extras (as in ECMWF data).
+#           All that is needed here is to alias modelName as model to the MARS and LS namespaces
 if ( defined(dataset) && dataset is "on-demand-extremes-dt" ) {
 
     if (modelName isnot "unknown") {

--- a/tests/grib_destine_mars_keys.sh
+++ b/tests/grib_destine_mars_keys.sh
@@ -114,6 +114,9 @@ ${tools_dir}/grib_set -s dataset=4,georef=gcpkd2eu,model=HARMONIE-AROME $destine
 grib_check_key_equals $temp_grib_a "georef" "gcpkd2eu"
 grib_check_key_equals $temp_grib_a "model" "HARMONIE-AROME"
 
+# ECC-2304: Check the size of the model keyword. This was accidentally defined in both section4_extras and post_meta_data.hook
+grib_check_key_is_scalar $temp_grib_a "model" "HARMONIE-AROME"
+
 # ECC-2161: We replace mars.step=stepRange with mars.step=endStep (default) and mars.timespan
 # in extremes-dt. We continue to unalias timespan in climate-dt streams clte/clmn (checked above)
 ${tools_dir}/grib_set -s dataset=2,productDefinitionTemplateNumber=8,startStep=0,endStep=6 $destine_sample $temp_grib_a

--- a/tests/grib_destine_test_mars_keys.sh
+++ b/tests/grib_destine_test_mars_keys.sh
@@ -115,6 +115,8 @@ ${tools_dir}/grib_set -s dataset=4,georef=gcpkd2eu,model=HARMONIE-AROME $destine
 grib_check_key_equals $temp_grib_a "georef" "gcpkd2eu"
 grib_check_key_equals $temp_grib_a "model" "HARMONIE-AROME"
 
+# ECC-2304: Check the size of the model keyword. This was accidentally defined in both section4_extras and post_meta_data.hook
+grib_check_key_is_scalar $temp_grib_a "model" "HARMONIE-AROME"
 
 # ECC-2161: We replace mars.step=stepRange with mars.step=endStep (default) and mars.timespan
 # in extremes-dt. We continue to unalias timespan in climate-dt streams clte/clmn (checked above)


### PR DESCRIPTION
### Description

I discovered that using ecCodes 2.48.0 with fdb and trying to write data that the model key was missing. After investigating further I found the cause:
- The model concept is defined both in `destine/section4_extras.def` and in `post_meta_data.hook.products_destine.def`.
- This duplicate definition cause eccodes to allocate an array to the `modelName` concept.
- This is then aliased to the mars `model` key.
- A `grib_ls -m` and `grib_get` as well as inspection of the DEBUG output does not indicate any issues with the key.
- Metkit throws away any MARS key which is not scalar, resulting in the key not arriving to FDB, see: [metkit/src/metkit/codes/GRIBDecoder.cc at develop · ecmwf/metkit](https://github.com/ecmwf/metkit/blob/develop/src/metkit/codes/GRIBDecoder.cc#L61-L65)
Desired behaviour:
- Duplicate definition of a concept results in overwrite, or at the very least a warning/error.
- In the DEBUG output the C++ type of the given metadata key would be useful information e.g. model (scalar).
Fix:
- The short term fix is to remove this duplicate definition of the concept from the definitions files, but I would like the issue to be more obvious in future.
- Extended tests to check the key is scalar.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
