### PR TITLE
eccodes + metkit: iDirectionIncrement/Ni=MISSING for reduced grids

### DIFF
--- a/src/eccodes/grib_util.cc
+++ b/src/eccodes/grib_util.cc
@@ -1121,7 +1121,8 @@ int grib_set_from_grid_spec(grib_handle* h, const grib_util_grid_spec* spec, con
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
             SET_LONG_VALUE("ijDirectionIncrementGiven", 0);
-
+            SET_LONG_VALUE("iDirectionIncrement", GRIB_MISSING_LONG);
+            SET_LONG_VALUE("Ni", GRIB_MISSING_LONG);
             COPY_SPEC_LONG(Nj);
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(longitudeOfLastGridPointInDegrees);
@@ -1205,6 +1206,8 @@ int grib_set_from_grid_spec(grib_handle* h, const grib_util_grid_spec* spec, con
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
             SET_LONG_VALUE("ijDirectionIncrementGiven", 0);
+            SET_LONG_VALUE("iDirectionIncrement", GRIB_MISSING_LONG);
+            SET_LONG_VALUE("Ni", GRIB_MISSING_LONG);
             COPY_SPEC_LONG(Nj);
             COPY_SPEC_LONG(N);
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
@@ -1629,7 +1632,8 @@ static grib_handle* grib_util_set_spec_(grib_handle* h,
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
             SET_LONG_VALUE("ijDirectionIncrementGiven", 0);
-
+            SET_LONG_VALUE("iDirectionIncrement", GRIB_MISSING_LONG);
+            SET_LONG_VALUE("Ni", GRIB_MISSING_LONG);
             COPY_SPEC_LONG(Nj);
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);
             COPY_SPEC_DOUBLE(longitudeOfLastGridPointInDegrees);
@@ -1719,7 +1723,8 @@ static grib_handle* grib_util_set_spec_(grib_handle* h,
             COPY_SPEC_LONG(bitmapPresent);
             if (spec->missingValue) COPY_SPEC_DOUBLE(missingValue);
             SET_LONG_VALUE("ijDirectionIncrementGiven", 0);
-
+            SET_LONG_VALUE("iDirectionIncrement", GRIB_MISSING_LONG);
+            SET_LONG_VALUE("Ni", GRIB_MISSING_LONG);
             COPY_SPEC_LONG(Nj);
             COPY_SPEC_LONG(N);
             COPY_SPEC_DOUBLE(longitudeOfFirstGridPointInDegrees);


### PR DESCRIPTION
### Description

Fix encoding using codes_set("gridSpec") for MTG2 and non-MTG2 data. The i increment was being set for reduced grids, the fix forces them to be MISSING, I thought the preceeding setting of ijDirectionIncrementGiven=0 a few lines above the fixes were doing this.

Surprisingly, this should have been working since forever, maybe the choice of template (which is in this case done by metkit) is doing a better job when using the "classical" encoder (this sample is calculated/provided by metkit.)

there is urgency in this.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
