### PR TITLE
ECC-2331: type icp for seas6

### DIFF
--- a/definitions/mars/grib.sfdd.icp.def
+++ b/definitions/mars/grib.sfdd.icp.def
@@ -1,1 +1,2 @@
+alias mars.number  = perturbationNumber;
 alias mars.system = systemNumber;

--- a/definitions/mars/grib.sfdd.icp.def
+++ b/definitions/mars/grib.sfdd.icp.def
@@ -1,0 +1,1 @@
+alias mars.system = systemNumber;

--- a/definitions/mars/grib.shdd.icp.def
+++ b/definitions/mars/grib.shdd.icp.def
@@ -1,1 +1,2 @@
+alias mars.number  = perturbationNumber;
 alias mars.system = systemNumber;

--- a/definitions/mars/grib.shdd.icp.def
+++ b/definitions/mars/grib.shdd.icp.def
@@ -1,0 +1,1 @@
+alias mars.system = systemNumber;


### PR DESCRIPTION
### Description
This PR is to add the type icp for the sfdd and shdd streams for Seasonal 6.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
