### PR TITLE
ECC-2326: date for dacl / em climate files

### DIFF
--- a/definitions/mars/grib.dacl.em.def
+++ b/definitions/mars/grib.dacl.em.def
@@ -1,0 +1,53 @@
+if ( edition == 2 ){
+ unalias mars.date;
+ transient hyphen='-' : hidden;
+ if (month == 1){
+    transient monthstr="jan" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 2){
+    transient monthstr="feb" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 3){
+    transient monthstr="mar" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 4){
+    transient monthstr="apr" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 5){
+    transient monthstr="may" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 6){
+    transient monthstr="jun" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 7){
+    transient monthstr="jul" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 8){
+    transient monthstr="aug" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 9){
+    transient monthstr="sep" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 10){
+    transient monthstr="oct" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 11){
+    transient monthstr="nov" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ if (month == 12){
+    transient monthstr="dec" : hidden;
+    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
+ }
+ alias mars.date=datestr;
+}

--- a/definitions/mars/grib.dacl.em.def
+++ b/definitions/mars/grib.dacl.em.def
@@ -3,51 +3,40 @@ if ( edition == 2 ){
  transient hyphen='-' : hidden;
  if (month == 1){
     transient monthstr="jan" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 2){
     transient monthstr="feb" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 3){
     transient monthstr="mar" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 4){
     transient monthstr="apr" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 5){
     transient monthstr="may" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 6){
     transient monthstr="jun" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 7){
     transient monthstr="jul" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 8){
     transient monthstr="aug" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 9){
     transient monthstr="sep" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 10){
     transient monthstr="oct" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 11){
     transient monthstr="nov" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
  if (month == 12){
     transient monthstr="dec" : hidden;
-    meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  }
+ meta datestr sprintf("%s%s%.2d",monthstr,hyphen,day);
  alias mars.date=datestr;
 }


### PR DESCRIPTION
### Description
The mars date entry need to be aligned between GRIB1 and GRIB2 stream dacl type em data. For the month a three letter abbreviation in GRIB2 has to be used in the same way as in GRIB1. This PR is to overrule the standard GRIB2 behaviour to be in line with GRIB1.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
