### PR TITLE
ECC-2327: MTG2 switch to enforce endStep for mars.step

### DIFF
--- a/definitions/mars/grib.eefo.em.def
+++ b/definitions/mars/grib.eefo.em.def
@@ -1,1 +1,6 @@
-alias   mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}

--- a/definitions/mars/grib.eefo.es.def
+++ b/definitions/mars/grib.eefo.es.def
@@ -1,1 +1,6 @@
-alias   mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}

--- a/definitions/mars/grib.eehs.em.def
+++ b/definitions/mars/grib.eehs.em.def
@@ -1,1 +1,7 @@
-alias mars.step = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.eehs.es.def
+++ b/definitions/mars/grib.eehs.es.def
@@ -1,1 +1,7 @@
-alias mars.step = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.efhs.em.def
+++ b/definitions/mars/grib.efhs.em.def
@@ -1,1 +1,7 @@
-alias mars.step = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.efhs.es.def
+++ b/definitions/mars/grib.efhs.es.def
@@ -1,1 +1,7 @@
-alias mars.step = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.enfo.em.def
+++ b/definitions/mars/grib.enfo.em.def
@@ -1,1 +1,7 @@
-alias   mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+

--- a/definitions/mars/grib.enfo.es.def
+++ b/definitions/mars/grib.enfo.es.def
@@ -1,1 +1,7 @@
-alias   mars.step     = stepRange;
+if ( !defined(MTG2Switch) || MTG2Switch == 0 ){
+ alias mars.step = stepRange;
+}
+else {
+ alias mars.step = endStep;
+}
+


### PR DESCRIPTION
### Description
For the following streams, the mars.step need to be changed to mars.step=endStep for post-mtg2 while remaining current behaviour for current data.

grib.eefo.em.def
grib.eefo.es.def
grib.eehs.em.def
grib.eehs.es.def
grib.efhs.em.def
grib.efhs.es.def
grib.enfo.em.def
grib.enfo.es.def

This PR includes the necessary changes.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
