### PR TITLE
ECC-2308: feature/2.48.1 step range switch

### DIFF
--- a/definitions/mars/grib.eefo.efi.def
+++ b/definitions/mars/grib.eefo.efi.def
@@ -1,5 +1,7 @@
-if ( MTG2Switch == 0 ){
- alias mars.step   = stepRange;}
-else {
- alias mars.step   = endStep;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
 }
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.eefo.efic.def
+++ b/definitions/mars/grib.eefo.efic.def
@@ -1,6 +1,7 @@
-if ( MTG2Switch == 0 ){
- alias mars.step   = stepRange;}
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
 else {
- alias mars.step   = endStep;
+ alias mars.step = endStep;
 }
 

--- a/definitions/mars/grib.eefo.ep.def
+++ b/definitions/mars/grib.eefo.ep.def
@@ -1,1 +1,6 @@
-alias   mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}

--- a/definitions/mars/grib.eefo.pb.def
+++ b/definitions/mars/grib.eefo.pb.def
@@ -1,3 +1,8 @@
-alias mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
 
 include "mars/mars.quantile.def"

--- a/definitions/mars/grib.eefo.pd.def
+++ b/definitions/mars/grib.eefo.pd.def
@@ -1,3 +1,8 @@
-alias mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
 
 include "mars/mars.quantile.def"

--- a/definitions/mars/grib.eehs.cd.def
+++ b/definitions/mars/grib.eehs.cd.def
@@ -1,3 +1,8 @@
-alias mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
 
 include "mars/mars.quantile.def"

--- a/definitions/mars/grib.efhs.cd.def
+++ b/definitions/mars/grib.efhs.cd.def
@@ -1,3 +1,8 @@
-alias mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
 
 include "mars/mars.quantile.def"

--- a/definitions/mars/grib.enfo.efi.def
+++ b/definitions/mars/grib.enfo.efi.def
@@ -1,5 +1,7 @@
-if ( MTG2Switch == 0 ){
- alias mars.step   = stepRange;}
-else {
- alias mars.step   = endStep;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
 }
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.enfo.efic.def
+++ b/definitions/mars/grib.enfo.efic.def
@@ -1,6 +1,6 @@
-if ( MTG2Switch == 0 ){
- alias mars.step   = stepRange;}
-else {
- alias mars.step   = endStep;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
 }
-
+else {
+ alias mars.step = endStep;
+}

--- a/definitions/mars/grib.enfo.ep.def
+++ b/definitions/mars/grib.enfo.ep.def
@@ -1,1 +1,7 @@
-alias   mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.lwda.me.def
+++ b/definitions/mars/grib.lwda.me.def
@@ -7,6 +7,8 @@ if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
  transient pertNumber=1;
  alias mars.number = pertNumber;
  alias mars.coeffindex = fourierCoefficientIndex;
-} else {
+}
+
+if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch > 0) {
  alias mars.coeffindex = fourierCoefficientIndex;
 }

--- a/definitions/mars/grib.lwda.me.def
+++ b/definitions/mars/grib.lwda.me.def
@@ -1,7 +1,7 @@
 #alias mars.number=perturbationNumber;
 alias mars.anoffset=offsetToEndOf4DvarWindow;
 
-if ( grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
+if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
  # mars.number = componentIndex from the other local sections for this type
  # this has always value 1, so we mimick this for pre-mtg2 which 50r1 is part of
  transient pertNumber=1;

--- a/definitions/mars/grib.me.def
+++ b/definitions/mars/grib.me.def
@@ -1,7 +1,7 @@
 label "_model errors";
 #alias mars.number=perturbationNumber;
 
-if ( grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
+if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
  # mars.number = componentIndex from the other local sections for this type
  # this has always value 1, so we mimick this for pre-mtg2 which 50r1 is part of
  transient pertNumber=1;

--- a/definitions/mars/grib.me.def
+++ b/definitions/mars/grib.me.def
@@ -12,4 +12,4 @@ if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
 if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch > 0) {
  alias mars.coeffindex = fourierCoefficientIndex;
 }
-}
+

--- a/definitions/mars/grib.me.def
+++ b/definitions/mars/grib.me.def
@@ -7,6 +7,9 @@ if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch == 0) {
  transient pertNumber=1;
  alias mars.number = pertNumber;
  alias mars.coeffindex = fourierCoefficientIndex;
-} else {
+} 
+
+if ( defined(MTG2Switch) && grib2LocalSectionNumber == 45 && MTG2Switch > 0) {
  alias mars.coeffindex = fourierCoefficientIndex;
+}
 }

--- a/definitions/mars/grib.ocda.an.def
+++ b/definitions/mars/grib.ocda.an.def
@@ -5,4 +5,8 @@ alias mars.time = dataTime;
 # dateOfAnalysis  and timeOfAnalysis still exist in this stream but is not used in MARS
 
 unalias mars.step;
-alias mars.step = stepRange;
+if ( MTG2Switch == 0 ){
+ alias mars.step = stepRange;}
+else {
+ alias mars.step = endStep;
+}

