### PR TITLE
CI: land the cross-repo orchestration ahead of the rest of the rollout

### DIFF
--- a/.ci/manifest.toml
+++ b/.ci/manifest.toml
@@ -1,0 +1,117 @@
+# Single source of truth for eccodes' CI under ecmwf/ci-infrastructure.
+#
+# Alongside this manifest:
+#   - .github/workflows/ci.yml               push/PR build that publishes the artifact
+#   - .github/workflows/cross-repo-trigger.yml
+#                                            GENERATED entry point for upstream fan-out
+#                                            and consumer-driven rebuilds
+#   - .github/workflows/old_CI.yml           the legacy ecmwf/downstream-ci pipeline,
+#                                            still running unchanged during migration
+
+[package]
+name = "eccodes"
+prefix = "eccodes"
+repo = "ecmwf/eccodes"
+visibility = "public"
+compiler-inputs = ["cxx-compiler", "fortran-compiler"]
+
+[[deps]]
+repo = "ecmwf/ecbuild"
+package = "ecbuild"
+ref = "develop"
+compiler-inputs = []
+
+[[deps]]
+repo = "ecmwf/stack-dependencies"
+package = "stack-deps"
+ref = "master"
+# libaec: FEATURE AEC is DEFAULT ON, CONDITION libaec_FOUND, so without this the
+# default build silently loses CCSDS support.
+compiler-inputs = ["cxx-compiler"]
+
+[[deps]]
+repo = "ecmwf/eckit"
+package = "eckit"
+ref = "develop"
+compiler-inputs = ["cxx-compiler"]
+# eccodes needs eckit only for FEATURE ECKIT_GEO, which is DEFAULT OFF. Scoping
+# the dep to the legs that actually enable it keeps eckit out of the plain legs'
+# cmake-prefix-path AND out of their deps-hash8 — so an eckit commit does not
+# invalidate the ordinary eccodes artifacts and force them to rebuild.
+when = { options = ["eckit-geo"] }
+
+# Plain legs: ECKIT_GEO off, eckit not a dependency at all.
+[[matrix.build.include]]
+cxx-compiler = "clang++-18"
+build-type = "Release"
+fortran-compiler = "gfortran-13"
+runs-on = "arc-runner-very-large"
+container = "eccr.ecmwf.int/public-playground-ci/ubuntu24.04-clang18-gfortran13:latest"
+platform = "ubuntu-24.04"
+
+[[matrix.build.include]]
+cxx-compiler = "g++-13"
+build-type = "Release"
+fortran-compiler = "gfortran-13"
+runs-on = "arc-runner-very-large"
+container = "eccr.ecmwf.int/public-playground-ci/ubuntu24.04-clang18-gfortran13:latest"
+platform = "ubuntu-24.04"
+
+# The one leg that builds against eckit. `options` is part of artifact identity,
+# so this publishes under an opts.eckit-geo segment and cannot collide with the
+# plain g++-13 leg above.
+[[matrix.build.include]]
+cxx-compiler = "g++-13"
+build-type = "Release"
+fortran-compiler = "gfortran-13"
+options = "eckit-geo"
+runs-on = "arc-runner-very-large"
+container = "eccr.ecmwf.int/public-playground-ci/ubuntu24.04-clang18-gfortran13:latest"
+platform = "ubuntu-24.04"
+
+[matrix.build]
+triggers = ["upstream-change", "rebuild-request"]
+action = "./.github/actions/build-eccodes"
+forwarded-inputs = ["cxx-compiler", "fortran-compiler", "build-type", "options"]
+forwarded-deps-outputs = ["cmake-prefix-path"]
+needs = ["ecbuild/build", "stack-deps/build", "eckit/build"]
+
+# --- HPC build --------------------------------------------------------------
+# eccodes built inside a SLURM job, linking the atos-hpc-gnu ecbuild and
+# stack-deps artifacts — and, on the eckit-geo leg only, the atos-hpc-gnu eckit
+# artifact. The `when` predicate on the eckit [[deps]] entry above is per-leg and
+# lane-agnostic, so it scopes this lane exactly as it scopes the runner one: the
+# plain HPC leg neither fetches eckit nor carries it in its deps-hash.
+#
+# `needs` names HPC kinds only: the two lanes are separate artifact universes
+# distinguished by platform, and a runner rebuild must not re-run this.
+[[matrix.build-hpc.include]]
+cxx-compiler = "g++-13"
+fortran-compiler = "gfortran-13"
+build-type = "Release"
+runs-on = "arc-hpc-pet-vsphere-prod"
+container = "eccr.ecmwf.int/private-playground-ci/ubuntu24.04-internal-tools:latest"
+site = "hpc-batch"
+platform = "atos-hpc-gnu"
+
+# The one HPC leg that links eckit. `options` is part of artifact identity, so it
+# publishes under an opts.eckit-geo segment and cannot collide with the plain leg
+# above. `job-script` is per-leg and is NOT part of identity.
+[[matrix.build-hpc.include]]
+cxx-compiler = "g++-13"
+fortran-compiler = "gfortran-13"
+build-type = "Release"
+options = "eckit-geo"
+runs-on = "arc-hpc-pet-vsphere-prod"
+container = "eccr.ecmwf.int/private-playground-ci/ubuntu24.04-internal-tools:latest"
+site = "hpc-batch"
+platform = "atos-hpc-gnu"
+job-script = "./.ci/hpc/build-eckit-geo.sh"
+
+[matrix.build-hpc]
+execution = "hpc"
+container-credentials = true
+job-script = "./.ci/hpc/build.sh"
+triggers = ["upstream-change", "rebuild-request"]
+forwarded-deps-outputs = ["cmake-prefix-path"]
+needs = ["ecbuild/build-hpc", "stack-deps/build-hpc", "eckit/build-hpc"]

