### PR TITLE
Fetch HPC test data in its own ctest pass

### DIFF
--- a/.ci/hpc/build.sh.j2
+++ b/.ci/hpc/build.sh.j2
@@ -37,7 +37,16 @@ cmake --build "${TMPDIR:-/tmp}/build" --parallel "${SLURM_NTASKS:-8}"
 # on "Unable to find boot.def".
 export ECCODES_DEFINITION_PATH="${TMPDIR:-/tmp}/build/share/eccodes/definitions"
 export ECCODES_SAMPLES_PATH="${TMPDIR:-/tmp}/build/share/eccodes/samples"
-ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure -j "${SLURM_NTASKS:-8}"
+# Fetch the test data first, at low concurrency and with a retry. Four
+# concurrent HTTPS fetches against sites.ecmwf.int have been enough to draw
+# `curl: (16) Error in the HTTP2 framing layer`, and curl's own --retry does not
+# cover exit 16 -- so the retry has to be ctest's. Scoped by the download_data
+# label ecbuild_get_test_multidata applies, so a real eccodes test failure is
+# never silently re-run.
+ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure \
+  -L download_data -j 2 --repeat until-pass:3
+ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure \
+  -LE download_data -j "${SLURM_NTASKS:-8}"
 
 # Install to node-local SSD, then copy the tree across in one pass. eccodes
 # installs ~24k small definition files; doing that as individual `cmake

--- a/.ci/hpc/build.sh.j2
+++ b/.ci/hpc/build.sh.j2
@@ -38,10 +38,7 @@ cmake --build "${TMPDIR:-/tmp}/build" --parallel "${SLURM_NTASKS:-8}"
 export ECCODES_DEFINITION_PATH="${TMPDIR:-/tmp}/build/share/eccodes/definitions"
 export ECCODES_SAMPLES_PATH="${TMPDIR:-/tmp}/build/share/eccodes/samples"
 # Fetch the test data first. A download failure otherwise surfaces as dozens of
-# unrelated test failures: on 2026-09-08 two `curl: (16)` errors cost 66 of 481
-# tests, only 2 of which were the download tests themselves. Retrying is
-# ecbuild's job, not ctest's. Exactly six targets carry the download_data label
-# that ecbuild_get_test_multidata applies, hence -j 6.
+# unrelated test failures:
 ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure \
   -L download_data -j 6
 ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure \

--- a/.ci/hpc/build.sh.j2
+++ b/.ci/hpc/build.sh.j2
@@ -37,14 +37,13 @@ cmake --build "${TMPDIR:-/tmp}/build" --parallel "${SLURM_NTASKS:-8}"
 # on "Unable to find boot.def".
 export ECCODES_DEFINITION_PATH="${TMPDIR:-/tmp}/build/share/eccodes/definitions"
 export ECCODES_SAMPLES_PATH="${TMPDIR:-/tmp}/build/share/eccodes/samples"
-# Fetch the test data first, at low concurrency and with a retry. Four
-# concurrent HTTPS fetches against sites.ecmwf.int have been enough to draw
-# `curl: (16) Error in the HTTP2 framing layer`, and curl's own --retry does not
-# cover exit 16 -- so the retry has to be ctest's. Scoped by the download_data
-# label ecbuild_get_test_multidata applies, so a real eccodes test failure is
-# never silently re-run.
+# Fetch the test data first. A download failure otherwise surfaces as dozens of
+# unrelated test failures: on 2026-09-08 two `curl: (16)` errors cost 66 of 481
+# tests, only 2 of which were the download tests themselves. Retrying is
+# ecbuild's job, not ctest's. Exactly six targets carry the download_data label
+# that ecbuild_get_test_multidata applies, hence -j 6.
 ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure \
-  -L download_data -j 2 --repeat until-pass:3
+  -L download_data -j 6
 ctest --test-dir "${TMPDIR:-/tmp}/build" --output-on-failure \
   -LE download_data -j "${SLURM_NTASKS:-8}"
 


### PR DESCRIPTION
The suite is now run in two passes, using the `download_data` label that `ecbuild_get_test_multidata` already applies 

This separates download failures from other failures.
```
ctest ... -L download_data -j 2
ctest ... -LE download_data -j "${SLURM_NTASKS:-8}"
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.