### PR TITLE
ECC-2319: Match numberOfDataPoints and numberOfValues in SH

### DIFF
--- a/src/eccodes/geo/GribFromSpec.cc
+++ b/src/eccodes/geo/GribFromSpec.cc
@@ -625,7 +625,19 @@ codes_handle* GribFromSpec::set(const codes_handle* h, const Spec& spec, const s
     ASSERT(edition != 0);
 
     if (edition >= 2) {
-        info.extra_set("numberOfDataPoints", static_cast<long>(grid->size()));
+        if (info.grid.grid_type == CODES_UTIL_GRID_SPEC_SH) {
+            // For spherical harmonics, numberOfDataPoints is the number of real
+            // coefficients: (T+1)*(T+2). Each complex coefficient has a real and
+            // imaginary part. We compute this from the truncation rather than
+            // relying on grid->size() which may return the complex coefficient count.
+            const long T = info.grid.truncation;
+            const long numberOfRealCoeffs = (T + 1) * (T + 2);
+            info.extra_set("numberOfDataPoints", numberOfRealCoeffs);
+            info.extra_set("numberOfValues", numberOfRealCoeffs);
+        }
+        else {
+            info.extra_set("numberOfDataPoints", static_cast<long>(grid->size()));
+        }
     }
 
     try {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,7 @@ if( HAVE_BUILD_TOOLS )
         grib_ecc-1766
         grib_ecc-1829
         grib_ecc-2140
+        grib_ecc-2319
         bufr_ecc-1028
         bufr_ecc-912
         bufr_ecc-1195

--- a/tests/grib_ecc-2319.sh
+++ b/tests/grib_ecc-2319.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# (C) Copyright 2005- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# 
+# In applying this licence, ECMWF does not waive the privileges and immunities granted to it by
+# virtue of its status as an intergovernmental organisation nor does it submit to any jurisdiction.
+#
+
+. ./include.ctest.sh
+
+# ---------------------------------------------------------
+# This is the test for JIRA issue ECC-2319
+# The numberOfDataPoints and numberOfValues keys are not set correctly when using grib_set -s gridSpec=... on spectral data.
+# ---------------------------------------------------------
+
+REDIRECT=/dev/null
+
+label=`basename $0 | sed -e 's/\.sh/_test/'`
+
+tempGrib=temp.$label.grib
+sample_grib2=$ECCODES_SAMPLES_PATH/sh_ml_grib2.tmpl
+
+if [ $HAVE_ECKIT_GEO -ne 1 ]; then
+    echo "$0: This test is disabled when HAVE_ECKIT_GEO=OFF"
+    exit 0
+fi
+
+# Check env. variable too
+if [ "${ECCODES_ECKIT_GEO:-0}" -eq 0 ]
+then
+    echo "$0: This test is disabled (env. variable ECCODES_ECKIT_GEO=0)"
+    exit 0
+fi
+set -u
+
+$tools_dir/grib_set -s gridSpec="{"grid":"T106"}" $sample_grib2 $tempGrib
+grib_check_key_equals $tempGrib numberOfDataPoints,numberOfValues "11556 11556"
+
+# Clean up
+rm -f $tempGrib


### PR DESCRIPTION
### Description
This pull request addresses the correct calculation and setting of the `numberOfDataPoints` and `numberOfValues` keys for spectral (spherical harmonics) grids in GRIB2 files, specifically when using `grib_set` with a `gridSpec` parameter. It also adds a regression test to ensure this behavior remains correct in the future.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
