### PR TITLE
ECC-2318: Use default scanning modes for zero increments

### DIFF
--- a/src/eccodes/geo/GribFromSpec.cc
+++ b/src/eccodes/geo/GribFromSpec.cc
@@ -270,11 +270,13 @@ void set_grid_type_regular_ll(grib_info& info, const Grid& grid, const BasicAngl
 
     auto order = g.order();
 
-    info.grid.iScansNegatively = static_cast<long>(order.find("i-") != std::string::npos);
-    info.grid.jScansPositively = static_cast<long>(order.find("j+") != std::string::npos);
+    // ECC-2318
+    // For dx==0 and dy==0 use default values iScansNegatively=0, jScansPositively=0, respectively.
+    info.grid.iScansNegatively = is_approximately_equal(g.dx(), 0.) ? 0L : order.find("i-") != std::string::npos ? 1L : 0L;
+    info.grid.jScansPositively = is_approximately_equal(g.dy(), 0.) ? 0L : order.find("j+") != std::string::npos ? 1L : 0L;
 
-    ASSERT(g.dx() < 0 == (info.grid.iScansNegatively == 1L));
-    ASSERT(0 <= g.dy() == (info.grid.jScansPositively == 1L));
+    ASSERT((g.dx() < 0) == (info.grid.iScansNegatively == 1L));
+    ASSERT((0 < g.dy()) == (info.grid.jScansPositively == 1L));
 
     info.grid.iDirectionIncrementInDegrees = std::abs(g.dx());  // west-east
     info.grid.jDirectionIncrementInDegrees = std::abs(g.dy());  // south-north

--- a/tests/grib_gridSpec.sh
+++ b/tests/grib_gridSpec.sh
@@ -114,8 +114,8 @@ for setKeysResult in \
 do
     setKeys=$(echo $setKeysResult | cut -d'|' -f1)
     expectedSpec=$(echo $setKeysResult | cut -d'|' -f2)
-    ${tools_dir}/grib_set -s $setKeys $sample $tempGrib
     set +e
+    ${tools_dir}/grib_set -s $setKeys $sample $tempGrib
     ${tools_dir}/grib_get -p gridSpec $tempGrib > $tempText
     status=$?
     set -e
@@ -127,17 +127,20 @@ rm -f $tempGrib
 
 # Encoding: an explicitly degenerate spec, and an area with no extent
 for spec in \
-    '{area:[0,0,0,0],grid:[0,0]}' \
-    '{area:[0,0,0,0],grid:[1,1]}' \
-    '{area:[60,0,60,30],grid:[2,2]}' \
-    '{area:[60,0,0,0],grid:[2,2]}'
+    '{"area":[0,0,0,0],"grid":[0,0]}|{"area":[0,0,0,0],"grid":[0,0]}' \
+    '{"area":[0,0,0,0],"grid":[1,1]}|{"area":[0,0,0,0],"grid":[0,0]}' \
+    '{"area":[60,0,60,30],"grid":[2,2]}|{"area":[60,0,60,30],"grid":[2,0]}' \
+    '{"area":[60,0,0,0],"grid":[2,2]}|{"area":[60,0,0,0],"grid":[0,2]}'
 do
+    setKeys=$(echo $spec | cut -d'|' -f1)
+    expectedSpec=$(echo $spec | cut -d'|' -f2)
     set +e
-    ${tools_dir}/grib_set -s gridSpec="$spec" $sample $tempGrib 2>$tempText
+    ${tools_dir}/grib_set -s gridSpec="$setKeys" $sample $tempGrib
+    ${tools_dir}/grib_get -p gridSpec $tempGrib > $tempText
     status=$?
     set -e
     [ $status -eq 0 ]
-    grep -F -q $spec $tempText
+    grep -F -q $expectedSpec $tempText
 done
 rm -f $tempGrib
 


### PR DESCRIPTION
### Description
This pull request addresses degenerate grid specifications and improves the robustness of grid encoding/decoding, especially when grid increments are zero. It also updates the corresponding tests to reflect these changes and ensure correctness.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
