### PR TITLE
Add MTG2Encoder key

### DIFF
--- a/definitions/grib2/section.4.def
+++ b/definitions/grib2/section.4.def
@@ -86,11 +86,13 @@ meta MTG2SwitchDefault mtg2_switch_default(tablesVersion, tablesVersionMTG2Switc
 
 concept MTG2Switch(MTG2SwitchDefault, "MTG2SwitchConcept.def", conceptsDir2,conceptsDir1): hidden, read_only, long_type;
 
+# MTG2Encoder tells software using ecCodes when to use the encoder to create a post-MTG2 file.
+# For now, this is intended for internal use at ECMWF
 if (centre == 98) {
     alias MTG2Encoder = MTG2Switch;
 }
 else {
-    transient MTG2Encoder = 0;
+    transient MTG2Encoder = 0: read_only;
 }
 
 # ECC-2002

--- a/definitions/grib2/section.4.def
+++ b/definitions/grib2/section.4.def
@@ -92,7 +92,7 @@ if (centre == 98) {
     alias MTG2Encoder = MTG2Switch;
 }
 else {
-    transient MTG2Encoder = 0: read_only;
+    constant MTG2Encoder = 0;
 }
 
 # ECC-2002

--- a/definitions/grib2/section.4.def
+++ b/definitions/grib2/section.4.def
@@ -86,6 +86,13 @@ meta MTG2SwitchDefault mtg2_switch_default(tablesVersion, tablesVersionMTG2Switc
 
 concept MTG2Switch(MTG2SwitchDefault, "MTG2SwitchConcept.def", conceptsDir2,conceptsDir1): hidden, read_only, long_type;
 
+if (centre == 98) {
+    alias MTG2Encoder = MTG2Switch;
+}
+else {
+    transient MTG2Encoder = 0;
+}
+
 # ECC-2002
 # if datasetForLocal is not "unknown", we remap conceptsDir1 and conceptsDir2
 # See the g2_concept_dir accessor


### PR DESCRIPTION
### Description
This pull request introduces a new mechanism to indicate when the MTG2 encoder should be used, specifically targeting internal use at ECMWF. The main change is the addition of the `MTG2Encoder` field, which is conditionally set based on the `centre` value.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