--- a/.github/workflows/cross-repo-trigger-hpc.yml
+++ b/.github/workflows/cross-repo-trigger-hpc.yml
@@ -1,0 +1,206 @@
+# GENERATED FILE - DO NOT EDIT.
+# Regenerate via the ci-infrastructure-generate CLI.
+# Source of truth: each repo's .ci/manifest.toml.
+name: Cross-repo trigger (eccodes)
+run-name: Cross-repo trigger (${{ inputs.from-repo }}@${{ inputs.from-sha }}) [${{ inputs.dispatch-id }}]
+on:
+  workflow_call:
+    inputs:
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+  workflow_dispatch:
+    inputs:
+      dispatch-id:
+        description: Correlation id stamped into run-name so the dispatcher can find this run
+        required: false
+        default: ''
+        type: string
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+concurrency:
+  group: cross-repo-trigger-hpc-eccodes-${{ github.ref }}
+  cancel-in-progress: false
+env:
+  ARTIFACT_POLL_INTERVAL: ${{ vars.ARTIFACT_POLL_INTERVAL || '60' }}
+  ARTIFACT_S3_ENDPOINT: ${{ secrets.ARTIFACT_S3_ENDPOINT }}
+  ARTIFACT_S3_BUCKET: ${{ secrets.ARTIFACT_S3_BUCKET }}
+  SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+jobs:
+  resolve:
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || contains(fromJSON(inputs.from-jobs), 'eckit/build-hpc') || inputs.rebuild-request
+    runs-on: ubuntu-slim
+    outputs:
+      ref: ${{ steps.pick.outputs.ref }}
+      matrix-build-hpc: ${{ steps.r.outputs.matrix-build-hpc }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: pick
+      uses: ecmwf/ci-infrastructure/actions/pick-ref@main
+      with:
+        repo: ecmwf/eccodes
+        try-branch: ${{ inputs.branch }}
+        fallback-ref: ${{ inputs.fallback-ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eccodes
+        ref: ${{ steps.pick.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - id: r
+      uses: ecmwf/ci-infrastructure/actions/resolve-deps@main
+      with:
+        current-branch: ${{ steps.pick.outputs.ref }}
+        matrix: build-hpc
+        token: ${{ steps.mint.outputs.token }}
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        app-private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+  eccodes__build_hpc:
+    needs:
+    - resolve
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || contains(fromJSON(inputs.from-jobs), 'eckit/build-hpc') || inputs.rebuild-request
+    name: eccodes/build-hpc (${{ matrix['build-type'] }}, ${{ matrix.platform }})
+    runs-on: ${{ matrix['runs-on'] }}
+    container:
+      image: ${{ matrix.container || '' }}
+      credentials:
+        username: ${{ secrets.ECCR_PULL_ROBOT_NAME }}
+        password: ${{ secrets.ECCR_PULL_ROBOT_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix-build-hpc) }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: check_start
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eccodes/build-hpc (${{ matrix['build-type'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: start
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eccodes
+        ref: ${{ needs.resolve.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - name: Decode matrix-leg
+      id: m
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s inherit_errexit 2>/dev/null || true
+        command -v jq >/dev/null || {
+          echo "::error::jq is required but not installed in this runner/image." >&2
+          exit 1
+        }
+        leg='${{ toJSON(matrix) }}'
+        require() {
+          local val
+          val=$(jq -r "$1" <<<"$leg")
+          if [ -z "$val" ] || [ "$val" = "null" ]; then
+            echo "::error::matrix-leg field '$2' empty or null (jq -r '$1' returned '$val')." >&2
+            exit 1
+          fi
+          printf '%s' "$val"
+        }
+        deps_json=$(require '._resolved.deps | tojson' '_resolved.deps')
+        own_artifact_name=$(require '._resolved."own-artifact-name"' '_resolved.own-artifact-name')
+        {
+          echo "deps-json=${deps_json}"
+          echo "own-artifact-name=${own_artifact_name}"
+        } >> "$GITHUB_OUTPUT"
+    - name: Fetch resolved deps
+      id: deps
+      uses: ecmwf/ci-infrastructure/actions/fetch-and-publish@main
+      with:
+        mode: download-only
+        deps-json: ${{ steps.m.outputs.deps-json }}
+        token: ${{ steps.mint.outputs.token }}
+        install-python-deps: 'false'
+    - name: Build on HPC
+      id: build
+      uses: ecmwf/ci-infrastructure/actions/build-on-hpc@main
+      with:
+        site: ${{ matrix.site }}
+        job-script: ${{ matrix.job-script || './.ci/hpc/build.sh' }}
+        artifact-name: ${{ steps.m.outputs.own-artifact-name }}
+        cmake-prefix-path: ${{ steps.deps.outputs.cmake-prefix-path }}
+        work-dir: ${{ vars.HPC_CI_WORK_DIR }}
+        remote-work-dir: ${{ vars.HPC_CI_REMOTE_WORK_DIR }}
+        troika-user: ${{ secrets.HPC_CI_SSH_USER }}
+    - name: Report check-run conclusion
+      if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eccodes/build-hpc (${{ matrix['build-type'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: finish
+        conclusion: ${{ job.status }}
+        check-run-id: ${{ steps.check_start.outputs.check-run-id }}

--- a/.github/workflows/cross-repo-trigger.yml
+++ b/.github/workflows/cross-repo-trigger.yml
@@ -1,0 +1,214 @@
+# GENERATED FILE - DO NOT EDIT.
+# Regenerate via the ci-infrastructure-generate CLI.
+# Source of truth: each repo's .ci/manifest.toml.
+name: Cross-repo trigger (eccodes)
+run-name: Cross-repo trigger (${{ inputs.from-repo }}@${{ inputs.from-sha }}) [${{ inputs.dispatch-id }}]
+on:
+  workflow_call:
+    inputs:
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+  workflow_dispatch:
+    inputs:
+      dispatch-id:
+        description: Correlation id stamped into run-name so the dispatcher can find this run
+        required: false
+        default: ''
+        type: string
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+concurrency:
+  group: cross-repo-trigger-runner-eccodes-${{ github.ref }}
+  cancel-in-progress: false
+env:
+  ARTIFACT_POLL_INTERVAL: ${{ vars.ARTIFACT_POLL_INTERVAL || '60' }}
+  ARTIFACT_S3_ENDPOINT: ${{ secrets.ARTIFACT_S3_ENDPOINT }}
+  ARTIFACT_S3_BUCKET: ${{ secrets.ARTIFACT_S3_BUCKET }}
+  SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+jobs:
+  resolve:
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || contains(fromJSON(inputs.from-jobs), 'eckit/build') || inputs.rebuild-request
+    runs-on: ubuntu-slim
+    outputs:
+      ref: ${{ steps.pick.outputs.ref }}
+      matrix-build: ${{ steps.r.outputs.matrix-build }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: pick
+      uses: ecmwf/ci-infrastructure/actions/pick-ref@main
+      with:
+        repo: ecmwf/eccodes
+        try-branch: ${{ inputs.branch }}
+        fallback-ref: ${{ inputs.fallback-ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eccodes
+        ref: ${{ steps.pick.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - id: r
+      uses: ecmwf/ci-infrastructure/actions/resolve-deps@main
+      with:
+        current-branch: ${{ steps.pick.outputs.ref }}
+        matrix: build
+        token: ${{ steps.mint.outputs.token }}
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        app-private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+  eccodes__build:
+    needs:
+    - resolve
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || contains(fromJSON(inputs.from-jobs), 'eckit/build') || inputs.rebuild-request
+    name: eccodes/build (${{ matrix['cxx-compiler'] }}, ${{ matrix.platform }})
+    runs-on: ${{ matrix['runs-on'] }}
+    container:
+      image: ${{ matrix.container || '' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix-build) }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: check_start
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eccodes/build (${{ matrix['cxx-compiler'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: start
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eccodes
+        ref: ${{ needs.resolve.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - name: Decode matrix-leg
+      id: m
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s inherit_errexit 2>/dev/null || true
+        command -v jq >/dev/null || {
+          echo "::error::jq is required but not installed in this runner/image." >&2
+          exit 1
+        }
+        leg='${{ toJSON(matrix) }}'
+        require() {
+          local val
+          val=$(jq -r "$1" <<<"$leg")
+          if [ -z "$val" ] || [ "$val" = "null" ]; then
+            echo "::error::matrix-leg field '$2' empty or null (jq -r '$1' returned '$val')." >&2
+            exit 1
+          fi
+          printf '%s' "$val"
+        }
+        cxx_compiler=$(require '."cxx-compiler"' cxx-compiler)
+        fortran_compiler=$(require '."fortran-compiler"' fortran-compiler)
+        build_type=$(require '."build-type"' build-type)
+        options=$(jq -r '."options" // ""' <<<"$leg")
+        deps_json=$(require '._resolved.deps | tojson' '_resolved.deps')
+        own_artifact_name=$(require '._resolved."own-artifact-name"' '_resolved.own-artifact-name')
+        {
+          echo "cxx-compiler=${cxx_compiler}"
+          echo "fortran-compiler=${fortran_compiler}"
+          echo "build-type=${build_type}"
+          echo "options=${options}"
+          echo "deps-json=${deps_json}"
+          echo "own-artifact-name=${own_artifact_name}"
+        } >> "$GITHUB_OUTPUT"
+    - name: Fetch resolved deps
+      id: deps
+      uses: ecmwf/ci-infrastructure/actions/fetch-and-publish@main
+      with:
+        mode: download-only
+        deps-json: ${{ steps.m.outputs.deps-json }}
+        token: ${{ steps.mint.outputs.token }}
+    - name: Build
+      id: build
+      uses: ./.github/actions/build-eccodes
+      with:
+        cmake-prefix-path: ${{ steps.deps.outputs.cmake-prefix-path }}
+        cxx-compiler: ${{ steps.m.outputs.cxx-compiler }}
+        fortran-compiler: ${{ steps.m.outputs.fortran-compiler }}
+        build-type: ${{ steps.m.outputs.build-type }}
+        options: ${{ steps.m.outputs.options }}
+    - name: Publish
+      uses: ecmwf/ci-infrastructure/actions/fetch-and-publish@main
+      with:
+        mode: publish
+        install-path: ${{ steps.build.outputs.install-path }}
+        artifact-name: ${{ steps.m.outputs.own-artifact-name }}
+    - name: Report check-run conclusion
+      if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eccodes/build (${{ matrix['cxx-compiler'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: finish
+        conclusion: ${{ job.status }}
+        check-run-id: ${{ steps.check_start.outputs.check-run-id }}


### PR DESCRIPTION
## CI: land the cross-repo orchestration

  Adds `.ci/manifest.toml` — declaring this package, its dependencies and its
  consumers — plus the generated workflows that let other repos trigger this one.

  These only work **on the default branch**: `on: workflow_run` always runs the
  default branch's copy, so a fan-out on a feature branch is inert. Landing it
  first is what makes the downstream CI observable before the rollout merges.

  No build definitions — `ci.yml`, the build actions and the HPC recipes stay on
  `sync-branch-ci-rollout`.

  ⚠️ `[[trigger-downstream]].ref` is temporarily pinned to
  `sync-branch-ci-rollout`; flip to `develop` and regenerate when the rollout
  merges (see the `ROLLOUT NOTE` in the manifest).

  `cross-repo-trigger*.yml` / `trigger-downstream*.yml` are generated by
  `ci-infrastructure-generate` — don't hand-edit.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