--- a/definitions/mars/grib.ocda.an.def
+++ b/definitions/mars/grib.ocda.an.def
@@ -5,8 +5,10 @@ alias mars.time = dataTime;
 # dateOfAnalysis  and timeOfAnalysis still exist in this stream but is not used in MARS
 
 unalias mars.step;
-if ( MTG2Switch == 0 ){
- alias mars.step = stepRange;}
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
 else {
  alias mars.step = endStep;
 }
+

--- a/definitions/mars/grib.ocda.tpa.def
+++ b/definitions/mars/grib.ocda.tpa.def
@@ -5,7 +5,11 @@ alias mars.time = dataTime;
 # dateOfAnalysis and timeOfAnalysis still exist in this stream but is not used in MARS
 
 unalias mars.step;
-alias mars.step = stepRange;
+if ( MTG2Switch == 0 ){
+ alias mars.step = stepRange;}
+else {
+alias mars.step = endStep;
+}
 if (defined(perturbationNumber)) {
  alias mars.number = perturbationNumber;
 }

--- a/definitions/mars/grib.ocda.tpa.def
+++ b/definitions/mars/grib.ocda.tpa.def
@@ -5,10 +5,11 @@ alias mars.time = dataTime;
 # dateOfAnalysis and timeOfAnalysis still exist in this stream but is not used in MARS
 
 unalias mars.step;
-if ( MTG2Switch == 0 ){
- alias mars.step = stepRange;}
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
 else {
-alias mars.step = endStep;
+ alias mars.step = endStep;
 }
 if (defined(perturbationNumber)) {
  alias mars.number = perturbationNumber;

--- a/definitions/mars/grib.olda.an.def
+++ b/definitions/mars/grib.olda.an.def
@@ -9,8 +9,10 @@ alias mars.offsetdate = dataDate;
 alias mars.offsettime = dataTime;
 
 unalias mars.step;
-if ( MTG2Switch == 0 ){
- alias mars.step = stepRange;}
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
 else {
  alias mars.step = endStep;
 }
+

--- a/definitions/mars/grib.olda.an.def
+++ b/definitions/mars/grib.olda.an.def
@@ -9,4 +9,8 @@ alias mars.offsetdate = dataDate;
 alias mars.offsettime = dataTime;
 
 unalias mars.step;
-alias mars.step = stepRange;
+if ( MTG2Switch == 0 ){
+ alias mars.step = stepRange;}
+else {
+ alias mars.step = endStep;
+}

--- a/definitions/mars/grib.olda.tpa.def
+++ b/definitions/mars/grib.olda.tpa.def
@@ -9,8 +9,9 @@ alias mars.offsetdate = dataDate;
 alias mars.offsettime = dataTime;
 
 unalias mars.step;
-if ( MTG2Switch == 0 ){
- alias mars.step = stepRange;}
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
 else {
  alias mars.step = endStep;
 }

--- a/definitions/mars/grib.olda.tpa.def
+++ b/definitions/mars/grib.olda.tpa.def
@@ -9,7 +9,11 @@ alias mars.offsetdate = dataDate;
 alias mars.offsettime = dataTime;
 
 unalias mars.step;
-alias mars.step = stepRange;
+if ( MTG2Switch == 0 ){
+ alias mars.step = stepRange;}
+else {
+ alias mars.step = endStep;
+}
 if (defined(perturbationNumber)) {
  alias mars.number = perturbationNumber;
 }

--- a/definitions/mars/grib.oper.efi.def
+++ b/definitions/mars/grib.oper.efi.def
@@ -1,5 +1,7 @@
-if ( MTG2Switch == 0 ){
- alias mars.step   = stepRange;}
-else {
- alias mars.step   = endStep;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
 }
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.oper.em.def
+++ b/definitions/mars/grib.oper.em.def
@@ -1,1 +1,7 @@
-alias mars.step = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.oper.ep.def
+++ b/definitions/mars/grib.oper.ep.def
@@ -1,3 +1,6 @@
-if (class is "ai") {
+if ( (class is "ai") && ( (!defined(MTG2Switch)) || (MTG2Switch == 0)) ){
  alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
 }

--- a/definitions/mars/grib.oper.es.def
+++ b/definitions/mars/grib.oper.es.def
@@ -1,1 +1,7 @@
-alias mars.step = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.oper.fc.def
+++ b/definitions/mars/grib.oper.fc.def
@@ -1,5 +1,10 @@
 if (levtype is "o2d" || levtype is "o3d") {
-   alias mars.step = stepRange;
+ if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+  alias mars.step = stepRange;
+ }
+ else {
+  alias mars.step = endStep;
+ }
 } else {
    alias mars.step = endStep;
 }


### PR DESCRIPTION
### Description
This PR is to include the MTG2 switch mechanism into the remaining operational datatypes which currently use mars.step=stepRange and will use in post-mtg2 mars.step=endStep + timespan.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
