### PR TITLE
ECC-2322: Feature/fillup date of forecast

### DIFF
--- a/definitions/mars/grib.enfo.fu.def
+++ b/definitions/mars/grib.enfo.fu.def
@@ -1,5 +1,11 @@
 if (edition == 2) {
- if (grib2LocalSectionNumber == 44){
+ if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  unalias mars.date;
+  unalias mars.time;
+  alias mars.date = dateOfForecast ;
+  alias mars.time = timeOfForecast ;
  }
 }

--- a/definitions/mars/grib.enfo.fu.def
+++ b/definitions/mars/grib.enfo.fu.def
@@ -1,8 +1,8 @@
 if (edition == 2) {
  if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
-  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
-  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  meta dateOfForecast validity_date(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
   unalias mars.date;
   unalias mars.time;
   alias mars.date = dateOfForecast ;

--- a/definitions/mars/grib.enfo.sfo.def
+++ b/definitions/mars/grib.enfo.sfo.def
@@ -1,5 +1,3 @@
-alias mars.anoffset=anoffset;
-
 if (edition == 2) {
  if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   unalias mars.anoffset;
@@ -9,7 +7,7 @@ if (edition == 2) {
   unalias mars.date;
   unalias mars.time;
   alias mars.date = dateOfForecast ;
-  alias	mars.time = timeOfForecast ;
+  alias mars.time = timeOfForecast ;
  }
 }
 

--- a/definitions/mars/grib.enfo.sfo.def
+++ b/definitions/mars/grib.enfo.sfo.def
@@ -2,8 +2,8 @@ if (edition == 2) {
  if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   unalias mars.anoffset;
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
-  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
-  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  meta dateOfForecast validity_date(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
   unalias mars.date;
   unalias mars.time;
   alias mars.date = dateOfForecast ;

--- a/definitions/mars/grib.oper.fu.def
+++ b/definitions/mars/grib.oper.fu.def
@@ -1,7 +1,7 @@
 alias mars.anoffset=anoffset;
 
 if (edition == 2) {
- if (grib2LocalSectionNumber == 44){
+ if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
   meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
   meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;

--- a/definitions/mars/grib.oper.fu.def
+++ b/definitions/mars/grib.oper.fu.def
@@ -3,6 +3,12 @@ alias mars.anoffset=anoffset;
 if (edition == 2) {
  if (grib2LocalSectionNumber == 44){
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  unalias mars.date;
+  unalias mars.time;
+  alias mars.date = dateOfForecast ;
+  alias	mars.time = timeOfForecast ;
  }
 }
 

--- a/definitions/mars/grib.oper.fu.def
+++ b/definitions/mars/grib.oper.fu.def
@@ -9,7 +9,7 @@ if (edition == 2) {
   unalias mars.date;
   unalias mars.time;
   alias mars.date = dateOfForecast ;
-  alias	mars.time = timeOfForecast ;
+  alias mars.time = timeOfForecast ;
  }
 }
 

--- a/definitions/mars/grib.oper.fu.def
+++ b/definitions/mars/grib.oper.fu.def
@@ -4,8 +4,8 @@ if (edition == 2) {
  if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   unalias mars.anoffset;
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
-  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
-  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  meta dateOfForecast validity_date(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
   unalias mars.date;
   unalias mars.time;
   alias mars.date = dateOfForecast ;

--- a/definitions/mars/grib.oper.sfo.def
+++ b/definitions/mars/grib.oper.sfo.def
@@ -1,7 +1,7 @@
 alias mars.anoffset=anoffset;
 
 if (edition == 2) {
- if (grib2LocalSectionNumber == 44){
+ if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
   meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
   meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;

--- a/definitions/mars/grib.oper.sfo.def
+++ b/definitions/mars/grib.oper.sfo.def
@@ -2,6 +2,7 @@ alias mars.anoffset=anoffset;
 
 if (edition == 2) {
  if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
+  unalias mars.anoffset;
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
   meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
   meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;

--- a/definitions/mars/grib.oper.sfo.def
+++ b/definitions/mars/grib.oper.sfo.def
@@ -1,1 +1,14 @@
 alias mars.anoffset=anoffset;
+
+if (edition == 2) {
+ if (grib2LocalSectionNumber == 44){
+  alias mars.anoffset=offsetToStartOfForecastFillupInHours;
+  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  unalias mars.date;
+  unalias mars.time;
+  alias mars.date = dateOfForecast ;
+  alias mars.time = timeOfForecast ;
+ }
+}
+

--- a/definitions/mars/grib.oper.sfo.def
+++ b/definitions/mars/grib.oper.sfo.def
@@ -4,8 +4,8 @@ if (edition == 2) {
  if (defined(grib2LocalSectionNumber) && grib2LocalSectionNumber == 44){
   unalias mars.anoffset;
   alias mars.anoffset=offsetToStartOfForecastFillupInHours;
-  meta dateOfForecast validity_date(dataDate,dataTime,anoffset,one) : read_only;
-  meta timeOfForecast validity_time(dataDate,dataTime,anoffset,one) : read_only;
+  meta dateOfForecast validity_date(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
+  meta timeOfForecast validity_time(dataDate,dataTime,offsetToStartOfForecastFillupInHours,one) : read_only;
   unalias mars.date;
   unalias mars.time;
   alias mars.date = dateOfForecast ;


### PR DESCRIPTION
### Description
This PR is to change the date and time entries used for the MARS date and time for the hydrological fill-up data.

Those data should not be indexed with the date which corresponds to the start of the fill-up but with the date / time of the start of the forecast for which they are produced.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
