### PR TITLE
ECC-2325: correct date for ldas statistical streams

### DIFF
--- a/definitions/mars/grib.ldsb.an.def
+++ b/definitions/mars/grib.ldsb.an.def
@@ -1,7 +1,18 @@
 alias mars.step = startStep;
 
-alias monthlyVerificationTime = zero;
-alias monthlyVerificationDate = dataDate;
+if ( defined(stattype) && is_one_of(stattype,"moav","momn","momx","mosd") ) {
+ meta verificationDate        g1verificationdate(dataDate, dataTime, endStep) : read_only;
+ meta monthlyVerificationDate g1monthlydate(verificationDate) : dump,no_copy;
+ alias mars.date            = monthlyVerificationDate;
+ alias monthlyVerificationTime = zero;
+ meta verificationYear          evaluate(verificationDate/10000);
+ meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
+ meta verificationMonth         evaluate( (verificationDate/100)%100 );
+ meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
+} else {
+ alias monthlyVerificationTime = zero;
+ alias monthlyVerificationDate = dataDate;
+}
 
 unalias mars.step;
 

--- a/definitions/mars/grib.ldsb.fc.def
+++ b/definitions/mars/grib.ldsb.fc.def
@@ -1,13 +1,16 @@
-meta verificationDate        g1verificationdate(dataDate, dataTime, endStep) : read_only;
-meta monthlyVerificationDate g1monthlydate(verificationDate) : dump,no_copy;
-alias mars.date            = monthlyVerificationDate;
-
-alias monthlyVerificationTime = zero;
-
-meta verificationYear          evaluate(verificationDate/10000);
-meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
-meta verificationMonth         evaluate( (verificationDate/100)%100 );
-meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
+if ( defined(stattype) && is_one_of(stattype,"moav","momn","momx","mosd") ) {
+ meta verificationDate        g1verificationdate(dataDate, dataTime, endStep) : read_only;
+ meta monthlyVerificationDate g1monthlydate(verificationDate) : dump,no_copy;
+ alias mars.date            = monthlyVerificationDate;
+ alias monthlyVerificationTime = zero;
+ meta verificationYear          evaluate(verificationDate/10000);
+ meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
+ meta verificationMonth         evaluate( (verificationDate/100)%100 );
+ meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
+} else {
+ alias monthlyVerificationTime = zero;
+ alias monthlyVerificationDate = dataDate;
+}
 
 unalias mars.step;
 

--- a/definitions/mars/grib.ldst.an.def
+++ b/definitions/mars/grib.ldst.an.def
@@ -1,7 +1,18 @@
 alias mars.step = startStep;
 
-alias monthlyVerificationTime = zero;
-alias monthlyVerificationDate = dataDate;
+if ( defined(stattype) && is_one_of(stattype,"moav","momn","momx","mosd") ) {
+ meta verificationDate        g1verificationdate(dataDate, dataTime, endStep) : read_only;
+ meta monthlyVerificationDate g1monthlydate(verificationDate) : dump,no_copy;
+ alias mars.date            = monthlyVerificationDate;
+ alias monthlyVerificationTime = zero;
+ meta verificationYear          evaluate(verificationDate/10000);
+ meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
+ meta verificationMonth         evaluate( (verificationDate/100)%100 );
+ meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
+} else {
+ alias monthlyVerificationTime = zero;
+ alias monthlyVerificationDate = dataDate;
+}
 
 unalias mars.step;
 

--- a/definitions/mars/grib.ldst.fc.def
+++ b/definitions/mars/grib.ldst.fc.def
@@ -1,13 +1,16 @@
-meta verificationDate        g1verificationdate(dataDate, dataTime, endStep) : read_only;
-meta monthlyVerificationDate g1monthlydate(verificationDate) : dump,no_copy;
-alias mars.date            = monthlyVerificationDate;
-
-alias monthlyVerificationTime = zero;
-
-meta verificationYear          evaluate(verificationDate/10000);
-meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
-meta verificationMonth         evaluate( (verificationDate/100)%100 );
-meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
+if ( defined(stattype) && is_one_of(stattype,"moav","momn","momx","mosd") ) {
+ meta verificationDate        g1verificationdate(dataDate, dataTime, endStep) : read_only;
+ meta monthlyVerificationDate g1monthlydate(verificationDate) : dump,no_copy;
+ alias mars.date            = monthlyVerificationDate;
+ alias monthlyVerificationTime = zero;
+ meta verificationYear          evaluate(verificationDate/10000);
+ meta monthlyVerificationYear   evaluate(monthlyVerificationDate/10000);
+ meta verificationMonth         evaluate( (verificationDate/100)%100 );
+ meta monthlyVerificationMonth  evaluate( (monthlyVerificationDate/100)%100 );
+} else {
+ alias monthlyVerificationTime = zero;
+ alias monthlyVerificationDate = dataDate;
+}
 
 unalias mars.step;
 


### PR DESCRIPTION
### Description
The mars date and time need to be corrected for grib.{ldst,ldsb}.{an,fc}.def. This PR includes the required changes.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
